### PR TITLE
Fix for incorrect assembly version information

### DIFF
--- a/Libraries/dotNetRDF.Data.DataTables/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Data.DataTables/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("dotNetRDF DataTables")]
+[assembly: AssemblyDescription("Package which allow integrating dotNetRDF with System.Data.DataTable")]
+[assembly: AssemblyProduct("dotNetRDF.Data.DataTables")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2009-2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ed9495dd-2143-416f-ab9d-33078a1e5eb0")]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]

--- a/Libraries/dotNetRDF.Data.Virtuoso/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Data.Virtuoso/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
@@ -25,7 +25,6 @@
 */
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -33,10 +32,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("dotNetRDF.Data.Virtuoso")]
 [assembly: AssemblyDescription("Virtuoso Backend for dotNetRDF (.Net 4.0)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("dotNetRDF.Data.Virtuoso")]
-[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2011-2012")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2011-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -48,18 +45,10 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ab4c87e7-5b5b-492c-9db3-a01a2a086c97")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyFileVersion("1.0.13.0")]
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]
 
 
 
@@ -95,3 +84,5 @@ using System.Runtime.InteropServices;
 
 
 
+
+[assembly: AssemblyInformationalVersion("2.0.1+5.Branch.master.Sha.2b2692866fdc3f3bb5bc6f318ab2f93abcc1a689")]

--- a/Libraries/dotNetRDF.Data.Virtuoso/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Data.Virtuoso/Properties/AssemblyInfo.cs
@@ -48,7 +48,6 @@ using System.Runtime.InteropServices;
 // Version information is managed by GitVersion
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("")]
 
 
 

--- a/Libraries/dotNetRDF.Query.FullText/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Query.FullText/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
@@ -31,12 +31,10 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("dotNetRDF.Query.FullText")]
+[assembly: AssemblyTitle("dotNetRDF FullText Query")]
 [assembly: AssemblyDescription("Provides full text SPARQL capabilities using Lucene.Net to dotNetRDF's query engine (.Net 4.0)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("dotNetRDF.Query.FullText")]
-[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2011-2012")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2011-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -48,16 +46,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("adcd96c4-cc89-4d91-91ae-43fa4f8049e4")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyFileVersion("1.0.13.0")]
 [assembly: InternalsVisibleTo("dotNetRDF.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d9118ebaf78c95309b80c81fe948290c8bd462fca5fc60d4f1a291bc32406feac610f9955f9bdb535f0a4b0609b06805f51b20a36703443546528f0fa27c1b63dce6133dec56f63d950ccfa059d7fe02270ee293da1a95228a15c414a89143962a03e3f48c1a42eaa09254403a1edd764980bc55bab37cf8908f1faadf4ae1b9")]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]

--- a/Libraries/dotNetRDF.Query.Spin/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Query.Spin/Properties/AssemblyInfo.cs
@@ -48,7 +48,6 @@ using System.Runtime.InteropServices;
 // Version information is managed by GitVersion
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("")]
 
 
 

--- a/Libraries/dotNetRDF.Query.Spin/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Query.Spin/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
@@ -25,7 +25,6 @@
 */
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -33,10 +32,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("dotNetRDF SPIN")]
 [assembly: AssemblyDescription("A library which provides a full SPIN implementation using dotNetRDF's Leviathan SPARQL engine")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("dotNetRDF.Query.SPIN")]
-[assembly: AssemblyCopyright("Copyright © Robert Vesse 2010")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2010-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -48,21 +45,10 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e2b905e0-5527-4bc8-8011-5413744bb1c6")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyVersion("1.0.13.0")]
-[assembly: AssemblyFileVersion("1.0.13.0")]
-
-//TODO: Remove once finished
-//[assembly: InternalsVisibleTo("spin-tests")]
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]
 
 
 
@@ -88,8 +74,4 @@ using System.Runtime.InteropServices;
 
 
 
-
-
-
-
-
+[assembly: AssemblyInformationalVersion("2.0.1+5.Branch.master.Sha.2b2692866fdc3f3bb5bc6f318ab2f93abcc1a689")]

--- a/Libraries/dotNetRDF.Web/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF.Web/Properties/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("dotNetRDF Web")]
+[assembly: AssemblyDescription("Provides a framework for building RDF-powered web applications and web APIs.")]
+[assembly: AssemblyProduct("dotNetRDF.Web")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2009-2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c29086c7-e9ed-433d-96d4-331b96c2481c")]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]

--- a/Libraries/dotNetRDF/Properties/AssemblyInfo.cs
+++ b/Libraries/dotNetRDF/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
@@ -31,12 +31,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("dotNetRDF.Core")]
+[assembly: AssemblyTitle("dotNetRDF Core")]
 [assembly: AssemblyDescription("API for manipulating RDF data")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Visual Design Studios")]
-[assembly: AssemblyProduct("dotNetRDF.Core")]
-[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2009-2017")]
+[assembly: AssemblyProduct("dotNetRDF")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2009-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -48,14 +47,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("39beeb2e-f86b-46ef-a4c1-c91d5f3fe432")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.13.0")]
 [assembly: InternalsVisibleTo("dotNetRDF.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d9118ebaf78c95309b80c81fe948290c8bd462fca5fc60d4f1a291bc32406feac610f9955f9bdb535f0a4b0609b06805f51b20a36703443546528f0fa27c1b63dce6133dec56f63d950ccfa059d7fe02270ee293da1a95228a15c414a89143962a03e3f48c1a42eaa09254403a1edd764980bc55bab37cf8908f1faadf4ae1b9")]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]

--- a/Testing/dotNetRDF.MockServerTests/Properties/AssemblyInfo.cs
+++ b/Testing/dotNetRDF.MockServerTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,51 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2018 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("dotNetRDF Mock Server Unit Tests")]
+[assembly: AssemblyProduct("dotNetRDF.MockServerTests")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2017-2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM componenets.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c5473f9e-3b55-4227-b131-307b96c5d0fa")]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]
+

--- a/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
+++ b/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
@@ -4,6 +4,15 @@
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Testing/sparqlDawgTests/Properties/AssemblyInfo.cs
+++ b/Testing/sparqlDawgTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 dotNetRDF is free and open source software licensed under the MIT License
 
 -----------------------------------------------------------------------------
@@ -56,8 +56,10 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
 
 
+
+[assembly: AssemblyInformationalVersion("2.0.1+5.Branch.master.Sha.2b2692866fdc3f3bb5bc6f318ab2f93abcc1a689")]

--- a/Testing/unittest/Properties/AssemblyInfo.cs
+++ b/Testing/unittest/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 dotNetRDF is free and open source software licensed under the MIT License
 
 -----------------------------------------------------------------------------
@@ -31,12 +31,9 @@ using Xunit;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("dotNetRDFUnitTests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
-[assembly: AssemblyProduct("dotNetRDFUnitTests")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2009")]
+[assembly: AssemblyTitle("dotNetRDF Unit Tests")]
+[assembly: AssemblyProduct("unittest")]
+[assembly: AssemblyCopyright("Copyright © dotNetRDF Project 2009-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -48,15 +45,10 @@ using Xunit;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c5473f9e-3b55-4227-b131-307b96c5d0fa")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, MaxParallelThreads =1)]
+
+// Version information is managed by GitVersion
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("")]
+


### PR DESCRIPTION
Updated all AssemblyInfo.cs files and added them to projects that did not already have them. The files in Git all have version 0.0.0.0 specified as default. GitVersion will update these properties with the correct values on the build server.
Addresses #159