### PR TITLE
Removal of NO_WEB #def from netstandard target

### DIFF
--- a/Libraries/dotNetRDF/Parsing/SPARQLXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/SPARQLXMLParser.cs
@@ -30,7 +30,7 @@ using System.Xml;
 using VDS.RDF.Parsing.Contexts;
 using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Query;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Query/Expressions/Functions/XPath/String/EscapeHtmlUriFunction.cs
+++ b/Libraries/dotNetRDF/Query/Expressions/Functions/XPath/String/EscapeHtmlUriFunction.cs
@@ -26,7 +26,7 @@
 
 using VDS.RDF.Nodes;
 using VDS.RDF.Parsing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Query/Inference/Pellet/Services/ExplainServices.cs
+++ b/Libraries/dotNetRDF/Query/Inference/Pellet/Services/ExplainServices.cs
@@ -30,7 +30,7 @@ using System.Linq;
 using System.Net;
 using Newtonsoft.Json.Linq;
 using VDS.RDF.Parsing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Query/Inference/Pellet/Services/SearchService.cs
+++ b/Libraries/dotNetRDF/Query/Inference/Pellet/Services/SearchService.cs
@@ -30,7 +30,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using Newtonsoft.Json.Linq;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Query/SPARQLRemoteEndpoint.cs
+++ b/Libraries/dotNetRDF/Query/SPARQLRemoteEndpoint.cs
@@ -34,7 +34,7 @@ using System.Text;
 using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
 using VDS.RDF.Parsing.Handlers;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/AllegroGraphConnector.cs
+++ b/Libraries/dotNetRDF/Storage/AllegroGraphConnector.cs
@@ -33,7 +33,7 @@ using System.Text;
 using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
 using VDS.RDF.Storage.Management;
-#if !NO_WEB
+#if !NO_SYNC_HTTP && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/FourStoreConnector.cs
+++ b/Libraries/dotNetRDF/Storage/FourStoreConnector.cs
@@ -37,7 +37,7 @@ using VDS.RDF.Query;
 using VDS.RDF.Update;
 using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/FusekiConnector.cs
+++ b/Libraries/dotNetRDF/Storage/FusekiConnector.cs
@@ -35,7 +35,7 @@ using VDS.RDF.Parsing;
 using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Query;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/Management/SesameServer.cs
+++ b/Libraries/dotNetRDF/Storage/Management/SesameServer.cs
@@ -36,7 +36,7 @@ using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Storage.Management.Provisioning;
 using VDS.RDF.Storage.Management.Provisioning.Sesame;
 using VDS.RDF.Writing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/Management/StardogServer.cs
+++ b/Libraries/dotNetRDF/Storage/Management/StardogServer.cs
@@ -36,7 +36,7 @@ using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
 using VDS.RDF.Storage.Management.Provisioning;
 using VDS.RDF.Storage.Management.Provisioning.Stardog;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/SesameHTTPProtocolConnector.cs
+++ b/Libraries/dotNetRDF/Storage/SesameHTTPProtocolConnector.cs
@@ -39,7 +39,7 @@ using VDS.RDF.Query;
 using VDS.RDF.Storage.Management;
 using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/SparqlHttpProtocolConnector.cs
+++ b/Libraries/dotNetRDF/Storage/SparqlHttpProtocolConnector.cs
@@ -33,7 +33,7 @@ using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
 using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Writing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Storage/StardogConnector.cs
+++ b/Libraries/dotNetRDF/Storage/StardogConnector.cs
@@ -39,7 +39,7 @@ using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Query;
 using VDS.RDF.Storage.Management;
 using VDS.RDF.Writing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Update/Protocol/GenericProtocolProcessor.cs
+++ b/Libraries/dotNetRDF/Update/Protocol/GenericProtocolProcessor.cs
@@ -24,7 +24,7 @@
 // </copyright>
 */
 
-#if !NO_ASP
+//#if !NO_ASP
 
 using System;
 using System.Collections.Generic;
@@ -374,4 +374,4 @@ namespace VDS.RDF.Update.Protocol
     }
 }
 
-#endif
+//#endif

--- a/Libraries/dotNetRDF/Update/SparqlRemoteUpdateEndpoint.cs
+++ b/Libraries/dotNetRDF/Update/SparqlRemoteUpdateEndpoint.cs
@@ -31,7 +31,7 @@ using System.Security;
 using System.Text;
 using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Web/Configuration/BaseHandlerConfiguration.cs
+++ b/Libraries/dotNetRDF/Web/Configuration/BaseHandlerConfiguration.cs
@@ -153,7 +153,7 @@ namespace VDS.RDF.Web.Configuration
                 introFile = ConfigurationLoader.ResolvePath(introFile);
                 if (File.Exists(introFile))
                 {
-                    using (StreamReader reader = new StreamReader(introFile))
+                    using (StreamReader reader = new StreamReader(new FileStream(introFile, FileMode.Open)))
                     {
                         this._introText = reader.ReadToEnd();
                         reader.Close();

--- a/Libraries/dotNetRDF/Web/Configuration/Query/BaseQueryHandlerConfiguration.cs
+++ b/Libraries/dotNetRDF/Web/Configuration/Query/BaseQueryHandlerConfiguration.cs
@@ -146,7 +146,7 @@ namespace VDS.RDF.Web.Configuration.Query
                 defQueryFile = ConfigurationLoader.ResolvePath(defQueryFile);
                 if (File.Exists(defQueryFile))
                 {
-                    using (StreamReader reader = new StreamReader(defQueryFile))
+                    using (StreamReader reader = new StreamReader(new FileStream(defQueryFile, FileMode.Open)))
                     {
                         this._defaultQuery = reader.ReadToEnd();
                         reader.Close();

--- a/Libraries/dotNetRDF/Web/Configuration/Server/BaseSparqlServerConfiguration.cs
+++ b/Libraries/dotNetRDF/Web/Configuration/Server/BaseSparqlServerConfiguration.cs
@@ -353,7 +353,7 @@ namespace VDS.RDF.Web.Configuration.Server
                 defQueryFile = ConfigurationLoader.ResolvePath(defQueryFile);
                 if (File.Exists(defQueryFile))
                 {
-                    using (StreamReader reader = new StreamReader(defQueryFile))
+                    using (StreamReader reader = new StreamReader(new FileStream(defQueryFile, FileMode.Open)))
                     {
                         this._defaultQuery = reader.ReadToEnd();
                         reader.Close();
@@ -457,7 +457,7 @@ namespace VDS.RDF.Web.Configuration.Server
                 defUpdateFile = ConfigurationLoader.ResolvePath(defUpdateFile);
                 if (File.Exists(defUpdateFile))
                 {
-                    using (StreamReader reader = new StreamReader(defUpdateFile))
+                    using (StreamReader reader = new StreamReader(new FileStream(defUpdateFile, FileMode.Open)))
                     {
                         this._defaultUpdate = reader.ReadToEnd();
                         reader.Close();

--- a/Libraries/dotNetRDF/Web/Configuration/Update/BaseUpdateHandlerConfiguration.cs
+++ b/Libraries/dotNetRDF/Web/Configuration/Update/BaseUpdateHandlerConfiguration.cs
@@ -89,7 +89,7 @@ namespace VDS.RDF.Web.Configuration.Update
                 defUpdateFile = ConfigurationLoader.ResolvePath(defUpdateFile);
                 if (File.Exists(defUpdateFile))
                 {
-                    using (StreamReader reader = new StreamReader(defUpdateFile))
+                    using (StreamReader reader = new StreamReader(new FileStream(defUpdateFile, FileMode.Open)))
                     {
                         this._defaultUpdate = reader.ReadToEnd();
                         reader.Close();

--- a/Libraries/dotNetRDF/Web/Configuration/WebConfigurationLoader.cs
+++ b/Libraries/dotNetRDF/Web/Configuration/WebConfigurationLoader.cs
@@ -24,7 +24,7 @@
 // </copyright>
 */
 
-#if !NO_WEB && !NO_ASP
+#if !NO_WEB && !NO_ASP && !NETSTANDARD1_4
 
 using System;
 using System.IO;

--- a/Libraries/dotNetRDF/Web/HandlerHelper.cs
+++ b/Libraries/dotNetRDF/Web/HandlerHelper.cs
@@ -621,6 +621,16 @@ namespace VDS.RDF.Web
         /// <param name="config">Handler Configuration</param>
         public static void AddStandardHeaders(IHttpContext context, BaseHandlerConfiguration config)
         {
+#if NETSTANDARD1_4
+            try
+            {
+                context.Response.Headers.Add("X-dotNetRDF-Version", typeof(HandlerHelper).GetTypeInfo().Assembly.GetName().Version.ToString());
+            }
+            catch (PlatformNotSupportedException)
+            {
+                context.Response.AddHeader("X-dotNetRDF-Version", typeof(HandlerHelper).GetTypeInfo().Assembly.GetName().Version.ToString());
+            }
+#else
             try
             {
                 context.Response.Headers.Add("X-dotNetRDF-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
@@ -629,6 +639,7 @@ namespace VDS.RDF.Web
             {
                 context.Response.AddHeader("X-dotNetRDF-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             }
+#endif
             if (config.IsCorsEnabled) AddCorsHeaders(context);
         }
 
@@ -658,7 +669,7 @@ namespace VDS.RDF.Web
             return dt.ToString("ddd, d MMM yyyy HH:mm:ss K");
         }
 
-        #endregion
+#endregion
     }
 }
 

--- a/Libraries/dotNetRDF/Writing/Contexts/HtmlWriterContext.cs
+++ b/Libraries/dotNetRDF/Writing/Contexts/HtmlWriterContext.cs
@@ -27,7 +27,7 @@
 using System;
 using System.IO;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web.UI;
 #endif
 

--- a/Libraries/dotNetRDF/Writing/Formatting/HtmlFormatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/HtmlFormatter.cs
@@ -26,7 +26,7 @@
 
 using System;
 
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web;
 #endif
 

--- a/Libraries/dotNetRDF/Writing/HtmlSchemaWriter.cs
+++ b/Libraries/dotNetRDF/Writing/HtmlSchemaWriter.cs
@@ -33,7 +33,7 @@ using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Writing.Contexts;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web.UI;
 #endif
 

--- a/Libraries/dotNetRDF/Writing/HtmlWriter.cs
+++ b/Libraries/dotNetRDF/Writing/HtmlWriter.cs
@@ -30,7 +30,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using VDS.RDF.Writing.Contexts;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web.UI;
 #endif
 

--- a/Libraries/dotNetRDF/Writing/SPARQLHTMLWriter.cs
+++ b/Libraries/dotNetRDF/Writing/SPARQLHTMLWriter.cs
@@ -29,7 +29,7 @@ using System.IO;
 using System.Text;
 using VDS.RDF.Query;
 using VDS.RDF.Writing.Formatting;
-#if !NO_WEB
+#if !NO_WEB && !NETSTANDARD1_4
 using System.Web.UI;
 #endif
 

--- a/Libraries/dotNetRDF/dotNetRDF.csproj
+++ b/Libraries/dotNetRDF/dotNetRDF.csproj
@@ -63,10 +63,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+	<PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.0.1" />
     <PackageReference Include="System.Net.Requests" Version="4.0.11" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
+	<PackageReference Include="System.Security.Principal" Version="4.0.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
@@ -96,11 +98,12 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <DefineConstants>$(DefineConstants);NO_SYSTEMCONFIGURATION;NO_PROXY;NO_XSL;NO_HTMLAGILITYPACK;NO_DATA;NO_WEB;NO_PROCESS;NO_URICACHE;NETCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_SYSTEMCONFIGURATION;NO_PROXY;NO_XSL;NO_HTMLAGILITYPACK;NO_DATA;NO_PROCESS;NO_URICACHE;NETCORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <Compile Remove="Web\**\*.cs;Update\Protocol\*.cs;Compatibility\Portable\**\*.cs" />
+    <Compile Remove="Web\**\*.cs;Compatibility\Portable\**\*.cs" />
+	<Compile Include="Web\IHttpContext.cs;Web\HandlerHelper.cs;Web\SparqlServiceDescriber.cs;Web\Configuration\**\*.cs" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">


### PR DESCRIPTION
This is a PR to add the web functionality back in to the netstandard1.4 build of the core library.

The main pieces of this are:

- [x] Remove the NO_WEB #def and fix any resulting compilation issues
- [ ] Reimplement the custom ASP.NET HTTP Handlers in VDS.RDF.Web as ASP.NET 5 Middleware