### PR TITLE
Added Save overload to control the closing of the passed in TextWriter

### DIFF
--- a/Libraries/dotNetRDF/Core/IRDFWriter.cs
+++ b/Libraries/dotNetRDF/Core/IRDFWriter.cs
@@ -56,6 +56,16 @@ namespace VDS.RDF
         void Save(IGraph g, TextWriter output);
 
         /// <summary>
+        /// Method for saving a graph to a concrete RDF syntax via some arbitray <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="g">The graph to save</param>
+        /// <param name="output">The <see cref="TextWriter"/> to save the graph to</param>
+        /// <param name="leaveOpen"><code>true</code> to leave the stream open when the method completes; <code>false</code> otherwise</param>
+        /// <exception cref="RdfException">Thrown if the RDF in the graph is not representable by the writer</exception>
+        /// <exception cref="IOException">Thrown if the writer is unable to write to the underlying storage of the <see cref="TextWriter">TextWriter</see> specified in the <paramref name="output"/></exception>
+        void Save(IGraph g, TextWriter output, bool leaveOpen);
+
+        /// <summary>
         /// Event which writers can raise to indicate possible ambiguities or issues in the syntax they are producing
         /// </summary>
         event RdfWriterWarning Warning;

--- a/Libraries/dotNetRDF/Writing/BaseGZipWriter.cs
+++ b/Libraries/dotNetRDF/Writing/BaseGZipWriter.cs
@@ -41,7 +41,7 @@ namespace VDS.RDF.Writing
     /// </para>
     /// </remarks>
     public abstract class BaseGZipWriter
-        : IRdfWriter
+        : BaseRdfWriter
     {
         private IRdfWriter _writer;
 
@@ -61,7 +61,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             if (filename == null) throw new RdfOutputException("Cannot write RDF to a null file");
             this.Save(g, new StreamWriter(new GZipStream(new FileStream(filename, FileMode.OpenOrCreate, FileAccess.Write), CompressionMode.Compress)));
@@ -73,7 +73,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="output">Writer to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
             if (g == null) throw new RdfOutputException("Cannot write RDF from a null Graph");
 
@@ -110,7 +110,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised if non-fatal errors occur writing RDF output
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the description of the writer

--- a/Libraries/dotNetRDF/Writing/BaseRdfWriter.cs
+++ b/Libraries/dotNetRDF/Writing/BaseRdfWriter.cs
@@ -1,0 +1,82 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace VDS.RDF.Writing
+{
+    /// <summary>
+    /// Base implementation of <see cref="IRdfWriter"/> that simply handles the logic of optionally closing a text writer stream.
+    /// </summary>
+    public abstract class BaseRdfWriter : IRdfWriter
+    {
+        /// <inheritdoc/>
+        public abstract event RdfWriterWarning Warning;
+
+        /// <inheritdoc/>
+        public abstract void Save(IGraph g, string filename);
+
+        /// <inheritdoc/>
+        public void Save(IGraph g, TextWriter output)
+        {
+            Save(g, output, false);
+        }
+
+        /// <inheritdoc/>
+        public void Save(IGraph g, TextWriter output, bool leaveOpen) {
+            try
+            {
+                SaveInternal(g, output);
+                if (!leaveOpen) output.Close();
+            }
+            catch (Exception)
+            {
+                if (!leaveOpen)
+                {
+                    try
+                    {
+                        output.Close();
+                    }
+                    catch (Exception)
+                    {
+                        // No handling, just clean up
+                    }
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Method to be implemented in derived classes to perform the actual writing to a TextWriter
+        /// </summary>
+        /// <param name="graph">The graph to be saved</param>
+        /// <param name="output">The <see cref="TextWriter"/> to save the graph to.</param>
+        protected abstract void SaveInternal(IGraph graph, TextWriter output);
+    }
+}

--- a/Libraries/dotNetRDF/Writing/CompressingTurtleWriter.cs
+++ b/Libraries/dotNetRDF/Writing/CompressingTurtleWriter.cs
@@ -44,7 +44,7 @@ namespace VDS.RDF.Writing
     /// </remarks>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     public class CompressingTurtleWriter 
-        : IRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, ICompressingWriter, INamespaceWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, ICompressingWriter, INamespaceWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
         private bool _allowHiSpeed = true;
@@ -178,7 +178,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -192,26 +192,12 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                // Create the Writing Context
-                g.NamespaceMap.Import(this._defaultNamespaces);
-                CompressingTurtleWriterContext context = new CompressingTurtleWriterContext(g, output, this._compressionLevel, this._prettyprint, this._allowHiSpeed, this._syntax);
-                this.GenerateOutput(context);
-            }
-            finally
-            {
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions - just trying to clean up
-                }
-            }
+            // Create the Writing Context
+            g.NamespaceMap.Import(this._defaultNamespaces);
+            CompressingTurtleWriterContext context = new CompressingTurtleWriterContext(g, output, this._compressionLevel, this._prettyprint, this._allowHiSpeed, this._syntax);
+            this.GenerateOutput(context);
         }
 
         /// <summary>
@@ -495,7 +481,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is a non-fatal issue with the Graph being written
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/CsvWriter.cs
+++ b/Libraries/dotNetRDF/Writing/CsvWriter.cs
@@ -40,7 +40,7 @@ namespace VDS.RDF.Writing
     /// Class for generating CSV output from RDF Graphs
     /// </summary>
     public class CsvWriter 
-        : IRdfWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IFormatterBasedWriter
     {
         private CsvFormatter _formatter = new CsvFormatter();
 
@@ -62,7 +62,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -71,38 +71,21 @@ namespace VDS.RDF.Writing
         }
 #endif
 
-            /// <summary>
-            /// Saves a Graph to CSV format
-            /// </summary>
-            /// <param name="g">Graph</param>
-            /// <param name="output">Writer to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        /// <summary>
+        /// Saves a Graph to CSV format
+        /// </summary>
+        /// <param name="g">Graph</param>
+        /// <param name="output">Writer to save to</param>
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
+            foreach (Triple t in g.Triples)
             {
-                foreach (Triple t in g.Triples)
-                {
-                    this.GenerateNodeOutput(output, t.Subject, TripleSegment.Subject);
-                    output.Write(',');
-                    this.GenerateNodeOutput(output, t.Predicate, TripleSegment.Predicate);
-                    output.Write(',');
-                    this.GenerateNodeOutput(output, t.Object, TripleSegment.Object);
-                    output.Write("\r\n");
-                }
-
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No error handling, just trying to clean up
-                }
-                throw;
+                this.GenerateNodeOutput(output, t.Subject, TripleSegment.Subject);
+                output.Write(',');
+                this.GenerateNodeOutput(output, t.Predicate, TripleSegment.Predicate);
+                output.Write(',');
+                this.GenerateNodeOutput(output, t.Object, TripleSegment.Object);
+                output.Write("\r\n");
             }
         }
 
@@ -144,7 +127,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised if the Writer detects a non-fatal error while outputting CSV
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/GraphVizWriter.cs
+++ b/Libraries/dotNetRDF/Writing/GraphVizWriter.cs
@@ -35,7 +35,7 @@ namespace VDS.RDF.Writing
     /// A Writer which generates GraphViz DOT Format files from an RDF Graph
     /// </summary>
     public class GraphVizWriter 
-        : IRdfWriter
+        : BaseRdfWriter
     {
 
 #if !NO_FILE
@@ -44,7 +44,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             // Open the Stream for the File
             StreamWriter output = new StreamWriter(File.OpenWrite(filename));
@@ -59,7 +59,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
             // Start the Graph
             output.WriteLine("digraph G {");
@@ -74,8 +74,6 @@ namespace VDS.RDF.Writing
 
             // End the Graph
             output.WriteLine("}");
-
-            output.Close();
         }
 
         /// <summary>
@@ -240,7 +238,7 @@ namespace VDS.RDF.Writing
         /// Event that is raised if there is a potential problem with the RDF being output
         /// </summary>
         /// <remarks>Not used by this Writer</remarks>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/HtmlSchemaWriter.cs
+++ b/Libraries/dotNetRDF/Writing/HtmlSchemaWriter.cs
@@ -68,21 +68,30 @@ namespace VDS.RDF.Writing
         /// <param name="output">Stream to save to</param>
         public void Save(IGraph g, TextWriter output)
         {
+            Save(g, output, false);
+        }
+
+        /// <inheritdoc/>
+        public void Save(IGraph g, TextWriter output, bool leaveOpen)
+        { 
             try
             {
                 HtmlWriterContext context = new HtmlWriterContext(g, output);
                 this.GenerateOutput(context);
-                output.Close();
+                if (!leaveOpen) output.Close();
             }
             catch
             {
-                try
+                if (!leaveOpen)
                 {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch Actions
+                    try
+                    {
+                        output.Close();
+                    }
+                    catch
+                    {
+                        // No Catch Actions
+                    }
                 }
                 throw;
             }

--- a/Libraries/dotNetRDF/Writing/HtmlWriter.cs
+++ b/Libraries/dotNetRDF/Writing/HtmlWriter.cs
@@ -82,29 +82,37 @@ namespace VDS.RDF.Writing
         }
 #endif
 
-            /// <summary>
-            /// Saves the Result Set to the given Stream as an XHTML Table with embedded RDFa
-            /// </summary>
-            /// <param name="g">Graph to save</param>
-            /// <param name="output">Stream to save to</param>
+        /// <summary>
+        /// Saves the Result Set to the given Stream as an XHTML Table with embedded RDFa
+        /// </summary>
+        /// <param name="g">Graph to save</param>
+        /// <param name="output">Stream to save to</param>
         public void Save(IGraph g, TextWriter output)
         {
+            Save(g, output, false);
+        }
+
+        public void Save(IGraph g, TextWriter output, bool leaveOpen)
+        { 
             try
             {
                 g.NamespaceMap.Import(this._defaultNamespaces);
                 HtmlWriterContext context = new HtmlWriterContext(g, output);
                 this.GenerateOutput(context);
-                output.Close();
+                if (!leaveOpen) output.Close();
             }
             catch
             {
-                try
+                if (!leaveOpen)
                 {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch Actions
+                    try
+                    {
+                        output.Close();
+                    }
+                    catch
+                    {
+                        // No Catch Actions
+                    }
                 }
                 throw;
             }

--- a/Libraries/dotNetRDF/Writing/NTriplesWriter.cs
+++ b/Libraries/dotNetRDF/Writing/NTriplesWriter.cs
@@ -40,7 +40,7 @@ namespace VDS.RDF.Writing
     /// </summary>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     public class NTriplesWriter 
-        : IRdfWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IFormatterBasedWriter
     {
         private bool _sort = false;
 
@@ -96,7 +96,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
 #if SILVERLIGHT
             StreamWriter output = new StreamWriter(File.OpenWrite(filename));
@@ -115,33 +115,15 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                NTriplesWriterContext context = new NTriplesWriterContext(g, output, this.Syntax);
-                List<Triple> ts = g.Triples.ToList();
-                if (this._sort) ts.Sort(new FullTripleComparer(new FastNodeComparer()));
+            NTriplesWriterContext context = new NTriplesWriterContext(g, output, this.Syntax);
+            List<Triple> ts = g.Triples.ToList();
+            if (this._sort) ts.Sort(new FullTripleComparer(new FastNodeComparer()));
 
-                foreach (Triple t in ts)
-                {
-                    output.WriteLine(this.TripleToNTriples(context, t));
-                }
-
-                output.Close();
-            }
-            catch
+            foreach (Triple t in ts)
             {
-                // Try and ensure the Stream gets closed
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions
-                }
-                throw;
+                output.WriteLine(this.TripleToNTriples(context, t));
             }
         }
 
@@ -200,7 +182,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is an issue with the Graph being serialized that doesn't prevent serialization but the user should be aware of
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Internal Helper method which raises the Warning event only if there is an Event Handler registered

--- a/Libraries/dotNetRDF/Writing/Notation3Writer.cs
+++ b/Libraries/dotNetRDF/Writing/Notation3Writer.cs
@@ -40,7 +40,7 @@ namespace VDS.RDF.Writing
     /// </summary>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     public class Notation3Writer 
-        : IRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, ICompressingWriter, INamespaceWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, ICompressingWriter, INamespaceWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
         private bool _allowHiSpeed = true;
@@ -152,7 +152,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -166,26 +166,12 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                g.NamespaceMap.Import(this._defaultNamespaces);
-                CompressingTurtleWriterContext context = new CompressingTurtleWriterContext(g, output, this._compressionLevel, this._prettyprint, this._allowHiSpeed);
-                context.NodeFormatter = new Notation3Formatter(g);
-                this.GenerateOutput(context);
-            }
-            finally
-            {
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions - just trying to clean up
-                }
-            }
+            g.NamespaceMap.Import(this._defaultNamespaces);
+            CompressingTurtleWriterContext context = new CompressingTurtleWriterContext(g, output, this._compressionLevel, this._prettyprint, this._allowHiSpeed);
+            context.NodeFormatter = new Notation3Formatter(g);
+            this.GenerateOutput(context);
         }
 
         /// <summary>
@@ -539,7 +525,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is a non-fatal issue with the Graph being written
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/PrettyRdfXmlWriter.cs
+++ b/Libraries/dotNetRDF/Writing/PrettyRdfXmlWriter.cs
@@ -47,7 +47,7 @@ namespace VDS.RDF.Writing
     /// </para>
     /// </remarks>
     public class PrettyRdfXmlWriter 
-        : IRdfWriter, IPrettyPrintingWriter, ICompressingWriter, IDtdWriter,
+        : BaseRdfWriter, IPrettyPrintingWriter, ICompressingWriter, IDtdWriter,
         INamespaceWriter, IFormatterBasedWriter, IAttributeWriter
     {
         private bool _prettyprint = true;
@@ -194,7 +194,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">Filename to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -208,26 +208,9 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                this.GenerateOutput(g, output);
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    // Close the Output Stream
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions here
-                }
-                throw;
-            }
+            this.GenerateOutput(g, output);
         }
 
         /// <summary>
@@ -371,7 +354,6 @@ namespace VDS.RDF.Writing
 
             // Save to the Output Stream
             context.Writer.Flush();
-            context.Writer.Close();
         }
 
         private void GenerateSubjectOutput(RdfXmlWriterContext context, List<Triple> ts, bool allowRdfDescription)
@@ -864,7 +846,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is a non-fatal issue with the RDF being output
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/RDFJSONWriter.cs
+++ b/Libraries/dotNetRDF/Writing/RDFJSONWriter.cs
@@ -42,7 +42,7 @@ namespace VDS.RDF.Writing
     /// </p>
     /// </remarks>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
-    public class RdfJsonWriter : IRdfWriter, IPrettyPrintingWriter
+    public class RdfJsonWriter : BaseRdfWriter, IPrettyPrintingWriter
     {
         private bool _prettyprint = true;
 
@@ -67,7 +67,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">Filename to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -81,29 +81,12 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                // Always issue a Warning
-                this.RaiseWarning("RDF/JSON does not contain any Namespace information.  If you read this serialized data back in at a later date you may not be able to reserialize it to Namespace reliant formats (like RDF/XML)");
+            // Always issue a Warning
+            this.RaiseWarning("RDF/JSON does not contain any Namespace information.  If you read this serialized data back in at a later date you may not be able to reserialize it to Namespace reliant formats (like RDF/XML)");
 
-                this.GenerateOutput(g, output);
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    // Close the Output Stream
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions here
-                }
-                throw;
-            }
+            this.GenerateOutput(g, output);
         }
 
         /// <summary>
@@ -303,7 +286,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is a non-fatal issue with the RDF being output
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/RdfXmlWriter.cs
+++ b/Libraries/dotNetRDF/Writing/RdfXmlWriter.cs
@@ -47,7 +47,7 @@ namespace VDS.RDF.Writing
     /// </para>
     /// </remarks>
     public class RdfXmlWriter 
-        : IRdfWriter, IPrettyPrintingWriter, ICompressingWriter, IDtdWriter, INamespaceWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IPrettyPrintingWriter, ICompressingWriter, IDtdWriter, INamespaceWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
         private int _compressionLevel = WriterCompressionLevel.High;
@@ -165,7 +165,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">Filename to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -179,26 +179,9 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Stream to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                this.GenerateOutput(g, output);
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    // Close the Output Stream
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch actions here
-                }
-                throw;
-            }
+            this.GenerateOutput(g, output);
         }
 
         /// <summary>
@@ -470,7 +453,6 @@ namespace VDS.RDF.Writing
 
             // Save to the Output Stream
             context.Writer.Flush();
-            context.Writer.Close();
         }
 
         private void GenerateCollectionOutput(RdfXmlWriterContext context, INode key)
@@ -898,7 +880,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when there is a non-fatal issue with the RDF being output
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/TsvWriter.cs
+++ b/Libraries/dotNetRDF/Writing/TsvWriter.cs
@@ -40,7 +40,7 @@ namespace VDS.RDF.Writing
     /// Class for generating TSV files from RDF Graphs
     /// </summary>
     public class TsvWriter 
-        : IRdfWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IFormatterBasedWriter
     {
         private TsvFormatter _formatter = new TsvFormatter();
 
@@ -61,7 +61,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph</param>
         /// <param name="filename">File to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -75,33 +75,16 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph</param>
             /// <param name="output">Writer to save to</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
+            foreach (Triple t in g.Triples)
             {
-                foreach (Triple t in g.Triples)
-                {
-                    this.GenerateNodeOutput(output, t.Subject, TripleSegment.Subject);
-                    output.Write('\t');
-                    this.GenerateNodeOutput(output, t.Predicate, TripleSegment.Predicate);
-                    output.Write('\t');
-                    this.GenerateNodeOutput(output, t.Object, TripleSegment.Object);
-                    output.Write('\n');
-                }
-
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No error handling, just trying to clean up
-                }
-                throw;
+                this.GenerateNodeOutput(output, t.Subject, TripleSegment.Subject);
+                output.Write('\t');
+                this.GenerateNodeOutput(output, t.Predicate, TripleSegment.Predicate);
+                output.Write('\t');
+                this.GenerateNodeOutput(output, t.Object, TripleSegment.Object);
+                output.Write('\n');
             }
         }
 
@@ -124,7 +107,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised if the Writer detects a non-fatal error with the RDF being output
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Libraries/dotNetRDF/Writing/TurtleWriter.cs
+++ b/Libraries/dotNetRDF/Writing/TurtleWriter.cs
@@ -44,7 +44,7 @@ namespace VDS.RDF.Writing
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     [Obsolete("Deprecated in favour of the CompressionTurtleWriter which uses a much fuller range of syntax compressions", false)]
     public class TurtleWriter 
-        : IRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, IFormatterBasedWriter
+        : BaseRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
         private bool _allowhispeed = false;
@@ -112,7 +112,7 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="g">Graph to save</param>
         /// <param name="filename">Filename to save to</param>
-        public void Save(IGraph g, string filename)
+        public override void Save(IGraph g, string filename)
         {
             using (var stream = File.Open(filename, FileMode.Create))
             {
@@ -126,26 +126,10 @@ namespace VDS.RDF.Writing
             /// </summary>
             /// <param name="g">Graph to save</param>
             /// <param name="output">Writer to save using</param>
-        public void Save(IGraph g, TextWriter output)
+        protected override void SaveInternal(IGraph g, TextWriter output)
         {
-            try
-            {
-                TurtleWriterContext context = new TurtleWriterContext(g, output, this._prettyprint, this._allowhispeed, this._syntax);
-                this.GenerateOutput(context);
-                output.Close();
-            }
-            catch
-            {
-                try
-                {
-                    output.Close();
-                }
-                catch
-                {
-                    // No Catch Actions - just trying to clean up
-                }
-                throw;
-            }
+            TurtleWriterContext context = new TurtleWriterContext(g, output, this._prettyprint, this._allowhispeed, this._syntax);
+            this.GenerateOutput(context);
         }
 
         /// <summary>
@@ -308,7 +292,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Event which is raised when a non-fatal issue with the Graph being serialized is encountered
         /// </summary>
-        public event RdfWriterWarning Warning;
+        public override event RdfWriterWarning Warning;
 
         /// <summary>
         /// Gets the String representation of the writer which is a description of the syntax it produces

--- a/Testing/unittest/Writing/WriterTests.cs
+++ b/Testing/unittest/Writing/WriterTests.cs
@@ -305,5 +305,25 @@ namespace VDS.RDF.Writing
 
             this.CheckCompressionRoundTrip(g);
         }
+
+        [Theory]
+        [InlineData(typeof(NTriplesWriter))]
+        [InlineData(typeof(RdfXmlWriter))]
+        [InlineData(typeof(PrettyRdfXmlWriter))]
+        [InlineData(typeof(RdfJsonWriter))]
+        [InlineData(typeof(CompressingTurtleWriter))]
+        [InlineData(typeof(HtmlWriter))]
+        [InlineData(typeof(HtmlSchemaWriter))]
+        [InlineData(typeof(GraphVizWriter))]
+        public void TextWriterCanBeLeftOpen(Type writerType)
+        {
+            var g = new Graph();
+            var writer = new System.IO.StringWriter();
+            var rdfWriter = writerType.GetConstructor(new Type[0]).Invoke(new object[0]) as IRdfWriter;
+            rdfWriter.Save(g, writer, true);
+            writer.Write("\n"); // This should not throw because the writer is still open
+            rdfWriter.Save(g, writer);
+            Assert.Throws<ObjectDisposedException>(() => writer.Write("\n"));
+        }
     }
 }


### PR DESCRIPTION
Fix for #86 that uses a method overload rather than a constructor
parameter as it seems to fit better with the structure of the IRdfWriter
interface.