### PR TITLE
Fix for RDF namespace handling

### DIFF
--- a/Libraries/dotNetRDF/Parsing/Events/RdfXml/StreamingEventGenerator.cs
+++ b/Libraries/dotNetRDF/Parsing/Events/RdfXml/StreamingEventGenerator.cs
@@ -348,7 +348,7 @@ namespace VDS.RDF.Parsing.Events.RdfXml
                     else if (attr is ParseTypeAttributeEvent)
                     {
                         el.ParseType = ((ParseTypeAttributeEvent)attr).ParseType;
-                        el.Attributes.Add(new AttributeEvent(_reader.Name, _reader.Value, _reader.Value, GetPosition()));
+                        el.Attributes.Add(new AttributeEvent( _reader.LocalName, _reader.NamespaceURI, _reader.Value, _reader.Value, GetPosition()));
                     }
                     else if (attr is XmlBaseAttributeEvent)
                     {

--- a/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
@@ -644,7 +644,8 @@ namespace VDS.RDF.Parsing
                 ValidateID(context, ID, subj);
             }
 
-            if (!element.QName.Equals("rdf:Description") && !element.QName.Equals(":Description"))
+            //if (!element.QName.Equals("rdf:Description") && !element.QName.Equals(":Description"))
+            if (!ElementHasName(element, "Description", NamespaceMapper.RDF, context))
             {
                 // Assert a Triple regarding Type
                 pred = context.Handler.CreateUriNode(UriFactory.Create(RdfSpecsHelper.RdfType));
@@ -1960,6 +1961,12 @@ namespace VDS.RDF.Parsing
                 default:
                     return "RDF/XML (Streaming)";
             }
+        }
+        private static bool ElementHasName(ElementEvent el, string localName, string namespaceUri, RdfXmlParserContext context)
+        {
+            return el.LocalName.Equals(localName) && 
+                   context.Namespaces.HasNamespace(el.Namespace) && 
+                   context.Namespaces.GetNamespaceUri(el.Namespace).ToString().Equals(namespaceUri);
         }
     }
 }

--- a/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
@@ -657,7 +657,8 @@ namespace VDS.RDF.Parsing
             {
                 if (RdfXmlSpecsHelper.IsPropertyAttribute(attr))
                 {
-                    if (attr.QName.Equals("rdf:type"))
+                    if (attr.Namespace.Equals(NamespaceMapper.RDF) && attr.LocalName.Equals("type"))
+                    //if (attr.QName.Equals("rdf:type"))
                     {
                         // Generate a Type Triple
                         pred = context.Handler.CreateUriNode(UriFactory.Create(RdfSpecsHelper.RdfType));
@@ -789,7 +790,7 @@ namespace VDS.RDF.Parsing
             }
 
             // List Expansion
-            if (element.QName.Equals("rdf:li"))
+            if (element.Namespace.Equals(NamespaceMapper.RDF) && element.LocalName.Equals("li"))
             {
                 UriReferenceEvent u = ListExpand(parent);
                 element.SetUri(u);

--- a/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
@@ -1131,7 +1131,7 @@ namespace VDS.RDF.Parsing
                     {
                         ID = "#" + a.Value;
                     }
-                    else if (a.QName.Equals("rdf:parseType"))
+                    else if (a.Namespace.Equals(NamespaceMapper.RDF) && a.LocalName.Equals("parseType"))
                     {
                         // OK
                     }
@@ -1235,7 +1235,7 @@ namespace VDS.RDF.Parsing
                     {
                         ID = "#" + a.Value;
                     }
-                    else if (a.QName.Equals("rdf:parseType"))
+                    else if (a.Namespace.Equals(NamespaceMapper.RDF) && a.LocalName.Equals("parseType"))
                     {
                         // OK
                     }
@@ -1369,7 +1369,7 @@ namespace VDS.RDF.Parsing
                     {
                         ID = "#" + a.Value;
                     }
-                    else if (a.QName.Equals("rdf:parseType"))
+                    else if (a.Namespace.Equals(NamespaceMapper.RDF) && a.LocalName.Equals("parseType"))
                     {
                         // OK
                     }

--- a/Testing/unittest/Parsing/RdfXmlTests.cs
+++ b/Testing/unittest/Parsing/RdfXmlTests.cs
@@ -287,5 +287,31 @@ namespace VDS.RDF.Parsing
 
             Assert.True(diff12.AreEqual);
         }
+
+	    [Fact]
+	    public void ItHandlesRdfDescriptionRegardessOfNamespacePrefix()
+	    {
+	        var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property rdf:Resource='http://example.org/object'/></rdf:Description></rdf:RDF>";
+	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><foo:Description rdf:about='http://example.org/#us' xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><ex:property rdf:Resource='http://example.org/object' xmlns:ex='http://example.org/'/></foo:Description></rdf:RDF>";
+	        var rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><Description     rdf:about='http://example.org/#us' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><ex:property rdf:Resource='http://example.org/object'/></Description></rdf:RDF>";
+
+	        var parser = new RdfXmlParser();
+
+	        var graph1 = new Graph();
+	        graph1.LoadFromString(rdfXml1, parser);
+
+	        var graph2 = new Graph();
+	        graph2.LoadFromString(rdfXml2, parser);
+
+	        var graph3 = new Graph();
+	        graph3.LoadFromString(rdfXml3, parser);
+
+	        var diff12 = graph1.Difference(graph2);
+	        var diff13 = graph1.Difference(graph3);
+
+	        Assert.True(diff12.AreEqual);
+	        Assert.True(diff13.AreEqual);
+
+        }
     }
 }

--- a/Testing/unittest/Parsing/RdfXmlTests.cs
+++ b/Testing/unittest/Parsing/RdfXmlTests.cs
@@ -29,7 +29,6 @@ using System.Linq;
 using Xunit;
 using VDS.RDF.Parsing.Handlers;
 using VDS.RDF.Writing;
-using VDS.RDF.Writing.Formatting;
 
 namespace VDS.RDF.Parsing
 {
@@ -220,5 +219,54 @@ namespace VDS.RDF.Parsing
 	        Assert.True(diff.AreEqual);
         }
 
-	}
+	    [Fact]
+	    public void ItExpandsRdfListElementsRegardlessOfNamespacePrefix()
+	    {
+	        var rdfXml1 = "<RDF xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><Seq><li>bar</li></Seq></RDF>";
+	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><rdf:li>bar</rdf:li></rdf:Seq></rdf:RDF>";
+	        var rdfXml3 =
+	            "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><foo:li xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>bar</foo:li></rdf:Seq></rdf:RDF>";
+
+            var parser = new RdfXmlParser();
+	        var graph1 = new Graph();
+	        graph1.LoadFromString(rdfXml1, parser);
+
+	        var graph2 = new Graph();
+	        graph2.LoadFromString(rdfXml2, parser);
+
+	        var graph3 = new Graph();
+            graph3.LoadFromString(rdfXml3, parser);
+
+	        var diff12 = graph1.Difference(graph2);
+	        var diff13 = graph1.Difference(graph3);
+            
+            Assert.True(diff12.AreEqual);
+            Assert.True(diff13.AreEqual);
+        }
+
+        [Fact]
+	    public void ItHandlesRdfTypeAttributesRegardlessOfNamespacePrefix()
+	    {
+	        var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><rdf:type rdf:Resource='http://example.org/SomeType'/></eg:Example></rdf:RDF>";
+	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:type  rdf:Resource='http://example.org/SomeType' xmlns:eg='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/></eg:Example></rdf:RDF>";
+	        var rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><type     rdf:Resource='http://example.org/SomeType' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#' /></eg:Example></rdf:RDF>";
+
+            var parser = new RdfXmlParser();
+
+	        var graph1 = new Graph();
+	        graph1.LoadFromString(rdfXml1, parser);
+
+	        var graph2 = new Graph();
+	        graph2.LoadFromString(rdfXml2, parser);
+
+	        var graph3 = new Graph();
+            graph3.LoadFromString(rdfXml3, parser);
+
+	        var diff12 = graph1.Difference(graph2);
+	        var diff13 = graph1.Difference(graph3);
+
+	        Assert.True(diff12.AreEqual);
+	        Assert.True(diff13.AreEqual);
+        }
+    }
 }

--- a/Testing/unittest/Parsing/RdfXmlTests.cs
+++ b/Testing/unittest/Parsing/RdfXmlTests.cs
@@ -268,5 +268,24 @@ namespace VDS.RDF.Parsing
 	        Assert.True(diff12.AreEqual);
 	        Assert.True(diff13.AreEqual);
         }
+
+        [Fact]
+        public void ItHandlesRdfParseTypeRegardlessOfNamespacePrefix()
+        {
+            var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop rdf:parseType='Literal'/><eg:Value /></eg:Example></rdf:RDF>";
+            var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop  xx:parseType='Literal' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/><eg:Value /></eg:Example></rdf:RDF>";
+
+            var parser = new RdfXmlParser();
+
+            var graph1 = new Graph();
+            graph1.LoadFromString(rdfXml1, parser);
+
+            var graph2 = new Graph();
+            graph2.LoadFromString(rdfXml2, parser);
+
+            var diff12 = graph1.Difference(graph2);
+
+            Assert.True(diff12.AreEqual);
+        }
     }
 }


### PR DESCRIPTION
Fix that allows the RDF/XML parser to process attributes and elements from the rdf namespace regardless of the namespace prefix used.
Addresses #140