### PR TITLE
Updates regex to recognise default prefixes

### DIFF
--- a/Libraries/dotNetRDF/Query/SparqlParameterizedString.cs
+++ b/Libraries/dotNetRDF/Query/SparqlParameterizedString.cs
@@ -94,7 +94,7 @@ namespace VDS.RDF.Query
         private static Regex ValidParameterNamePattern = new Regex("^@?[\\w\\-_]+$", RegexOptions.IgnoreCase);
         private static Regex ValidVariableNamePattern = new Regex("^[?$]?[\\w\\-_]+$", RegexOptions.IgnoreCase);
 
-        private static Regex PreambleCapturePattern = new Regex("(BASE|PREFIX\\s+([\\w\\-_]+):)\\s*<([^>]+)>", RegexOptions.IgnoreCase);
+        private static Regex PreambleCapturePattern = new Regex("(BASE|PREFIX\\s+([\\w\\-_]*):)\\s*<([^>]+)>", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Creates a new empty parameterized String

--- a/Testing/unittest/Query/SparqlTests.cs
+++ b/Testing/unittest/Query/SparqlTests.cs
@@ -692,5 +692,24 @@ WHERE
             Assert.NotNull(resultGraph);
             Assert.Equal(9, resultGraph.Triples.Count); // Returns 3 rather than 9
         }
+        [Fact]
+        public void SparqlParameterizedStringDefaultPrefixOrder()
+        {
+            // given
+            const string queryString = @"
+PREFIX : <http://id.ukpds.org/schema/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+CONSTRUCT *
+WHERE {
+    ?s ?p ?o
+}";
+
+            // when
+            var query = new SparqlParameterizedString(queryString);
+
+            // then
+            query.Namespaces.Prefixes.Should().HaveCount(2);
+            query.Namespaces.GetNamespaceUri(string.Empty).Should().Be(new Uri("http://id.ukpds.org/schema/"));
+        }
     }
 }


### PR DESCRIPTION
solves https://github.com/dotnetrdf/dotnetrdf/issues/111
h/t @langsamu
Current behaviour is that if you only say `PREFIX : <http://example.com#>`
you get the desired behaviour that `:Thing` resolves to <http://example.com#Thing>
However if you say the following:
`PREFIX : <http://example.com#>`
`PREFIX another: <http://anotherexample.com#>`
the first prefix is stripped and `:Thing` will not resolve and the validator says you've not declared the default namespace

Regex fix makes dotnetrdf treat `PREFIX : <http://example.com>` in the same way as `PREFIX example: <http://example.com>`, and lets you state your prefixes in whatever order you like, as per SPARQL's grammar rules: https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#grammar