### PR TITLE
Ported changes to QueryBuilder from pull request #144

### DIFF
--- a/Libraries/dotNetRDF/Query/Builder/ExpressionBuilder.Aggregates.cs
+++ b/Libraries/dotNetRDF/Query/Builder/ExpressionBuilder.Aggregates.cs
@@ -52,6 +52,11 @@ namespace VDS.RDF.Query.Builder
             return Sum(new VariableTerm(variable));
         }
 
+        public AggregateExpression Sum(SparqlVariable variable)
+        {
+            return Sum(new VariableTerm(variable.Name));
+        }
+
         public AggregateExpression Sum(SparqlExpression expression)
         {
             var sumAggregate = new SumAggregate(expression.Expression, _distinctAggregate);
@@ -69,6 +74,11 @@ namespace VDS.RDF.Query.Builder
         public AggregateExpression Avg(string variable)
         {
             return Avg(new VariableTerm(variable));
+        }
+
+        public AggregateExpression Avg(SparqlVariable variable)
+        {
+            return Avg(new VariableTerm(variable.Name));
         }
 
         public AggregateExpression Avg(SparqlExpression expression)
@@ -90,6 +100,11 @@ namespace VDS.RDF.Query.Builder
             return Min(new VariableTerm(variable));
         }
 
+        public AggregateExpression Min(SparqlVariable variable)
+        {
+            return Min(new VariableTerm(variable.Name));
+        }
+
         public AggregateExpression Min(SparqlExpression expression)
         {
             var aggregate = new MinAggregate(expression.Expression, _distinctAggregate);
@@ -107,6 +122,11 @@ namespace VDS.RDF.Query.Builder
         public AggregateExpression Max(string variable)
         {
             return Max(new VariableTerm(variable));
+        }
+
+        public AggregateExpression Max(SparqlVariable variable)
+        {
+            return Max(new VariableTerm(variable.Name));
         }
 
         public AggregateExpression Max(SparqlExpression expression)
@@ -191,6 +211,11 @@ namespace VDS.RDF.Query.Builder
         public AggregateExpression Count(string variable)
         {
             return Count(new VariableTerm(variable));
+        }
+
+        public AggregateExpression Count(SparqlVariable variable)
+        {
+            return Count(new VariableTerm(variable.Name));
         }
 
         public AggregateExpression Count(SparqlExpression expression)

--- a/Libraries/dotNetRDF/Query/Builder/ExpressionBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/ExpressionBuilder.cs
@@ -98,6 +98,11 @@ namespace VDS.RDF.Query.Builder
             return new NumericExpression<DateTime>(value);
         }
 
+        public VariableExpression Variable(SparqlVariable variable)
+        {
+            return new VariableExpression(variable.Name);
+        }
+
         public RdfTermExpression Constant(Uri value)
         {
             return new RdfTermExpression(new ConstantTerm(new UriNode(null, value)));

--- a/Libraries/dotNetRDF/Query/Builder/GraphPatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/GraphPatternBuilder.cs
@@ -35,7 +35,7 @@ using VDS.RDF.Query.Patterns;
 
 namespace VDS.RDF.Query.Builder
 {
-    sealed class GraphPatternBuilder : IGraphPatternBuilder
+    public sealed class GraphPatternBuilder : IGraphPatternBuilder
     {
         private readonly IList<GraphPatternBuilder> _childGraphPatternBuilders = new List<GraphPatternBuilder>();
         private readonly IList<Func<INamespaceMapper, ISparqlExpression>> _filterBuilders = new List<Func<INamespaceMapper, ISparqlExpression>>();
@@ -46,7 +46,7 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Creates a builder of a normal graph patterns
         /// </summary>
-        internal GraphPatternBuilder()
+        public GraphPatternBuilder()
             : this(GraphPatternType.Normal)
         {
         }
@@ -55,7 +55,7 @@ namespace VDS.RDF.Query.Builder
         /// Creates a builder of a graph pattern
         /// </summary>
         /// <param name="graphPatternType">MINUS, GRAPH, SERVICE etc.</param>
-        private GraphPatternBuilder(GraphPatternType graphPatternType)
+        public GraphPatternBuilder(GraphPatternType graphPatternType)
         {
             _graphPatternType = graphPatternType;
         }
@@ -132,6 +132,26 @@ namespace VDS.RDF.Query.Builder
             return graphPattern;
         }
 
+        public IGraphPatternBuilder Group(GraphPatternBuilder groupBuilder)
+        {
+            if (!_childGraphPatternBuilders.Contains(groupBuilder))
+            {
+                _childGraphPatternBuilders.Add(groupBuilder);
+            }
+
+            return this;
+        }
+
+        public IGraphPatternBuilder Group(Action<IGraphPatternBuilder> buildGraphPattern)
+        {
+            GraphPatternBuilder groupBuilder = new GraphPatternBuilder();
+
+            buildGraphPattern(groupBuilder);
+
+            _childGraphPatternBuilders.Add(groupBuilder);
+            return this;
+        }
+
         public IGraphPatternBuilder Where(params ITriplePattern[] triplePatterns)
         {
             _triplePatterns.Add(prefixes => triplePatterns);
@@ -185,6 +205,26 @@ namespace VDS.RDF.Query.Builder
             return this;
         }
 
+        public IGraphPatternBuilder Union(GraphPatternBuilder firstGraphPattern, params GraphPatternBuilder[] unionedGraphPatternBuilders)
+        {
+            if (unionedGraphPatternBuilders == null || unionedGraphPatternBuilders.Length == 0)
+            {
+                return Child(firstGraphPattern);
+            }
+
+            var union = new GraphPatternBuilder(GraphPatternType.Union);
+            union.Child(firstGraphPattern);
+
+            foreach (var builder in unionedGraphPatternBuilders)
+            {
+                union.Child(builder);
+            }
+
+            _childGraphPatternBuilders.Add(union);
+
+            return this;
+        }
+
         public IGraphPatternBuilder Union(Action<IGraphPatternBuilder> firstGraphPattern, params Action<IGraphPatternBuilder>[] unionedGraphPatternBuilders)
         {
             if (unionedGraphPatternBuilders == null || unionedGraphPatternBuilders.Length == 0)
@@ -207,6 +247,23 @@ namespace VDS.RDF.Query.Builder
         public IAssignmentVariableNamePart<IGraphPatternBuilder> Bind(Func<INonAggregateExpressionBuilder, SparqlExpression> buildAssignmentExpression)
         {
             return new BindAssignmentVariableNamePart(this, buildAssignmentExpression);
+        }
+
+        public IGraphPatternBuilder Child(IQueryBuilder queryBuilder)
+        {
+            SparqlQuery subquery = queryBuilder.BuildQuery();
+
+            GraphPatternBuilder childBuilder = new GraphPatternBuilder();
+            childBuilder.Where(new SubQueryPattern(subquery));
+
+            _childGraphPatternBuilders.Add(childBuilder);
+            return this;
+        }
+
+        public IGraphPatternBuilder Child(GraphPatternBuilder childBuilder)
+        {
+            _childGraphPatternBuilders.Add(childBuilder);
+            return this;
         }
 
         public IGraphPatternBuilder Child(Action<IGraphPatternBuilder> buildGraphPattern)

--- a/Libraries/dotNetRDF/Query/Builder/GraphPatternType.cs
+++ b/Libraries/dotNetRDF/Query/Builder/GraphPatternType.cs
@@ -26,7 +26,7 @@
 
 namespace VDS.RDF.Query.Builder
 {
-    internal enum GraphPatternType
+    public enum GraphPatternType
     {
         Normal,
         Optional,

--- a/Libraries/dotNetRDF/Query/Builder/IDistinctAggregateBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IDistinctAggregateBuilder.cs
@@ -47,6 +47,11 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Creates a SUM aggregate
         /// </summary>
+        AggregateExpression Sum(SparqlVariable variable);
+
+        /// <summary>
+        /// Creates a SUM aggregate
+        /// </summary>
         AggregateExpression Sum(SparqlExpression expression);
 
         /// <summary>
@@ -58,6 +63,11 @@ namespace VDS.RDF.Query.Builder
         /// Creates a AVG aggregate
         /// </summary>
         AggregateExpression Avg(string variable);
+
+        /// <summary>
+        /// Creates a AVG aggregate
+        /// </summary>
+        AggregateExpression Avg(SparqlVariable variable);
 
         /// <summary>
         /// Creates a AVG aggregate
@@ -77,6 +87,11 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Creates a MIN aggregate
         /// </summary>
+        AggregateExpression Min(SparqlVariable variable);
+
+        /// <summary>
+        /// Creates a MIN aggregate
+        /// </summary>
         AggregateExpression Min(SparqlExpression expression);
 
         /// <summary>
@@ -88,6 +103,11 @@ namespace VDS.RDF.Query.Builder
         /// Creates a MAX aggregate
         /// </summary>
         AggregateExpression Max(string variable);
+
+        /// <summary>
+        /// Creates a MAX aggregate
+        /// </summary>
+        AggregateExpression Max(SparqlVariable variable);
 
         /// <summary>
         /// Creates a MAX aggregate
@@ -123,6 +143,11 @@ namespace VDS.RDF.Query.Builder
         /// Creates a COUNT aggregate
         /// </summary>
         AggregateExpression Count(string variable);
+
+        /// <summary>
+        /// Creates a COUNT aggregate
+        /// </summary>
+        AggregateExpression Count(SparqlVariable variable);
 
         /// <summary>
         /// Creates a COUNT aggregate

--- a/Libraries/dotNetRDF/Query/Builder/IGraphPatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IGraphPatternBuilder.cs
@@ -37,6 +37,19 @@ namespace VDS.RDF.Query.Builder
     public interface IGraphPatternBuilder
     {
         /// <summary>
+        /// Adds another child graph pattern builder.
+        /// </summary>
+        IGraphPatternBuilder Group(GraphPatternBuilder groupBuilder);
+        /// <summary>
+        /// Adds another child graph pattern builder.
+        /// </summary>
+        IGraphPatternBuilder Group(Action<IGraphPatternBuilder> buildTriplePatterns);
+        /// <summary>
+        /// Creates a UNION of multiple graph patterns. If <paramref name="unionedGraphPatternBuilders"/> is null or empty,
+        /// acts as a call to the <see cref="Child"/> method.
+        /// </summary>
+        IGraphPatternBuilder Union(GraphPatternBuilder firstGraphPattern, params GraphPatternBuilder[] unionedGraphPatternBuilders);
+        /// <summary>
         /// Creates a UNION of multiple graph patterns. If <paramref name="unionedGraphPatternBuilders"/> is null or empty,
         /// acts as a call to the <see cref="Child"/> method.
         /// </summary>
@@ -81,6 +94,14 @@ namespace VDS.RDF.Query.Builder
         /// Adds a BIND variable assignment to the graph pattern
         /// </summary>
         IAssignmentVariableNamePart<IGraphPatternBuilder> Bind(Func<INonAggregateExpressionBuilder, SparqlExpression> buildAssignmentExpression);
+        /// <summary>
+        /// Adds a "normal" child graph pattern
+        /// </summary>
+        IGraphPatternBuilder Child(IQueryBuilder queryBuilder);
+        /// <summary>
+        /// Adds a "normal" child graph pattern
+        /// </summary>
+        IGraphPatternBuilder Child(GraphPatternBuilder buildGraphPattern);
         /// <summary>
         /// Addsa "normal" child graph pattern
         /// </summary>

--- a/Libraries/dotNetRDF/Query/Builder/IQueryBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IQueryBuilder.cs
@@ -35,6 +35,14 @@ namespace VDS.RDF.Query.Builder
     public interface IQueryBuilder
     {
         /// <summary>
+        /// Gets the query type of the generated SPARQL query.
+        /// </summary>
+        SparqlQueryType QueryType { get; }
+        /// <summary>
+        /// Gets the builder associated with the root graph pattern.
+        /// </summary>
+        GraphPatternBuilder RootGraphPatternBuilder { get; }
+        /// <summary>
         /// Gets the prefix manager, which allows adding prefixes to the query or graph pattern
         /// </summary>
         INamespaceMapper Prefixes { get; set; }
@@ -54,7 +62,15 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Adds ascending ordering by a variable to the query
         /// </summary>
+        IQueryBuilder OrderBy(SparqlVariable variable);
+        /// <summary>
+        /// Adds ascending ordering by a variable to the query
+        /// </summary>
         IQueryBuilder OrderBy(string variableName);
+        /// <summary>
+        /// Adds descending ordering by a variable to the query
+        /// </summary>
+        IQueryBuilder OrderByDescending(SparqlVariable variable);
         /// <summary>
         /// Adds descending ordering by a variable to the query
         /// </summary>
@@ -67,6 +83,10 @@ namespace VDS.RDF.Query.Builder
         /// Adds descending ordering by an expression to the query
         /// </summary>
         IQueryBuilder OrderByDescending(Func<IExpressionBuilder, SparqlExpression> buildOrderExpression);
+        /// <summary>
+        /// Adds a GROUP BY clause to the query.
+        /// </summary>
+        IQueryBuilder GroupBy(SparqlVariable variable);
         /// <summary>
         /// Adds a GROUP BY clause to the query.
         /// </summary>

--- a/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilder.cs
@@ -37,6 +37,11 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Sets a variable as <see cref="IMatchTriplePattern.Subject"/>
         /// </summary>
+        TriplePatternPredicatePart Subject(SparqlVariable variable);
+
+        /// <summary>
+        /// Sets a variable as <see cref="IMatchTriplePattern.Subject"/>
+        /// </summary>
         TriplePatternPredicatePart Subject(string subjectVariableName);
         
         /// <summary>

--- a/Libraries/dotNetRDF/Query/Builder/QueryBuilderExtensions.cs
+++ b/Libraries/dotNetRDF/Query/Builder/QueryBuilderExtensions.cs
@@ -83,88 +83,115 @@ namespace VDS.RDF.Query.Builder
             return describeBuilder.GetQueryBuilder().Bind(buildAssignmentExpression);
         }
 
-        public static IQueryBuilder Child(this IDescribeBuilder describeBuilder, Action<IGraphPatternBuilder> buildGraphPattern)
-        {
-            return describeBuilder.GetQueryBuilder().Child(buildGraphPattern);
-        }
-
         /// <summary>
-        /// Builds a simple DESCRIBE query without the WHERE part
+        /// Build a simple DESCRIBE query without the WHERE part.
         /// </summary>
         public static SparqlQuery BuildQuery(this IDescribeBuilder describeBuilder)
         {
             return describeBuilder.GetQueryBuilder().BuildQuery();
         }
 
+        /// <summary>
+        /// Add a group graph pattern or a sub query to the query.
+        /// </summary>
+        /// <param name="childBuilder"></param>
+        public static IQueryBuilder Child(this IQueryBuilder queryBuilder, IQueryBuilder childBuilder)
+        {
+            if ((childBuilder.QueryType & SparqlQueryType.Select) == SparqlQueryType.Select)
+            {
+                queryBuilder.RootGraphPatternBuilder.Where(new SubQueryPattern(childBuilder.BuildQuery()));
+                return queryBuilder;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid query type: " + childBuilder.QueryType + "; only Select queries may be used as sub-queries.");
+            }
+        }
+
+        /// <summary>
+        /// Add a group graph pattern or a sub query to the query.
+        /// </summary>
+        /// <param name="buildGraphPattern"></param>
         public static IQueryBuilder Child(this IQueryBuilder queryBuilder, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Child(buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Child(buildGraphPattern);
             return queryBuilder;
+        }
+
+        public static IQueryBuilder Child(this IDescribeBuilder describeBuilder, Action<IGraphPatternBuilder> buildGraphPattern)
+        {
+            return describeBuilder.GetQueryBuilder().Child(buildGraphPattern);
         }
 
         public static IQueryBuilder Where(this IQueryBuilder queryBuilder, params ITriplePattern[] triplePatterns)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Where(triplePatterns);
+            queryBuilder.RootGraphPatternBuilder.Where(triplePatterns);
             return queryBuilder;
         }
 
         public static IQueryBuilder Where(this IQueryBuilder queryBuilder, Action<ITriplePatternBuilder> buildTriplePatterns)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Where(buildTriplePatterns);
+            queryBuilder.RootGraphPatternBuilder.Where(buildTriplePatterns);
             return queryBuilder;
         }
 
         internal static IQueryBuilder Where(this IQueryBuilder queryBuilder, Func<INamespaceMapper, ITriplePattern[]> buildTriplePatternFunc)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Where(buildTriplePatternFunc);
+            queryBuilder.RootGraphPatternBuilder.Where(buildTriplePatternFunc);
             return queryBuilder;
         }
 
         public static IQueryBuilder Optional(this IQueryBuilder queryBuilder, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Optional(buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Optional(buildGraphPattern);
             return queryBuilder;
         }
 
         public static IQueryBuilder Filter(this IQueryBuilder queryBuilder, ISparqlExpression expr)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Filter(expr);
+            queryBuilder.RootGraphPatternBuilder.Filter(expr);
             return queryBuilder;
         }
 
         public static IQueryBuilder Minus(this IQueryBuilder queryBuilder, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Minus(buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Minus(buildGraphPattern);
             return queryBuilder;
         }
 
         public static IQueryBuilder Graph(this IQueryBuilder queryBuilder, Uri graphUri, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Graph(graphUri, buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Graph(graphUri, buildGraphPattern);
             return queryBuilder;
         }
 
         public static IQueryBuilder Graph(this IQueryBuilder queryBuilder, string graphVariable, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Graph(graphVariable, buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Graph(graphVariable, buildGraphPattern);
             return queryBuilder;
         }
 
         public static IQueryBuilder Service(this IQueryBuilder queryBuilder, Uri serviceUri, Action<IGraphPatternBuilder> buildGraphPattern)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Service(serviceUri, buildGraphPattern);
+            queryBuilder.RootGraphPatternBuilder.Service(serviceUri, buildGraphPattern);
             return queryBuilder;
         }
 
         public static IQueryBuilder Filter(this IQueryBuilder queryBuilder, Func<INonAggregateExpressionBuilder, BooleanExpression> buildExpression)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Filter(buildExpression);
+            queryBuilder.RootGraphPatternBuilder.Filter(buildExpression);
             return queryBuilder;
         }
 
         public static IQueryBuilder Union(this IQueryBuilder queryBuilder, Action<IGraphPatternBuilder> firstGraphPattern, params Action<IGraphPatternBuilder>[] otherGraphPatterns)
         {
-            ((QueryBuilder)queryBuilder).RootGraphPatternBuilder.Union(firstGraphPattern, otherGraphPatterns);
+            queryBuilder.RootGraphPatternBuilder.Union(firstGraphPattern, otherGraphPatterns);
+            return queryBuilder;
+        }
+
+        public static IQueryBuilder Union(this IQueryBuilder queryBuilder, GraphPatternBuilder firstGraphPattern, params GraphPatternBuilder[] otherGraphPatterns)
+        {
+            queryBuilder.RootGraphPatternBuilder.Union(firstGraphPattern, otherGraphPatterns);
             return queryBuilder;
         }
     }

--- a/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
@@ -31,7 +31,7 @@ using VDS.RDF.Query.Patterns;
 
 namespace VDS.RDF.Query.Builder
 {
-    internal class TriplePatternBuilder : ITriplePatternBuilder
+    public class TriplePatternBuilder : ITriplePatternBuilder
     {
         private readonly IList<ITriplePattern> _patterns = new List<ITriplePattern>();
         private readonly PatternItemFactory _patternItemFactory;
@@ -41,6 +41,11 @@ namespace VDS.RDF.Query.Builder
         {
             _prefixes = prefixes;
             _patternItemFactory = new PatternItemFactory();
+        }
+
+        public TriplePatternPredicatePart Subject(SparqlVariable subjectVariable)
+        {
+            return Subject(PatternItemFactory.CreateVariablePattern(subjectVariable.Name));
         }
 
         public TriplePatternPredicatePart Subject(string subjectVariableName)
@@ -73,7 +78,7 @@ namespace VDS.RDF.Query.Builder
             get { return _patterns.ToArray(); }
         }
 
-        public PatternItemFactory PatternItemFactory
+        internal PatternItemFactory PatternItemFactory
         {
             get { return _patternItemFactory; }
         }

--- a/Libraries/dotNetRDF/Query/Builder/TriplePatternObjectPart.cs
+++ b/Libraries/dotNetRDF/Query/Builder/TriplePatternObjectPart.cs
@@ -50,6 +50,15 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Sets a SPARQL variable as <see cref="IMatchTriplePattern.Object"/>
         /// </summary>
+        public ITriplePatternBuilder Object(SparqlVariable variable)
+        {
+            var objectPattern = _triplePatternBuilder.PatternItemFactory.CreateVariablePattern(variable.Name);
+            return Object(objectPattern);
+        }
+
+        /// <summary>
+        /// Sets a SPARQL variable as <see cref="IMatchTriplePattern.Object"/>
+        /// </summary>
         public ITriplePatternBuilder Object(string variableName)
         {
             var objectPattern = _triplePatternBuilder.PatternItemFactory.CreateVariablePattern(variableName);

--- a/Libraries/dotNetRDF/Query/Builder/TriplePatternPredicatePart.cs
+++ b/Libraries/dotNetRDF/Query/Builder/TriplePatternPredicatePart.cs
@@ -48,6 +48,15 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Sets a SPARQL variable as <see cref="IMatchTriplePattern.Predicate"/>
         /// </summary>
+        public TriplePatternObjectPart Predicate(SparqlVariable variable)
+        {
+            var predicate = _triplePatternBuilder.PatternItemFactory.CreateVariablePattern(variable.Name);
+            return CreateTriplePatternObjectPart(predicate);
+        }
+
+        /// <summary>
+        /// Sets a SPARQL variable as <see cref="IMatchTriplePattern.Predicate"/>
+        /// </summary>
         public TriplePatternObjectPart Predicate(string variableName)
         {
             var predicate = _triplePatternBuilder.PatternItemFactory.CreateVariablePattern(variableName);


### PR DESCRIPTION
There are changes in the maintenance-1.x branch which I have pored to the current master branch. Specifically I added support for generating sub-queries using the QueryBuilder and added support for supplying own TripleBuilders in addition to the fluent style API.

The changes have been ported without the support for .NET 3.5, which was included in #144.