### PR TITLE
Use TripleCollection to look for nodes 

### DIFF
--- a/Libraries/dotNetRDF/Core/Graph.cs
+++ b/Libraries/dotNetRDF/Core/Graph.cs
@@ -161,11 +161,7 @@ namespace VDS.RDF
         /// <returns>Either the UriNode Or null if no Node with the given Uri exists</returns>
         public override IUriNode GetUriNode(Uri uri)
         {
-            IUriNode test = new UriNode(this, uri);
-            IEnumerable<IUriNode> us = from u in Nodes.UriNodes()
-                                          where u.Equals(test)
-                                          select u;
-            return us.FirstOrDefault();
+            return GetNode(new UriNode(this, uri));
         }
 
         /// <summary>
@@ -175,11 +171,7 @@ namespace VDS.RDF
         /// <returns></returns>
         public override IUriNode GetUriNode(String qname)
         {
-            IUriNode test = new UriNode(this, qname);
-            IEnumerable<IUriNode> us = from u in Nodes.UriNodes()
-                                      where u.Equals(test)
-                                      select u;
-            return us.FirstOrDefault();
+            return GetNode(new UriNode(this, qname));
         }
 
         /// <summary>
@@ -190,11 +182,7 @@ namespace VDS.RDF
         /// <remarks>The LiteralNode in the Graph must have no Language or DataType set</remarks>
         public override ILiteralNode GetLiteralNode(String literal)
         {
-            ILiteralNode test = new LiteralNode(this, literal);
-            IEnumerable<ILiteralNode> ls = from l in Nodes.LiteralNodes()
-                                          where l.Equals(test)
-                                          select l;
-            return ls.FirstOrDefault();
+            return GetNode(new LiteralNode(this, literal));
         }
 
         /// <summary>
@@ -205,11 +193,7 @@ namespace VDS.RDF
         /// <returns>Either the LiteralNode Or null if no Node with the given Value and Language Specifier exists</returns>
         public override ILiteralNode GetLiteralNode(String literal, String langspec)
         {
-            ILiteralNode test = new LiteralNode(this, literal, langspec);
-            IEnumerable<ILiteralNode> ls = from l in Nodes.LiteralNodes()
-                                          where l.Equals(test)
-                                          select l;
-            return ls.FirstOrDefault();
+            return GetNode(new LiteralNode(this, literal, langspec));
         }
 
         /// <summary>
@@ -220,11 +204,7 @@ namespace VDS.RDF
         /// <returns>Either the LiteralNode Or null if no Node with the given Value and Data Type exists</returns>
         public override ILiteralNode GetLiteralNode(String literal, Uri datatype)
         {
-            ILiteralNode test = new LiteralNode(this, literal, datatype);
-            IEnumerable<ILiteralNode> ls = from l in Nodes.LiteralNodes()
-                                          where l.Equals(test)
-                                          select l;
-            return ls.FirstOrDefault();
+            return GetNode(new LiteralNode(this, literal, datatype));
         }
 
         /// <summary>
@@ -234,11 +214,22 @@ namespace VDS.RDF
         /// <returns>Either the Blank Node or null if no Node with the given Identifier exists</returns>
         public override IBlankNode GetBlankNode(String nodeId)
         {
-            IEnumerable<IBlankNode> bs = from b in Nodes.BlankNodes()
-                                        where b.InternalID.Equals(nodeId)
-                                        select b;
+            return GetNode(new BlankNode(this, nodeId));
+        }
 
-            return bs.FirstOrDefault();
+        private T GetNode<T>(T node) where T: INode
+        {
+            var withSubject = Triples.WithSubject(node);
+            var withObject = Triples.WithObject(node);
+
+            var firstWithSubject = withSubject.FirstOrDefault();
+
+            if (firstWithSubject != null)
+            {
+                return (T)firstWithSubject.Subject;
+            }
+
+            return (T)withObject.FirstOrDefault()?.Object;
         }
 
         #endregion

--- a/Testing/unittest/Core/AbstractGraphTests.cs
+++ b/Testing/unittest/Core/AbstractGraphTests.cs
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -102,14 +103,344 @@ namespace VDS.RDF
             g.Retract(g.GetTriplesWithPredicate(rdfType).ToList());
             Assert.False(g.GetTriplesWithPredicate(rdfType).Any());
         }
+
+        [Fact]
+        public void GetUriNode_ShouldReturnIfUsedAsObject()
+        {
+            // given
+            var graph = GetInstance();
+            var uri = new Uri("http://example.com/obj");
+            var node = graph.CreateUriNode(uri);
+            graph.Assert(
+                node,
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                graph.CreateBlankNode());
+
+            // when
+            var uriNode = graph.GetUriNode(uri);
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetUriNode_ShouldReturnIfUsedAsSubject()
+        {
+            // given
+            var graph = GetInstance();
+            var uri = new Uri("http://example.com/subj");
+            var node = graph.CreateUriNode(uri);
+            graph.Assert(
+                graph.CreateBlankNode(),
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                node);
+
+            // subj
+            var uriNode = graph.GetUriNode(uri);
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetUriNode_ShouldReturnNullWhenNotFound()
+        {
+            // given
+            var graph = GetInstance();
+
+            // subj
+            var uriNode = graph.GetUriNode(new Uri("http://no/such/node"));
+
+            // then
+            Assert.Null(uriNode);
+        }
+
+        [Fact]
+        public void GetBlankNode_ShouldReturnIfUsedAsSubject()
+        {
+            // given
+            var graph = GetInstance();
+            var node = graph.CreateBlankNode("xyz");
+            graph.Assert(
+                graph.CreateBlankNode(),
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                node);
+
+            // subj
+            var uriNode = graph.GetBlankNode("xyz");
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetBlankNode_ShouldReturnIfUsedAsObject()
+        {
+            // given
+            var graph = GetInstance();
+            var node = graph.CreateBlankNode("xyz");
+            graph.Assert(
+                node,
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                graph.CreateBlankNode());
+
+            // subj
+            var uriNode = graph.GetBlankNode("xyz");
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetBlankNode_ShouldReturnNullWhenNotFound()
+        {
+            // given
+            var graph = GetInstance();
+
+            // subj
+            var uriNode = graph.GetBlankNode("other_id");
+
+            // then
+            Assert.Null(uriNode);
+        }
+
+        [Fact]
+        public void GetLiteralNode_Plain_ShouldReturnWhenFound()
+        {
+            // given
+            var graph = GetInstance();
+            var literal = "test";
+            var node = graph.CreateLiteralNode(literal);
+            graph.Assert(
+                graph.CreateBlankNode(),
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                node);
+
+            // subj
+            var uriNode = graph.GetLiteralNode(literal);
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetLiteralNode_WithLanguageTag_ShouldReturnWhenFound()
+        {
+            // given
+            var graph = GetInstance();
+            var literal = "test";
+            var tag = "de";
+            var node = graph.CreateLiteralNode(literal, tag);
+            graph.Assert(
+                graph.CreateBlankNode(),
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                node);
+
+            // subj
+            var uriNode = graph.GetLiteralNode(literal, tag);
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetLiteralNode_WithDatatype_ShouldReturnWhenFound()
+        {
+            // given
+            var graph = GetInstance();
+            var literal = "test";
+            var type = new Uri("http://data/type");
+            var node = graph.CreateLiteralNode(literal, type);
+            graph.Assert(
+                graph.CreateBlankNode(),
+                graph.CreateUriNode(new Uri("http://example.com/pred")),
+                node);
+
+            // subj
+            var uriNode = graph.GetLiteralNode(literal, type);
+
+            // then
+            Assert.Same(node, uriNode);
+        }
+
+        [Fact]
+        public void GetLiteralNode_ShouldReturnNullWhenNotFound()
+        {
+            // given
+            var graph = GetInstance();
+
+            // subj
+            var uriNode = graph.GetLiteralNode("something else");
+
+            // then
+            Assert.Null(uriNode);
+        }
     }
 
     public class GraphTests
         : AbstractGraphTests
     {
+        private const int GetNodeTestGraphSize = 100000;
+
         protected override IGraph GetInstance()
         {
             return new Graph();
+        }
+
+        [Fact]
+        public void GetUriNode_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetUriNode(new Uri($"http://example.org/{random.Next(GetNodeTestGraphSize)}"));
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
+        }
+
+        [Fact]
+        public void GetUriNode_WhenSelectedNodeIsNotInGraph_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetUriNode(new Uri("http://example.org/not/in/graph"));
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
+        }
+
+        [Fact]
+        public void GetLiteralNode_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateLiteralNode($"test {random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetLiteralNode($"test {random.Next(GetNodeTestGraphSize)}");
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
+        }
+
+        [Fact]
+        public void GetLiteralNode_WhenSelectedNodeIsNotInGraph_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateLiteralNode($"test {random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetLiteralNode("x y z");
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
+        }
+
+        [Fact]
+        public void GetBlankNode_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateBlankNode($"{random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetBlankNode($"{random.Next(GetNodeTestGraphSize)}");
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
+        }
+
+        [Fact]
+        public void GetBlankNode_WhenSelectedNodeIsNotInGraph_ShouldBeFastForLargeGraphs()
+        {
+            // given
+            var total = new TimeSpan();
+            var random = new Random();
+            var graph = GetInstance();
+            graph.NamespaceMap.AddNamespace("ex", new Uri("http://example.org/"));
+
+            for (int i1 = 0; i1 < GetNodeTestGraphSize; i1++)
+            {
+                graph.Assert(graph.CreateUriNode($"ex:{random.Next(GetNodeTestGraphSize)}"), graph.CreateUriNode("ex:p"), graph.CreateBlankNode($"{random.Next(GetNodeTestGraphSize)}"));
+            }
+
+            // when
+            for (int i = 0; i < 1000; i++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                graph.GetBlankNode("other_blank_id");
+                total += stopwatch.Elapsed;
+            }
+
+            // then
+            Assert.True(total.TotalMilliseconds < 100);
         }
     }
 


### PR DESCRIPTION
This is a bigger one.

The current implementation of Graph#GetUriNode and its companions are pretty slow because

they do a Distinct underneath on the subject and object nodes
more importantly, they bypass indexes by enumeration everything
By using Triples.WithSubject(node) and Triples.WithObject(node) the performance boost observed in indexed Graph is multiple orders of magnitude large 😁