### PR TITLE
Move HTTP authentication code to base class

### DIFF
--- a/Libraries/dotNetRDF/Storage/AllegroGraphConnector.cs
+++ b/Libraries/dotNetRDF/Storage/AllegroGraphConnector.cs
@@ -363,12 +363,12 @@ namespace VDS.RDF.Storage
             }
             context.Graph.Assert(new Triple(manager, store, context.Graph.CreateLiteralNode(_store)));
             
-            if (_username != null && _pwd != null)
+            if (Username != null && Password != null)
             {
                 INode username = context.Graph.CreateUriNode(UriFactory.Create(ConfigurationLoader.PropertyUser));
                 INode pwd = context.Graph.CreateUriNode(UriFactory.Create(ConfigurationLoader.PropertyPassword));
-                context.Graph.Assert(new Triple(manager, username, context.Graph.CreateLiteralNode(_username)));
-                context.Graph.Assert(new Triple(manager, pwd, context.Graph.CreateLiteralNode(_pwd)));
+                context.Graph.Assert(new Triple(manager, username, context.Graph.CreateLiteralNode(Username)));
+                context.Graph.Assert(new Triple(manager, pwd, context.Graph.CreateLiteralNode(Password)));
             }
 
             SerializeStandardConfig(manager, context);

--- a/Libraries/dotNetRDF/Storage/BaseHttpConnector.NetFull.cs
+++ b/Libraries/dotNetRDF/Storage/BaseHttpConnector.NetFull.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Threading;
 using VDS.RDF.Configuration;
 using VDS.RDF.Parsing;
@@ -56,6 +57,11 @@ namespace VDS.RDF.Storage
         {
             Timeout = 30000;
         }
+
+        /// <summary>
+        /// Whether the User has provided credentials for accessing the Store using authentication
+        /// </summary>
+        private bool _hasCredentials;
 
         private IWebProxy _proxy;
 
@@ -195,6 +201,16 @@ namespace VDS.RDF.Storage
         public int Timeout { get; set; }
 
         /// <summary>
+        /// Password for accessing the Store
+        /// </summary>
+        protected string Username { get; private set; }
+
+        /// <summary>
+        /// Password for accessing the Store
+        /// </summary>
+        protected string Password { get; private set; }
+
+        /// <summary>
         /// Helper method which applies standard request options to the request, these currently include proxy settings and HTTP timeout
         /// </summary>
         /// <param name="request">HTTP Web Request</param>
@@ -205,6 +221,24 @@ namespace VDS.RDF.Storage
             if (_proxy != null)
             {
                 request.Proxy = _proxy;
+            }
+
+            // Add Credentials if needed
+            if (_hasCredentials)
+            {
+                if (Options.ForceHttpBasicAuth)
+                {
+                    // Forcibly include a HTTP basic authentication header
+                    string credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(this.Username + ":" + this.Password));
+                    request.Headers["Authorization"] = "Basic " + credentials;
+                }
+                else
+                {
+                    // Leave .Net to cope with HTTP auth challenge response
+                    NetworkCredential credentials = new NetworkCredential(Username, Password);
+                    request.Credentials = credentials;
+                    request.PreAuthenticate = true;
+                }
             }
             // Disable Keep Alive since it can cause errors when carrying out high volumes of operations or when performing long running operations
             request.KeepAlive = false;
@@ -243,6 +277,13 @@ namespace VDS.RDF.Storage
             NetworkCredential cred = (NetworkCredential)_proxy.Credentials;
             context.Graph.Assert(new Triple(proxy, user, context.Graph.CreateLiteralNode(cred.UserName)));
             context.Graph.Assert(new Triple(proxy, pwd, context.Graph.CreateLiteralNode(cred.Password)));
+        }
+
+        public void SetCredentials(string username, string password)
+        {
+            Username = username;
+            Password = password;
+            _hasCredentials = (!String.IsNullOrEmpty(username) && !String.IsNullOrEmpty(password));
         }
     }
 


### PR DESCRIPTION
This way any connector which inherits from `BaseHttpConnector` will be able to use basic authentication.

I needed this for Fuseki but simply moved up the inheritance tree