### PR TITLE
GraphVizWriter should collapse literals by default

### DIFF
--- a/Libraries/dotNetRDF/Writing/GraphVizWriter.cs
+++ b/Libraries/dotNetRDF/Writing/GraphVizWriter.cs
@@ -43,7 +43,7 @@ namespace VDS.RDF.Writing
         /// <summary>
         /// Gets/Sets whether to collapse distinct literal nodes
         /// </summary>
-        public bool CollapseLiterals { get; set; } = false;
+        public bool CollapseLiterals { get; set; } = true;
 
         /// <summary>
         /// Saves a Graph into GraphViz DOT Format


### PR DESCRIPTION
I'm afraid we ended up introducing a breaking change after all. This is a fix.