### PR TITLE
Further fixes for namespace handling in the RDF/XML parser

### DIFF
--- a/Libraries/dotNetRDF/Parsing/Events/RdfXml/DomBasedEventGenerator.cs
+++ b/Libraries/dotNetRDF/Parsing/Events/RdfXml/DomBasedEventGenerator.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using VDS.RDF.Parsing.Contexts;
 
@@ -303,7 +304,7 @@ namespace VDS.RDF.Parsing.Events.RdfXml
                 {
                     // Ignore other Reserved XML Names
                 }
-                else if (attr.Name == "rdf:parseType" && attr.Value == "Literal")
+                else if (RdfXmlSpecsHelper.IsRdfNamespace(attr.NamespaceURI) && attr.LocalName == "parseType" && attr.Value == "Literal")
                 {
                     // Literal Parse Type
                     parseTypeLiteral = true;
@@ -315,7 +316,7 @@ namespace VDS.RDF.Parsing.Events.RdfXml
                     // Set ParseType property correctly
                     element.ParseType = RdfXmlParseType.Literal;
                 }
-                else if (attr.Name == "rdf:parseType")
+                else if (RdfXmlSpecsHelper.IsRdfNamespace(attr.NamespaceURI) && attr.LocalName == "parseType")
                 {
                     // Some other Parse Type
 
@@ -355,12 +356,12 @@ namespace VDS.RDF.Parsing.Events.RdfXml
             foreach (AttributeEvent a in element.Attributes)
             {
                 // Namespace Confusion should only apply to Attributes without a Namespace specified
-                if (a.Namespace.Equals(String.Empty))
+                if (a.Namespace.Equals(string.Empty) && element.NamespaceAttributes.All(na => na.Prefix != string.Empty) && !context.Namespaces.HasNamespace(string.Empty))
                 {
                     if (RdfXmlSpecsHelper.IsAmbigiousAttributeName(a.LocalName))
                     {
                         // Can't use any of the RDF terms that mandate the rdf: prefix without it
-                        throw ParserHelper.Error("An Attribute with an ambigious name '" + a.LocalName + "' was encountered.  The following attribute names MUST have the rdf: prefix - about, aboutEach, ID, bagID, type, resource, parseType", element);
+                        throw ParserHelper.Error("An Attribute with an ambiguous name '" + a.LocalName + "' was encountered.  The following attribute names MUST have the rdf: prefix - about, aboutEach, ID, bagID, type, resource, parseType", element);
                     }
                 }
 

--- a/Libraries/dotNetRDF/Parsing/Events/RdfXml/XMLEvents.cs
+++ b/Libraries/dotNetRDF/Parsing/Events/RdfXml/XMLEvents.cs
@@ -413,6 +413,28 @@ namespace VDS.RDF.Parsing.Events.RdfXml
         }
 
         /// <summary>
+        /// Method which sets the Uri for this Element Event
+        /// </summary>
+        /// <param name="u">Uri Reference to set Uri from</param>
+        /// <param name="nsMapper">Namespace prefix mappings to use for resolving the QName of this element event</param>
+        /// <remarks>This can only be used on Elements which are rdf:li and thus need expanding into actual list elements according to List Expansion rules.  Attempting to set the Uri on any other Element Event will cause an Error message.</remarks>
+        public void SetUri(UriReferenceEvent u, INamespaceMapper nsMapper)
+        {
+            if (RdfXmlSpecsHelper.IsLiElement(this, nsMapper))
+            {
+                // Split the QName into Namespace and Local Name
+                String qname = u.Identifier;
+                String[] parts = qname.Split(':');
+                _namespace = parts[0];
+                _localname = parts[1];
+            }
+            else
+            {
+                throw new RdfParseException("It is forbidden to change the URI of an Element Event unless it is a rdf:li Element and thus needs expanding to the form rdf:_X according to List Expansion rules");
+            }
+        }
+
+        /// <summary>
         /// Gets the String representation of the Event
         /// </summary>
         /// <returns></returns>

--- a/Libraries/dotNetRDF/Parsing/RdfXmlSpecsHelper.cs
+++ b/Libraries/dotNetRDF/Parsing/RdfXmlSpecsHelper.cs
@@ -28,6 +28,7 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using VDS.RDF.Parsing.Events.RdfXml;
+// ReSharper disable InconsistentNaming
 
 namespace VDS.RDF.Parsing
 {
@@ -55,25 +56,45 @@ namespace VDS.RDF.Parsing
         /// <summary>
         /// Array containing the Core Syntax Terms
         /// </summary>
-        private static String[] coreSyntaxTerms = { "rdf:RDF", "rdf:ID", "rdf:about", "rdf:parseType", "rdf:resource", "rdf:nodeID", "rdf:datatype" };
+        private static string[] coreSyntaxTerms = { "rdf:RDF", "rdf:ID", "rdf:about", "rdf:parseType", "rdf:resource", "rdf:nodeID", "rdf:datatype" };
+
+        /// <summary>
+        /// The local name part of core syntax terms
+        /// </summary>
+        private static readonly string[] CoreSyntaxLocalNames = { "RDF", "ID", "about", "parseType", "resource", "nodeID", "datatype" };
+
         /// <summary>
         /// Array containing the other Syntax Terms
         /// </summary>
-        private static String[] syntaxTerms = { "rdf:Description", "rdf:li" };
+        private static string[] syntaxTerms = { "rdf:Description", "rdf:li" };
+
+        /// <summary>
+        /// The local name part of all syntax terms
+        /// </summary>
+        private static readonly string[] SyntaxLocalNames =
+            {"RDF", "ID", "about", "parseType", "resource", "nodeID", "datatype", "Description", "li"};
+
         /// <summary>
         /// Array containing the Old Syntax Terms
         /// </summary>
-        private static String[] oldTerms = { "rdf:aboutEach", "rdf:aboutEachPrefix", "rdf:bagID" };
+        private static string[] oldTerms = { "rdf:aboutEach", "rdf:aboutEachPrefix", "rdf:bagID" };
+
+        /// <summary>
+        /// The local name part of old syntax terms
+        /// </summary>
+        private static readonly string[] OldLocalNames = {"aboutEach", "aboutEachPrefix", "bagID"};
+
         /// <summary>
         /// Array containing Syntax Terms where the rdf: Prefix is mandated
         /// </summary>
-        private static String[] requiresRdfPrefix = { "about", "aboutEach", "ID", "bagID", "type", "resource", "parseType" };
+        private static string[] requiresRdfPrefix = { "about", "aboutEach", "ID", "bagID", "type", "resource", "parseType" };
 
         /// <summary>
         /// Checks whether a given QName is a Core Syntax Term
         /// </summary>
         /// <param name="qname">QName to Test</param>
         /// <returns>True if the QName is a Core Syntax Term</returns>
+        [Obsolete("Use IsCoreSyntaxTerm(Uri, string) instead")]
         public static bool IsCoreSyntaxTerm(String qname)
         {
             // Does the QName occur in the array of Core Syntax Terms?
@@ -81,10 +102,22 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether a given expanded name is a Core Syntax Term
+        /// </summary>
+        /// <param name="nsUri">The namespace URI of the expanded name</param>
+        /// <param name="localName">The local name part of the expanded name</param>
+        /// <returns>True if the expanded name is a Core Syntax Term</returns>
+        public static bool IsCoreSyntaxTerm(Uri nsUri, string localName)
+        {
+            return nsUri.ToString().Equals(NamespaceMapper.RDF) && CoreSyntaxLocalNames.Contains(localName);
+        }
+
+        /// <summary>
         /// Checks whether a given QName is a Syntax Term
         /// </summary>
         /// <param name="qname">QName to Test</param>
         /// <returns>True if the QName is a Syntax Term</returns>
+        [Obsolete("Use IsSyntaxTerm(Uri, string) instead")]
         public static bool IsSyntaxTerm(String qname)
         {
             // Does the QName occur as a Core Syntax Term or in the Array of Syntax Terms?
@@ -92,10 +125,22 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether a given expanded name is a Syntax Term
+        /// </summary>
+        /// <param name="nsUri">The namespace URI of the expanded name</param>
+        /// <param name="localName">The local name part of the expanded name</param>
+        /// <returns>True if the expanded name is a Syntax Term</returns>
+        public static bool IsSyntaxTerm(Uri nsUri, string localName)
+        {
+            return nsUri.ToString().Equals(NamespaceMapper.RDF) && SyntaxLocalNames.Contains(localName);
+        }
+
+        /// <summary>
         /// Checks whether a given QName is a Old Syntax Term
         /// </summary>
         /// <param name="qname">QName to Test</param>
         /// <returns>True if the QName is a Old Syntax Term</returns>
+        [Obsolete("Use IsOldTerm(Uri, string) instead")]
         public static bool IsOldTerm(String qname)
         {
             // Does the QName occur in the array of Old Syntax Terms?
@@ -103,10 +148,23 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether a given expanded name is a Old Syntax Term
+        /// </summary>
+        /// <param name="nsUri">The namespace URI of the expanded name</param>
+        /// <param name="localName">The local name part of the expanded name</param>
+        /// <returns>True if the expanded name is a Old Syntax Term</returns>
+        public static bool IsOldTerm(Uri nsUri, string localName)
+        {
+            // Does the QName occur in the array of Old Syntax Terms?
+            return nsUri.ToString().Equals(NamespaceMapper.RDF) && OldLocalNames.Contains(localName);
+        }
+
+        /// <summary>
         /// Checks whether a given QName is valid as a Node Element Uri
         /// </summary>
         /// <param name="qname">QName to Test</param>
         /// <returns>True if the QName is valid</returns>
+        [Obsolete("Use IsNodeElementUri(Uri, localName) instead")]
         public static bool IsNodeElementUri(String qname)
         {
             // Not allowed to be a Core Syntax Term, rdf:li or an Old Syntax Term
@@ -122,11 +180,34 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether a given expanded name is valid as a Node Element Uri
+        /// </summary>
+        /// <param name="nsUri">The namespace URI of the expanded name</param>
+        /// <param name="localName">The local name part of the expanded name</param>
+        /// <returns>True if the expanded name is valid</returns>
+        public static bool IsNodeElementUri(Uri nsUri, string localName)
+        {
+            // Not allowed to be a Core Syntax Term, rdf:li or an Old Syntax Term
+            if (IsCoreSyntaxTerm(nsUri, localName) || 
+                IsOldTerm(nsUri, localName) || 
+                nsUri.ToString().Equals(NamespaceMapper.RDF) && localName.Equals("li"))
+            {
+                return false;
+            }
+            else
+            {
+                // Any other URIs are allowed
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Checks whether a given QName is valid as a Property Element Uri
         /// </summary>
         /// <param name="qname">QName to Test</param>
         /// <returns>True if the QName is valid</returns>
-        public static bool IsPropertyElementURI(String qname)
+        [Obsolete("Use IsPropertyElement(ElementEvent, INamespaceMapper) instead")]
+        public static bool IsPropertyElementURI(string qname)
         {
             // Not allowed to be a Core Syntax Term, rdf:Description or an Old Syntax Term
             if (IsCoreSyntaxTerm(qname) || qname.Equals("rdf:Description") || IsOldTerm(qname))
@@ -138,6 +219,42 @@ namespace VDS.RDF.Parsing
                 // Any other URIs are allowed
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Checks whether a given element is a valid property element
+        /// </summary>
+        /// <param name="e">The element to test</param>
+        /// <param name="nsMapper">The namespace mappings to use when expanding element QName prefixes</param>
+        /// <returns>True if the element is valid</returns>
+        public static bool IsPropertyElement(ElementEvent e, INamespaceMapper nsMapper)
+        {
+            if (nsMapper.HasNamespace(e.Namespace))
+            {
+                var nsUri = nsMapper.GetNamespaceUri(e.Namespace);
+                // Not allowed to be a Core Syntax Term, rdf:Description or an Old Syntax Term
+                if (IsCoreSyntaxTerm(nsUri, e.LocalName) ||
+                    IsOldTerm(nsUri, e.LocalName) ||
+                    nsUri.ToString().Equals(NamespaceMapper.RDF) && e.LocalName.Equals("Description"))
+                {
+                    return false;
+                }
+            }
+            // Any other URIs are allowed
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether a give element is an rdf:li element
+        /// </summary>
+        /// <param name="e">The element to test</param>
+        /// <param name="nsMapper">The namespace mappings to use when expanding element QName prefixes</param>
+        /// <returns>True if the element is an rdf:li element, false otherwise</returns>
+        public static bool IsLiElement(ElementEvent e, INamespaceMapper nsMapper)
+        {
+            return nsMapper.HasNamespace(e.Namespace) &&
+                   IsRdfNamespace(nsMapper.GetNamespaceUri(e.Namespace)) &&
+                   e.LocalName.Equals("li");
         }
 
         /// <summary>
@@ -160,15 +277,36 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
-        /// Checks whether a given Local Name is potentially ambigious
+        /// Checks whether a given expanded name is valid as a Property Attribute Uri
+        /// </summary>
+        /// <param name="nsUri">The namespace URI of the expanded name</param>
+        /// <param name="localName">The local name part of the expanded name</param>
+        /// <returns>True if the expanded name is valid</returns>
+        public static bool IsPropertyAttributeURI(Uri nsUri, string localName)
+        {
+            // Not allowed to be a Core Syntax Term, rdf:li, rdf:Description or an Old Syntax Term
+            if (IsSyntaxTerm(nsUri, localName) || IsOldTerm(nsUri, localName))
+            {
+                return false;
+            }
+            else
+            {
+                // Any other URIs are allowed
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether a given Local Name is potentially ambiguous
         /// </summary>
         /// <param name="name">Local Name to Test</param>
-        /// <returns>True if the Local Name is ambigious</returns>
+        /// <returns>True if the Local Name is ambiguous</returns>
         /// <remarks>This embodies Local Names which must have an rdf prefix</remarks>
         public static bool IsAmbigiousAttributeName(String name)
         {
             return requiresRdfPrefix.Contains(name);
         }
+
 
         /// <summary>
         /// Checks whether a given URIRef is encoded in Unicode Normal Form C
@@ -234,6 +372,7 @@ namespace VDS.RDF.Parsing
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an rdf:ID attribute</returns>
         /// <remarks>Does some validation on ID value but other validation occurs at other points in the Parsing</remarks>
+        [Obsolete("Use IsIDAttribute(AttributeEvent, INamespaceMapper) instead")]
         public static bool IsIDAttribute(AttributeEvent attr)
         {
             // QName must be rdf:id
@@ -258,11 +397,57 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether an attribute is an rdf:ID attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:ID attribute</returns>
+        /// <remarks>Does some validation on ID value but other validation occurs at other points in the Parsing</remarks>
+        public static bool IsIDAttribute(AttributeEvent attr, INestedNamespaceMapper nsMapper)
+        {
+            // QName must be rdf:id
+            if (nsMapper.HasNamespace(attr.Namespace) && 
+                nsMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) && 
+                attr.LocalName.Equals("ID"))
+            {
+                // Must be a valid RDF ID
+                if (IsRdfID(attr.Value))
+                {
+                    // OK
+                    return true;
+                }
+                else
+                {
+                    // Invalid RDF ID so Error
+                    throw ParserHelper.Error("The value '" + attr.Value + "' for rdf:ID is not valid, RDF IDs can only be valid NCNames as defined by the W3C XML Namespaces specification", attr);
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether an attribute is an rdf:type attribute
+        /// </summary>
+        /// <param name="attr">The attribute to check</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use to expand QNames</param>
+        /// <returns>True if the attribute is and rdf:type attribute, false otherwise</returns>
+        public static bool IsTypeAttribute(AttributeEvent attr, INamespaceMapper nsMapper)
+        {
+            return nsMapper.HasNamespace(attr.Namespace) && 
+                   IsRdfNamespace(nsMapper.GetNamespaceUri(attr.Namespace)) &&
+                   attr.LocalName.Equals("type");
+        }
+
+        /// <summary>
         /// Checks whether an attribute is an rdf:nodeID attribute
         /// </summary>
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an rdf:nodeID attribute</returns>
         /// <remarks>Does some validation on ID value but other validation occurs at other points in the Parsing</remarks>
+        [Obsolete("Use IsNodeIDAttribute(AttributeEvent, INamespaceMapper) instead")]
         public static bool IsNodeIDAttribute(AttributeEvent attr)
         {
             // QName must be rdf:nodeID
@@ -287,10 +472,41 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether an attribute is an rdf:nodeID attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:nodeID attribute</returns>
+        /// <remarks>Does some validation on ID value but other validation occurs at other points in the Parsing</remarks>
+        public static bool IsNodeIDAttribute(AttributeEvent attr, INamespaceMapper nsMapper)
+        {
+            // QName must be rdf:nodeID
+            if (nsMapper.HasNamespace(attr.Namespace) && nsMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) && attr.LocalName.Equals("nodeID"))
+            {
+                // Must be a valid RDF ID
+                if (IsRdfID(attr.Value))
+                {
+                    // OK
+                    return true;
+                }
+                else
+                {
+                    // Invalid RDF ID so Error
+                    throw ParserHelper.Error("The value '" + attr.Value + "' for rdf:id is not valid, RDF IDs can only be valid NCNames as defined by the W3C XML Namespaces specification", attr);
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Checks whether an attribute is an rdf:about attribute
         /// </summary>
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an rdf:about attribute</returns>
+        [Obsolete("Use IsAboutAttribute(AttributeEvent, INamespaceMapper)")]
         public static bool IsAboutAttribute(AttributeEvent attr)
         {
             // QName must be rdf:id
@@ -306,10 +522,46 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether an attribute is an rdf:about attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:about attribute</returns>
+        public static bool IsAboutAttribute(AttributeEvent attr, INamespaceMapper nsMapper)
+        {
+            // QName must be rdf:id
+            if (nsMapper.HasNamespace(attr.Namespace) && 
+                nsMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) && 
+                attr.LocalName.Equals("about"))
+            {
+                // Must be a valid RDF Uri Reference
+                return IsRdfUriReference(attr.Value);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether an attribute is an rdf:parseType attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:parseType attribute</returns>
+        public static bool IsParseTypeAttribute(AttributeEvent attr, INestedNamespaceMapper nsMapper)
+        {
+            return nsMapper.HasNamespace(attr.Namespace) &&
+                   nsMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) &&
+                   attr.LocalName.Equals("parseType");
+        }
+
+        /// <summary>
         /// Checks whether an attribute is an property attribute
         /// </summary>
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an property attribute</returns>
+        [Obsolete("Use IsPropertyAttribute(AttributeEvent, INamespaceMapper)")]
         public static bool IsPropertyAttribute(AttributeEvent attr)
         {
             // QName must be a valid Property Attribute Uri
@@ -318,10 +570,25 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether an attribute is an property attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an property attribute</returns>
+        public static bool IsPropertyAttribute(AttributeEvent attr, INamespaceMapper nsMapper)
+        {
+            // QName must be a valid Property Attribute Uri
+            // Any string value allowed so if Uri test is true then we're a property Attribute
+            return nsMapper.HasNamespace(attr.Namespace) &&
+                   IsPropertyAttributeURI(nsMapper.GetNamespaceUri(attr.Namespace), attr.LocalName);
+        }
+
+        /// <summary>
         /// Checks whether an attribute is an rdf:resource attribute
         /// </summary>
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an rdf:resource attribute</returns>
+        [Obsolete("Use IsResourceAttribute(AttributeEvent, INamespaceMapper)")]
         public static bool IsResourceAttribute(AttributeEvent attr)
         {
             // QName must be rdf:resource
@@ -337,14 +604,57 @@ namespace VDS.RDF.Parsing
         }
 
         /// <summary>
+        /// Checks whether an attribute is an rdf:resource attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="nsMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:resource attribute</returns>
+        public static bool IsResourceAttribute(AttributeEvent attr, INamespaceMapper nsMapper)
+        {
+            // QName must be rdf:resource
+            if (nsMapper.HasNamespace(attr.Namespace) &&
+                nsMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) &&
+                attr.LocalName.Equals("resource"))
+            {
+                // Must be a valid RDF Uri Reference
+                return IsRdfUriReference(attr.Value);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Checks whether an attribute is an rdf:datatype attribute
         /// </summary>
         /// <param name="attr">Attribute to Test</param>
         /// <returns>True if is an rdf:datatype attribute</returns>
+        [Obsolete("Use IsDataTypeAttribute(AttributeEvent, INestedNamespaceMapper) instead.")]
         public static bool IsDataTypeAttribute(AttributeEvent attr)
         {
             // QName must be rdf:datatype
             if (attr.QName.Equals("rdf:datatype"))
+            {
+                // Must be a valid RDF Uri Reference
+                return IsRdfUriReference(attr.Value);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks whether an attribute is an rdf:datatype attribute
+        /// </summary>
+        /// <param name="attr">Attribute to Test</param>
+        /// <param name="namespaceMapper">The namespace prefix mappings to use when expanding the namespace prefix of the attribute</param>
+        /// <returns>True if is an rdf:datatype attribute</returns>
+        public static bool IsDataTypeAttribute(AttributeEvent attr, INestedNamespaceMapper namespaceMapper)
+        {
+            // QName must be rdf:datatype
+            if (namespaceMapper.HasNamespace(attr.Namespace) && namespaceMapper.GetNamespaceUri(attr.Namespace).ToString().Equals(NamespaceMapper.RDF) && attr.LocalName.Equals("datatype"))
             {
                 // Must be a valid RDF Uri Reference
                 return IsRdfUriReference(attr.Value);
@@ -390,6 +700,26 @@ namespace VDS.RDF.Parsing
             return true;
         }
 
+        /// <summary>
+        /// Validates that a URI matches the RDF/XML namespace URI
+        /// </summary>
+        /// <param name="nsUri">The namespace URI to be validated</param>
+        /// <returns>True if the URI matches the RDF/XML namespace URI</returns>
+        public static bool IsRdfNamespace(Uri nsUri)
+        {
+            return nsUri != null && nsUri.ToString().Equals(NamespaceMapper.RDF);
+        }
+
+        /// <summary>
+        /// Validates that a URI matches the RDF/XML namespace URI
+        /// </summary>
+        /// <param name="nsUri">The namespace URI to be validated</param>
+        /// <returns>True if the URI matches the RDF/XML namespace URI</returns>
+        public static bool IsRdfNamespace(string nsUri)
+        {
+            return nsUri != null && nsUri.Equals(NamespaceMapper.RDF);
+        }
         #endregion
+
     }
 }

--- a/Testing/unittest/JsonLd/JsonLdParserTests.cs
+++ b/Testing/unittest/JsonLd/JsonLdParserTests.cs
@@ -42,7 +42,7 @@ namespace VDS.RDF.JsonLd
                     x.Subject.As<IUriNode>().Uri.ToString().Equals("http://dbpedia.org/resource/John_Lennon") &&
                     x.Predicate.As<IUriNode>().Uri.ToString().Equals("http://schema.org/birthDate") &&
                     x.Object.As<ILiteralNode>().Value.Equals("1940-10-09") &&
-                    x.Object.As<ILiteralNode>().DataType.ToString().Equals("http://www.w3.org/2001/XMLSchema#dateTime"));
+                    x.Object.As<ILiteralNode>().DataType.ToString().Equals("http://www.w3.org/2001/XMLSchema#date"));
             Assert.Contains(tStore.Triples, x =>
                     x.Subject.As<IUriNode>().Uri.ToString().Equals("http://dbpedia.org/resource/John_Lennon") &&
                     x.Predicate.As<IUriNode>().Uri.ToString().Equals("http://schema.org/spouse") &&

--- a/Testing/unittest/Parsing/Handlers/GraphHandlerTests.NetFull.cs
+++ b/Testing/unittest/Parsing/Handlers/GraphHandlerTests.NetFull.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF.Parsing.Handlers
 {
     public partial class GraphHandlerTests
     {
-        [Fact]
+        [Fact(Skip="Replace test with a version that does not depend on an external service")]
         public void ParsingGraphHandlerImplicitBaseUriPropogation()
         {
             try
@@ -58,7 +58,7 @@ namespace VDS.RDF.Parsing.Handlers
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Replace test with a version that does not depend on an external service")]
         public void ParsingGraphHandlerImplicitBaseUriPropogation2()
         {
             try

--- a/Testing/unittest/Parsing/RdfXmlTests.cs
+++ b/Testing/unittest/Parsing/RdfXmlTests.cs
@@ -203,8 +203,8 @@ namespace VDS.RDF.Parsing
 	    [Fact]
 	    public void EmptySameDocumentReferenceResolvesAgainstUriPartOfBaseUri()
 	    {
-	        var rdfXml1 = "<rdf:RDF xml:base='http://example.org#fragment' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:type rdf:about='' /></rdf:RDF>";
-	        var rdfXml2 = "<rdf:RDF xml:base='http://example.org' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:type rdf:about='' /></rdf:RDF>";
+	        const string rdfXml1 = "<rdf:RDF xml:base='http://example.org#fragment' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:type rdf:about='' /></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xml:base='http://example.org' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:type rdf:about='' /></rdf:RDF>";
 
 	        var parser = new RdfXmlParser();
 
@@ -222,10 +222,9 @@ namespace VDS.RDF.Parsing
 	    [Fact]
 	    public void ItExpandsRdfListElementsRegardlessOfNamespacePrefix()
 	    {
-	        var rdfXml1 = "<RDF xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><Seq><li>bar</li></Seq></RDF>";
-	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><rdf:li>bar</rdf:li></rdf:Seq></rdf:RDF>";
-	        var rdfXml3 =
-	            "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><foo:li xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>bar</foo:li></rdf:Seq></rdf:RDF>";
+	        const string rdfXml1 = "<RDF xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><Seq><li>bar</li></Seq></RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><rdf:li>bar</rdf:li></rdf:Seq></rdf:RDF>";
+	        const string rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Seq><foo:li xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>bar</foo:li></rdf:Seq></rdf:RDF>";
 
             var parser = new RdfXmlParser();
 	        var graph1 = new Graph();
@@ -244,14 +243,17 @@ namespace VDS.RDF.Parsing
             Assert.True(diff13.AreEqual);
         }
 
-        [Fact]
-	    public void ItHandlesRdfTypeAttributesRegardlessOfNamespacePrefix()
+	    
+        [Theory]
+        [InlineData(RdfXmlParserMode.Streaming)]
+        [InlineData(RdfXmlParserMode.DOM)]
+	    public void ItHandlesRdfTypeAttributesRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
 	    {
-	        var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><rdf:type rdf:Resource='http://example.org/SomeType'/></eg:Example></rdf:RDF>";
-	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:type  rdf:Resource='http://example.org/SomeType' xmlns:eg='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/></eg:Example></rdf:RDF>";
-	        var rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><type     rdf:Resource='http://example.org/SomeType' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#' /></eg:Example></rdf:RDF>";
+	        const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><rdf:type rdf:Resource='http://example.org/SomeType'/></eg:Example></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:type  rdf:Resource='http://example.org/SomeType' xmlns:eg='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/></eg:Example></rdf:RDF>";
+	        const string rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><type     rdf:Resource='http://example.org/SomeType' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#' /></eg:Example></rdf:RDF>";
 
-            var parser = new RdfXmlParser();
+            var parser = new RdfXmlParser(parserMode);
 
 	        var graph1 = new Graph();
 	        graph1.LoadFromString(rdfXml1, parser);
@@ -269,13 +271,15 @@ namespace VDS.RDF.Parsing
 	        Assert.True(diff13.AreEqual);
         }
 
-        [Fact]
-        public void ItHandlesRdfParseTypeRegardlessOfNamespacePrefix()
+	    [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+        public void ItHandlesRdfParseTypeLiteralRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
         {
-            var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop rdf:parseType='Literal'/><eg:Value /></eg:Example></rdf:RDF>";
-            var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop  xx:parseType='Literal' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/><eg:Value /></eg:Example></rdf:RDF>";
+            const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop rdf:parseType='Literal'/><eg:Value /></eg:Example></rdf:RDF>";
+            const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><eg:Example rdf:about='http://example.org/#us'><eg:prop  xx:parseType='Literal' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/><eg:Value /></eg:Example></rdf:RDF>";
 
-            var parser = new RdfXmlParser();
+            var parser = new RdfXmlParser(parserMode);
 
             var graph1 = new Graph();
             graph1.LoadFromString(rdfXml1, parser);
@@ -288,30 +292,133 @@ namespace VDS.RDF.Parsing
             Assert.True(diff12.AreEqual);
         }
 
-	    [Fact]
-	    public void ItHandlesRdfDescriptionRegardessOfNamespacePrefix()
+	    [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+	    public void ItHandlesRdfParseTypeResourceRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
 	    {
-	        var rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property rdf:Resource='http://example.org/object'/></rdf:Description></rdf:RDF>";
-	        var rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><foo:Description rdf:about='http://example.org/#us' xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><ex:property rdf:Resource='http://example.org/object' xmlns:ex='http://example.org/'/></foo:Description></rdf:RDF>";
-	        var rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><Description     rdf:about='http://example.org/#us' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><ex:property rdf:Resource='http://example.org/object'/></Description></rdf:RDF>";
+	        const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><eg:prop rdf:parseType='Resource'><eg:value>ABC</eg:value></eg:prop></rdf:Description></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><eg:prop  xx:parseType='Resource' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><eg:value>ABC</eg:value></eg:prop></rdf:Description></rdf:RDF>";
+	        var expectGraph = new Graph();
+	        var bnode = expectGraph.CreateBlankNode();
+	        expectGraph.Assert(
+	            expectGraph.CreateUriNode(new Uri("http://example.org/#us")),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/prop")),
+	            bnode);
+	        expectGraph.Assert(
+	            bnode,
+	            expectGraph.CreateUriNode(new Uri("http://example.org/value")),
+	            expectGraph.CreateLiteralNode("ABC"));
+            AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2);
+	    }
 
-	        var parser = new RdfXmlParser();
 
-	        var graph1 = new Graph();
-	        graph1.LoadFromString(rdfXml1, parser);
+	    [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+	    public void ItHandlesRdfParseTypeCollectionRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
+	    {
+	        const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><eg:prop rdf:parseType='Collection'><rdf:Description rdf:about='http://example.org/1'/><rdf:Description rdf:about='http://example.org/2'/></eg:prop></rdf:Description></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><eg:prop  xx:parseType='Collection' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='http://example.org/1'/><rdf:Description rdf:about='http://example.org/2'/></eg:prop></rdf:Description></rdf:RDF>";
+	        var expectGraph = new Graph();
+	        var listNode1 = expectGraph.CreateBlankNode();
+	        var listNode2 = expectGraph.CreateBlankNode();
+	        var first = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "first"));
+	        var rest = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "rest"));
+	        var nil = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "nil"));
+            expectGraph.Assert(
+	            expectGraph.CreateUriNode(new Uri("http://example.org/#us")),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/prop")),
+	            listNode1);
+	        expectGraph.Assert(listNode1, first, expectGraph.CreateUriNode(new Uri("http://example.org/1")));
+            expectGraph.Assert(listNode1, rest, listNode2);
+	        expectGraph.Assert(listNode2, first, expectGraph.CreateUriNode(new Uri("http://example.org/2")));
+	        expectGraph.Assert(listNode2, rest, nil);
+	        AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2);
+	    }
 
-	        var graph2 = new Graph();
-	        graph2.LoadFromString(rdfXml2, parser);
-
-	        var graph3 = new Graph();
-	        graph3.LoadFromString(rdfXml3, parser);
-
-	        var diff12 = graph1.Difference(graph2);
-	        var diff13 = graph1.Difference(graph3);
-
-	        Assert.True(diff12.AreEqual);
-	        Assert.True(diff13.AreEqual);
-
+        [Theory]
+        [InlineData(RdfXmlParserMode.Streaming)]
+        [InlineData(RdfXmlParserMode.DOM)]
+        public void ItHandlesRdfLiRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
+        {
+            const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><rdf:Seq rdf:about='http://example.org/#us'><rdf:li rdf:resource='http://example.org/1'/><rdf:li rdf:resource='http://example.org/2'/></rdf:Seq></rdf:RDF>";
+            const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><xx:Seq rdf:about='http://example.org/#us' xmlns:xx='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><xx:li rdf:resource='http://example.org/1'/><xx:li rdf:resource='http://example.org/2'/></xx:Seq></rdf:RDF>";
+            const string rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:eg='http://example.org/'><Seq rdf:about='http://example.org/#us' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><li rdf:resource='http://example.org/1'/><li rdf:resource='http://example.org/2'/></Seq></rdf:RDF>";
+            var expectGraph = new Graph();
+            var type = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "type"));
+            var first = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "_1"));
+            var second = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "_2"));
+            var seq = expectGraph.CreateUriNode(new Uri(NamespaceMapper.RDF + "Seq"));
+            var coll = expectGraph.CreateUriNode(new Uri("http://example.org/#us"));
+            expectGraph.Assert(coll, type, seq);
+            expectGraph.Assert(coll, first, expectGraph.CreateUriNode(new Uri("http://example.org/1")));
+            expectGraph.Assert(coll, second, expectGraph.CreateUriNode(new Uri("http://example.org/2")));
+            AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2, rdfXml3);
         }
+
+        [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+        public void ItHandlesRdfDescriptionAndRdfAboutRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
+	    {
+	        const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property rdf:resource='http://example.org/object'/></rdf:Description></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><foo:Description foo:about='http://example.org/#us' xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><ex:property rdf:resource='http://example.org/object' xmlns:ex='http://example.org/'/></foo:Description></rdf:RDF>";
+	        var expectGraph = new Graph();
+	        expectGraph.Assert(
+	            expectGraph.CreateUriNode(new Uri("http://example.org/#us")),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/property")),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/object")));
+            AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2);
+        }
+
+	    [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+	    public void ItHandlesRdfDatatypeAttributeRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
+	    {
+	        const string rdfXml1 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property rdf:datatype='http://www.w3.org/2001/XMLSchema#int'>123</ex:property></rdf:Description></rdf:RDF>";
+	        const string rdfXml2 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property foo:datatype='http://www.w3.org/2001/XMLSchema#int' xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>123</ex:property></rdf:Description></rdf:RDF>";
+	        const string rdfXml3 = "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:about='http://example.org/#us'><ex:property datatype='http://www.w3.org/2001/XMLSchema#int' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>123</ex:property></rdf:Description></rdf:RDF>";
+	        var expectGraph = new Graph();
+	        expectGraph.Assert(
+	            expectGraph.CreateUriNode(new Uri("http://example.org/#us")),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/property")),
+	            expectGraph.CreateLiteralNode("123", new Uri("http://www.w3.org/2001/XMLSchema#int")));
+	        AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2, rdfXml3);
+	    }
+
+	    [Theory]
+	    [InlineData(RdfXmlParserMode.Streaming)]
+	    [InlineData(RdfXmlParserMode.DOM)]
+	    public void ItHandlesRdfNodeIdAttributeRegardlessOfNamespacePrefix(RdfXmlParserMode parserMode)
+	    {
+	        const string rdfXml1 =
+	            "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><rdf:Description rdf:nodeID='abc' ex:fullName='John Smith'/></rdf:RDF>";
+	        const string rdfXml2 =
+                "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><foo:Description foo:nodeID='abc' ex:fullName='John Smith' xmlns:foo='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/></rdf:RDF>";
+	        const string rdfXml3 =
+	            "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:ex='http://example.org/'><Description nodeID='abc' ex:fullName='John Smith' xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'/></rdf:RDF>";
+
+	        var expectGraph = new Graph();
+	        expectGraph.Assert(
+	            expectGraph.CreateBlankNode("abc"),
+	            expectGraph.CreateUriNode(new Uri("http://example.org/fullName")),
+	            expectGraph.CreateLiteralNode("John Smith"));
+            AssertGraphsAreEquivalent(parserMode, expectGraph, rdfXml1, rdfXml2, rdfXml3);
+	    }
+
+
+        private void AssertGraphsAreEquivalent(RdfXmlParserMode parserMode, IGraph expectGraph, params string[] testRdfXmlGraphs )
+	    {
+	        var parser = new RdfXmlParser(parserMode);
+	        for (var i = 0; i < testRdfXmlGraphs.Length; i++)
+	        {
+                var testGraph = new Graph();
+                testGraph.LoadFromString(testRdfXmlGraphs[i], parser);
+	            var diff = expectGraph.Difference(testGraph);
+                Assert.True(diff.AreEqual, "Expected test graph #" + i + " to match expect graph but found differences.");
+	        }
+	    }
     }
 }


### PR DESCRIPTION
This PR extends the API of RdfXmlSpecsHelper to support testing attributes and elements that have the RDF/XML namespace mapped to a prefix other than "rdf". Tests are now carried out using the expanded QName (which required access to the current RdfParserContext) rather than using the attribute or element QName directly.
The old APIs have been left in place as they are public APIs, but they have been marked as deprecated.
The RDFXMLParser and other related classes have been updated to use the new APIs and more unit tests have been added specifically to tests the handling of namespace mapping for RDF/XML attributes and elements.
Addresses #202 