### PR TITLE
Fluent union

### DIFF
--- a/Libraries/core/net40/Query/Builder/GraphPatternBuilder.cs
+++ b/Libraries/core/net40/Query/Builder/GraphPatternBuilder.cs
@@ -39,7 +39,7 @@ namespace VDS.RDF.Query.Builder
         private readonly IList<GraphPatternBuilder> _childGraphPatternBuilders = new List<GraphPatternBuilder>();
         private readonly IList<Func<INamespaceMapper, ISparqlExpression>> _filterBuilders = new List<Func<INamespaceMapper, ISparqlExpression>>();
         private readonly IList<Func<INamespaceMapper, ITriplePattern[]>> _triplePatterns = new List<Func<INamespaceMapper, ITriplePattern[]>>();
-        private GraphPatternType _graphPatternType;
+        private readonly GraphPatternType _graphPatternType;
         private readonly IToken _graphSpecifier;
 
         /// <summary>
@@ -57,15 +57,6 @@ namespace VDS.RDF.Query.Builder
         private GraphPatternBuilder(GraphPatternType graphPatternType)
         {
             _graphPatternType = graphPatternType;
-        }
-
-        private GraphPatternBuilder(GraphPatternBuilder graphPatternBuilder)
-            : this(graphPatternBuilder._graphPatternType)
-        {
-            _childGraphPatternBuilders = graphPatternBuilder._childGraphPatternBuilders.ToList();
-            _filterBuilders = graphPatternBuilder._filterBuilders.ToList();
-            _triplePatterns = graphPatternBuilder._triplePatterns.ToList();
-            _graphSpecifier = graphPatternBuilder._graphSpecifier;
         }
 
         internal GraphPatternBuilder(GraphPatternType graphPatternType, IToken graphSpecifier)

--- a/Libraries/core/net40/Query/Builder/IGraphPatternBuilder.cs
+++ b/Libraries/core/net40/Query/Builder/IGraphPatternBuilder.cs
@@ -1,28 +1,3 @@
-/*
-dotNetRDF is free and open source software licensed under the MIT License
-
------------------------------------------------------------------------------
-
-Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished
-to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 using System;
 using VDS.RDF.Query.Builder.Expressions;
 using VDS.RDF.Query.Expressions;
@@ -36,9 +11,10 @@ namespace VDS.RDF.Query.Builder
     public interface IGraphPatternBuilder
     {
         /// <summary>
-        /// Creates a UNION of the current graph pattern and a new one
+        /// Creates a UNION of multiple graph patterns. If <paramref name="unionedGraphPatternBuilders"/> is null or empty,
+        /// acts as a call to the <see cref="Child"/> method.
         /// </summary>
-        IGraphPatternBuilder Union(Action<IGraphPatternBuilder> buildGraphPattern);
+        IGraphPatternBuilder Union(Action<IGraphPatternBuilder> buildFirstGraphPattern, params Action<IGraphPatternBuilder>[] unionedGraphPatternBuilders);
         /// <summary>
         /// Adds triple patterns to the SPARQL query or graph pattern
         /// </summary>

--- a/Libraries/core/net40/Query/Builder/IGraphPatternBuilder.cs
+++ b/Libraries/core/net40/Query/Builder/IGraphPatternBuilder.cs
@@ -1,3 +1,28 @@
+/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 using System;
 using VDS.RDF.Query.Builder.Expressions;
 using VDS.RDF.Query.Expressions;

--- a/Libraries/core/net40/Query/Builder/QueryBuilderExtensions.cs
+++ b/Libraries/core/net40/Query/Builder/QueryBuilderExtensions.cs
@@ -160,5 +160,11 @@ namespace VDS.RDF.Query.Builder
             ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Filter(buildExpression);
             return queryBuilder;
         }
+
+        public static IQueryBuilder Union(this IQueryBuilder queryBuilder, Action<IGraphPatternBuilder> firstGraphPattern, params Action<IGraphPatternBuilder>[] otherGraphPatterns)
+        {
+            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Union(firstGraphPattern, otherGraphPatterns);
+            return queryBuilder;
+        }
     }
 }

--- a/Testing/unittest/Query/Builder/GraphPatternBuilderTests.cs
+++ b/Testing/unittest/Query/Builder/GraphPatternBuilderTests.cs
@@ -64,51 +64,6 @@ namespace VDS.RDF.Query.Builder
         }
 
         [Test]
-        public void ShouldAllowCreatingUnionOfTwoGraphPatterns()
-        {
-            // given
-            _builder.Where(t => t.Subject("s").Predicate("p").Object("o"));
-
-            // when
-            var unionBuilder =
-                _builder.Union(union => union.Where(t => t.Subject("x").Predicate("y").Object("z")));
-            var graphPattern = ((GraphPatternBuilder)unionBuilder).BuildGraphPattern(_namespaceMapper.Object);
-
-            // then
-            Assert.IsTrue(graphPattern.IsUnion);
-            Assert.AreEqual(2, graphPattern.ChildGraphPatterns.Count);
-            Assert.AreEqual(1, graphPattern.ChildGraphPatterns[0].TriplePatterns.Count);
-            Assert.AreEqual(1, graphPattern.ChildGraphPatterns[1].TriplePatterns.Count);
-            Assert.AreEqual(3, graphPattern.ChildGraphPatterns[0].Variables.Count());
-            Assert.AreEqual(3, graphPattern.ChildGraphPatterns[1].Variables.Count());
-        }
-
-        [Test]
-        public void ShouldAllowCreatingUnionOfMultipleGraphPatterns()
-        {
-            // given
-            Action<ITriplePatternBuilder> buildTriplePattern = t => t.Subject("s").Predicate("p").Object("o");
-            _builder.Where(buildTriplePattern);
-
-            // when
-            var unionBuilder =
-                _builder.Union(union => union.Where(buildTriplePattern))
-                        .Union(union => union.Where(buildTriplePattern))
-                        .Union(union => union.Where(buildTriplePattern))
-                        .Union(union => union.Where(buildTriplePattern))
-                        .Union(union => union.Where(buildTriplePattern));
-            var graphPattern = ((GraphPatternBuilder)unionBuilder).BuildGraphPattern(_namespaceMapper.Object);
-
-            // then
-            Assert.IsTrue(graphPattern.IsUnion);
-            Assert.AreEqual(6, graphPattern.ChildGraphPatterns.Count);
-            foreach (var childGraphPattern in graphPattern.ChildGraphPatterns)
-            {
-                Assert.AreEqual(1, childGraphPattern.TriplePatterns.Count);
-            }
-        }
-
-        [Test]
         public void ShouldAllowAddingSimpleChildGraphPatterns()
         {
             // given


### PR DESCRIPTION
A fix for #73, which changes the way to build `UNION`.

Previously a call to `Union` would join the object and the target of such call. This is different from the other methods like `Child`, `Graph`, `Service` which all produce a nested graph pattern. In addition to being awkward, different API meant that `Union` was incompatible with the how builder works.

I rewrote the `Union` method so that it works like its kin and takes the joined graph patterns as parameters. Thanks to that it was also possible to add an extension to `IQueryBuilder` to create `UNION` from topmost level.

``` c#
QueryBuilder.SelectAll()
    .Union(first => first.Where(tpb => tpb.Subject("s").Predicate("p").Object("o")),
           second => second.Where(tpb => tpb.Subject("a").Predicate("b").Object("c")),
           third => third.Where(tpb => tpb.Subject("x").Predicate("y").Object("z")))
    .BuildQuery();
```

will produce

```
SELECT *
WHERE
{
   { ?s ?p ?o }
   UNION
   { ?a ?b ?c }
   UNION
   { ?x ?y ?z }
}
```