### PR TITLE
[StardogConnector] Query with reasoning parameter

### DIFF
--- a/Libraries/dotNetRDF/Storage/IStorageProvider.cs
+++ b/Libraries/dotNetRDF/Storage/IStorageProvider.cs
@@ -294,6 +294,40 @@ namespace VDS.RDF.Storage
     }
 
     /// <summary>
+    /// Interface for storage providers which allow SPARQL Queries to be made against them with reasoning set by query
+    /// </summary>
+    public interface IReasoningQueryableStorage
+        : IStorageProvider
+    {
+        /// <summary>
+        /// Makes a SPARQL Query against the underlying store
+        /// </summary>
+        /// <param name="sparqlQuery">SPARQL Query</param>
+        /// <param name="reasoning">rReasoning On demand by query</param>
+        /// <returns><see cref="SparqlResultSet">SparqlResultSet</see> or a <see cref="Graph">Graph</see> depending on the Sparql Query</returns>
+        /// <exception cref="RdfQueryException">Thrown if an error occurs performing the query</exception>
+        /// <exception cref="RdfStorageException">Thrown if an error occurs performing the query</exception>
+        /// <exception cref="RdfParseException">Thrown if the query is invalid when validated by dotNetRDF prior to passing the query request to the store or if the request succeeds but the store returns malformed results</exception>
+        /// <exception cref="RdfParserSelectionException">Thrown if the store returns results in a format dotNetRDF does not understand</exception>
+        Object Query(String sparqlQuery, bool reasoning);
+
+        /// <summary>
+        /// Makes a SPARQL Query against the underlying store processing the resulting Graph/Result Set with a handler of your choice
+        /// </summary>
+        /// <param name="rdfHandler">RDF Handler</param>
+        /// <param name="resultsHandler">SPARQL Results Handler</param>
+        /// <param name="sparqlQuery">SPARQL Query</param>
+        /// <param name="reasoning">rReasoning On demand by query</param>
+        /// <exception cref="RdfQueryException">Thrown if an error occurs performing the query</exception>
+        /// <exception cref="RdfStorageException">Thrown if an error occurs performing the query</exception>
+        /// <exception cref="RdfParseException">Thrown if the query is invalid when validated by dotNetRDF prior to passing the query request to the store or if the request succeeds but the store returns malformed results</exception>
+        /// <exception cref="RdfParserSelectionException">Thrown if the store returns results in a format dotNetRDF does not understand</exception>
+        void Query(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, String sparqlQuery, bool reasoning
+            );
+    }
+
+
+    /// <summary>
     /// Interface for storage providers which allow SPARQL Updates to be made against them
     /// </summary>
     public interface IUpdateableStorage

--- a/Libraries/dotNetRDF/Storage/StardogConnector.cs
+++ b/Libraries/dotNetRDF/Storage/StardogConnector.cs
@@ -314,7 +314,7 @@ namespace VDS.RDF.Storage
         {
             Graph g = new Graph();
             SparqlResultSet results = new SparqlResultSet();
-            this.Query(new GraphHandler(g), new ResultSetHandler(results), sparqlQuery, false);
+            this.Query(new GraphHandler(g), new ResultSetHandler(results), sparqlQuery);
 
             if (results.ResultsType != SparqlResultsType.Unknown)
             {

--- a/Libraries/dotNetRDF/Storage/StardogConnector.cs
+++ b/Libraries/dotNetRDF/Storage/StardogConnector.cs
@@ -102,7 +102,7 @@ namespace VDS.RDF.Storage
     /// </remarks>
     public abstract class BaseStardogConnector
         : BaseAsyncHttpConnector, IAsyncQueryableStorage, IAsyncTransactionalStorage, IConfigurationSerializable
-        , IQueryableStorage, ITransactionalStorage
+        , IQueryableStorage, ITransactionalStorage, IReasoningQueryableStorage
     {
         /// <summary>
         /// Constant for the default Anonymous user account and password used by Stardog if you have not supplied a shiro.ini file or otherwise disabled security
@@ -327,7 +327,7 @@ namespace VDS.RDF.Storage
         }
 
         /// <summary>
-        /// Makes a SPARQL Query against the underlying Store using whatever reasoning mode is currently in-use
+        /// Makes a SPARQL Query against the underlying Store using whatever reasoning mode is currently in-use, the reasoning can be set by query
         /// </summary>
         /// <param name="sparqlQuery">Sparql Query</param>
         /// <param name="reasoning"></param>
@@ -432,7 +432,7 @@ namespace VDS.RDF.Storage
 
 
         /// <summary>
-        /// Makes a SPARQL Query against the underlying Store using whatever reasoning mode is currently in-use processing the results using an appropriate handler from those provided
+        /// Makes a SPARQL Query against the underlying Store using whatever reasoning mode is currently in-use processing the results using an appropriate handler from those provided, the reasoning can be set by query
         /// </summary>
         /// <param name="rdfHandler">RDF Handler</param>
         /// <param name="resultsHandler">Results Handler</param>

--- a/Testing/unittest/Storage/StardogTests.cs
+++ b/Testing/unittest/Storage/StardogTests.cs
@@ -390,6 +390,77 @@ namespace VDS.RDF.Storage
                 "Reasoning should yield as many if not more results");
         }
 
+
+        [SkippableFact]
+        public void StorageStardogReasoningByQuery1()
+        {
+            StardogConnector stardog = StardogTests.GetConnection();
+            if (stardog.Reasoning == StardogReasoningMode.DatabaseControlled)
+            {
+                throw new SkipTestException(
+                    "Version of Stardog being tested does not support configuring reasoning mode at connection level");
+            }
+
+            Graph g = new Graph();
+            g.LoadFromFile("resources\\stardog-reasoning-test.rdf");
+            g.BaseUri = new Uri("http://www.reasoningtest.com/");
+            stardog.SaveGraph(g);
+
+            String query = "Select ?building where { ?building <http://www.reasoningtest.com#hasLocation> ?room.}";
+
+            Console.WriteLine(query);
+            Console.WriteLine();
+
+            SparqlResultSet resultsWithReasoning = stardog.Query(query, true) as SparqlResultSet;
+            Assert.NotNull(resultsWithReasoning);
+            if (resultsWithReasoning != null)
+            {
+                Console.WriteLine("Results With Reasoning");
+                TestTools.ShowResults(resultsWithReasoning);
+                Assert.True(true , "Reasoning By Query OK !");
+            }
+            else
+            {
+                Assert.True(false, "Did not get a SPARQL Result Set as expected");
+            }
+
+        }
+
+
+        [SkippableFact]
+        public void StorageStardogReasoningByQuery2()
+        {
+            StardogConnector stardog = StardogTests.GetConnection();
+            if (stardog.Reasoning == StardogReasoningMode.DatabaseControlled)
+            {
+                throw new SkipTestException(
+                    "Version of Stardog being tested does not support configuring reasoning mode at connection level");
+            }
+
+            Graph g = new Graph();
+            g.LoadFromFile("resources\\stardog-reasoning-test.rdf");
+            g.BaseUri = new Uri("http://www.reasoningtest.com/");
+            stardog.SaveGraph(g);
+
+            String query = "Select ?building where { ?building <http://www.reasoningtest.com#hasLocation> ?room.}"; 
+            Console.WriteLine(query);
+            Console.WriteLine();
+
+            SparqlResultSet resultsWithNoReasoning = stardog.Query(query, false) as SparqlResultSet;
+            Assert.Null(resultsWithNoReasoning);
+            if (resultsWithNoReasoning != null )
+            {
+                Console.WriteLine("Results With No Reasoning");
+                Assert.True(false, "There should not be any reasoning results !");
+            }
+            else
+            {
+                Assert.True(true, "No SPARQL Results returned ! Success.");
+            }
+
+        }
+
+
         [SkippableFact]
         public void StorageStardogReasoningMode()
         {

--- a/Testing/unittest/resources/stardog-reasoning-test.rdf
+++ b/Testing/unittest/resources/stardog-reasoning-test.rdf
@@ -1,0 +1,207 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.reasoningtest.com/stardog#"
+     xml:base="http://www.reasoningtest.com/stardog"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:test="http://www.reasoningtest.com/stardog#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:www="http://www.reasoningtest.com#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://www.reasoningtest.com"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+ 
+
+    <!-- http://www.reasoningtest.com#hasLocation -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#hasLocation">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <owl:inverseOf rdf:resource="http://www.reasoningtest.com#isLocatedIn"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.reasoningtest.com#hasLocationBuilding -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#hasLocationBuilding">
+        <rdfs:subPropertyOf rdf:resource="http://www.reasoningtest.com#hasLocation"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.reasoningtest.com#hasLocationFloor -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#hasLocationFloor">
+        <rdfs:subPropertyOf rdf:resource="http://www.reasoningtest.com#hasLocation"/>
+        <owl:inverseOf rdf:resource="http://www.reasoningtest.com#isLocatedInBuilding"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.reasoningtest.com#hasLocationRoom -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#hasLocationRoom">
+        <rdfs:subPropertyOf rdf:resource="http://www.reasoningtest.com#hasLocation"/>
+        <owl:inverseOf rdf:resource="http://www.reasoningtest.com#isLocatedInFloor"/>
+    </owl:ObjectProperty>
+    
+
+
+    
+    
+
+    <!-- http://www.reasoningtest.com#isLocatedIn -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#isLocatedIn">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.reasoningtest.com#isLocatedInBuilding -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#isLocatedInBuilding">
+        <rdfs:subPropertyOf rdf:resource="http://www.reasoningtest.com#isLocatedIn"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.reasoningtest.com#isLocatedInFloor -->
+
+    <owl:ObjectProperty rdf:about="http://www.reasoningtest.com#isLocatedInFloor">
+        <rdfs:subPropertyOf rdf:resource="http://www.reasoningtest.com#isLocatedIn"/>
+    </owl:ObjectProperty>
+    
+
+
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.reasoningtest.com#Building -->
+
+    <owl:Class rdf:about="http://www.reasoningtest.com#Building">
+        <rdfs:subClassOf rdf:resource="http://www.reasoningtest.com#Location"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.reasoningtest.com#Floor -->
+
+    <owl:Class rdf:about="http://www.reasoningtest.com#Floor">
+        <rdfs:subClassOf rdf:resource="http://www.reasoningtest.com#Location"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.reasoningtest.com#Location -->
+
+    <owl:Class rdf:about="http://www.reasoningtest.com#Location"/>
+    
+
+
+    <!-- http://www.reasoningtest.com#Room -->
+
+    <owl:Class rdf:about="http://www.reasoningtest.com#Room">
+        <rdfs:subClassOf rdf:resource="http://www.reasoningtest.com#Location"/>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.reasoningtest.com#Building1 -->
+
+    <owl:NamedIndividual rdf:about="http://www.reasoningtest.com#Building1">
+        <rdf:type rdf:resource="http://www.reasoningtest.com#Building"/>
+        <www:hasLocationFloor rdf:resource="http://www.reasoningtest.com#Floor1"/>
+        <www:hasLocationFloor rdf:resource="http://www.reasoningtest.com#Floor2"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.reasoningtest.com#Floor1 -->
+
+    <owl:NamedIndividual rdf:about="http://www.reasoningtest.com#Floor1">
+        <rdf:type rdf:resource="http://www.reasoningtest.com#Floor"/>
+        <www:hasLocationRoom rdf:resource="http://www.reasoningtest.com#Room1"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.reasoningtest.com#Floor2 -->
+
+    <owl:NamedIndividual rdf:about="http://www.reasoningtest.com#Floor2">
+        <rdf:type rdf:resource="http://www.reasoningtest.com#Floor"/>
+        <www:hasLocationRoom rdf:resource="http://www.reasoningtest.com#Room2"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.reasoningtest.com#Room1 -->
+
+    <owl:NamedIndividual rdf:about="http://www.reasoningtest.com#Room1">
+        <rdf:type rdf:resource="http://www.reasoningtest.com#Room"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.reasoningtest.com#Room2 -->
+
+    <owl:NamedIndividual rdf:about="http://www.reasoningtest.com#Room2">
+        <rdf:type rdf:resource="http://www.reasoningtest.com#Room"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.reasoningtest.com#Building"/>
+            <rdf:Description rdf:about="http://www.reasoningtest.com#Floor"/>
+            <rdf:Description rdf:about="http://www.reasoningtest.com#Room"/>
+        </owl:members>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.2.6.20160910-2108) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
Updated the query function to add the reasoning parameter activation in the query.


In the [Java API](https://www.stardog.com/docs/java/snarl/com/complexible/stardog/api/query) it is possible to activate the reasoning by query:
```java
Query<T>	reasoning(boolean theReasoningFlag)
Specify whether you would like the query to be executed with reasoning.
```

This pull request adds two functions
```C#
Query( String sparqlQuery, bool reasoning).
```
and 
```C#
public virtual void Query(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, String sparqlQuery, bool reasoning)
```
It is preferable to have one `Query` function with the reasoning parameter instead of two but this will have impact on `IQueryableStorage`
