### PR TITLE
Modify StripStringHandler to work with HandlerExtensions.Apply.

### DIFF
--- a/Libraries/dotNetRDF/Parsing/Handlers/StripStringHandler.cs
+++ b/Libraries/dotNetRDF/Parsing/Handlers/StripStringHandler.cs
@@ -51,7 +51,7 @@ namespace VDS.RDF.Parsing.Handlers
         /// </summary>
         protected override bool HandleTripleInternal(Triple t)
         {
-            if (t.Object is ILiteralNode literal && literal.DataType == DataTypeString)
+            if (t.Object is ILiteralNode literal && EqualityHelper.AreUrisEqual(literal.DataType, DataTypeString))
                 t = new Triple(t.Subject, t.Predicate, t.Graph.CreateLiteralNode(literal.Value));
 
             return _handler.HandleTriple(t);

--- a/Libraries/dotNetRDF/Parsing/Handlers/StripStringHandler.cs
+++ b/Libraries/dotNetRDF/Parsing/Handlers/StripStringHandler.cs
@@ -52,7 +52,7 @@ namespace VDS.RDF.Parsing.Handlers
         protected override bool HandleTripleInternal(Triple t)
         {
             if (t.Object is ILiteralNode literal && literal.DataType == DataTypeString)
-                t = new Triple(t.Subject, t.Predicate, CreateLiteralNode(literal.Value));
+                t = new Triple(t.Subject, t.Predicate, t.Graph.CreateLiteralNode(literal.Value));
 
             return _handler.HandleTriple(t);
         }

--- a/Testing/unittest/Parsing/Handlers/StripStringHandlerTests.cs
+++ b/Testing/unittest/Parsing/Handlers/StripStringHandlerTests.cs
@@ -59,6 +59,30 @@ namespace VDS.RDF.Parsing.Handlers
             Assert.False(diff.AreEqual, "Graphs should be different.");
         }
 
+        [Fact]
+        public void WorksWithApply()
+        {
+            var originalRDF = "<http://example.com/subject> <http://example.com/predicate> \"object\"^^<http://www.w3.org/2001/XMLSchema#string>.";
+            var referenceRDF = "<http://example.com/subject> <http://example.com/predicate> \"object\".";
+
+            using (var originalGraph = new Graph())
+            {
+                originalGraph.LoadFromString(originalRDF);
+
+                using (var resultGraph = new Graph())
+                {
+                    new StripStringHandler(new GraphHandler(resultGraph)).Apply(originalGraph);
+
+                    using (var referenceGraph = new Graph())
+                    {
+                        referenceGraph.LoadFromString(referenceRDF);
+
+                        Assert.True(resultGraph.Difference(referenceGraph).AreEqual, "Graphs should be equal.");
+                    }
+                }
+            }
+        }
+
         private static IGraph Load(string source)
         {
             var result = new Graph();

--- a/Testing/unittest/Parsing/Handlers/StripStringHandlerTests.cs
+++ b/Testing/unittest/Parsing/Handlers/StripStringHandlerTests.cs
@@ -83,6 +83,24 @@ namespace VDS.RDF.Parsing.Handlers
             }
         }
 
+        [Fact]
+        public void DoesntConfuseFragmentUris()
+        {
+            var originalRDF = "<http://example.com/subject> <http://example.com/predicate> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>.";
+
+            using (var originalGraph = new Graph())
+            {
+                originalGraph.LoadFromString(originalRDF);
+
+                using (var resultGraph = new Graph())
+                {
+                    new StripStringHandler(new GraphHandler(resultGraph)).Apply(originalGraph);
+
+                    Assert.True(resultGraph.Difference(originalGraph).AreEqual, "Graphs should be equal.");
+                }
+            }
+        }
+
         private static IGraph Load(string source)
         {
             var result = new Graph();


### PR DESCRIPTION
Subject, predicate and object for the Triple constructor must come from the same graph. This was not an issue when the handler was used from IRdfReader.Load, but it broke when I tried to to use it from HandlerExtensions.Apply (on another graph).

I've added a new test and a fix.