### PR TITLE
Code coverage and codecov.io integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ _UpgradeReport*
 UpgradeLog*
 log-file.txt
 Backup/
-
+Tools/
+nugets/
+coverage
+test-*.xml
+dotcover.xml
 
 # Files not to version control
 *.suo

--- a/Libraries/dotNetRDF.Data.DataTables/dotNetRDF.Data.DataTables.csproj
+++ b/Libraries/dotNetRDF.Data.DataTables/dotNetRDF.Data.DataTables.csproj
@@ -30,6 +30,8 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>VDS.RDF.Data.DataTables</RootNamespace>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40-client'">

--- a/Libraries/dotNetRDF.Data.Virtuoso/dotNetRDF.Data.Virtuoso.csproj
+++ b/Libraries/dotNetRDF.Data.Virtuoso/dotNetRDF.Data.Virtuoso.csproj
@@ -29,6 +29,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
+++ b/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
@@ -29,6 +29,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/dotNetRDF.Query.Spin/dotNetRDF.Query.Spin.csproj
+++ b/Libraries/dotNetRDF.Query.Spin/dotNetRDF.Query.Spin.csproj
@@ -23,6 +23,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/dotNetRDF.Web/dotNetRDF.Web.csproj
+++ b/Libraries/dotNetRDF.Web/dotNetRDF.Web.csproj
@@ -30,6 +30,8 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>VDS.RDF.Web</RootNamespace>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Libraries/dotNetRDF/dotNetRDF.csproj
+++ b/Libraries/dotNetRDF/dotNetRDF.csproj
@@ -32,6 +32,8 @@
     <RootNamespace>VDS.RDF</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <LangVersion>7.1</LangVersion>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40-client'">

--- a/Testing/unittest/Core/CompareToTests.cs
+++ b/Testing/unittest/Core/CompareToTests.cs
@@ -992,6 +992,7 @@ namespace VDS.RDF
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void NodeCompareSpeed2()
         {
             //Generate 100,000 node list of random integer nodes
@@ -1001,6 +1002,7 @@ namespace VDS.RDF
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void NodeCompareSpeed3()
         {
             //Generate 1,000,000 node list of random integer nodes

--- a/Testing/unittest/Parsing/BlockingTextReaderTests.cs
+++ b/Testing/unittest/Parsing/BlockingTextReaderTests.cs
@@ -504,6 +504,7 @@ namespace VDS.RDF.Parsing
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void ParsingBlockingVsNonBlocking1()
         {
             this.EnsureNIOData();
@@ -558,6 +559,7 @@ namespace VDS.RDF.Parsing
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void ParsingBlockingVsNonBlocking2()
         {
             this.EnsureNIOData();
@@ -669,6 +671,7 @@ namespace VDS.RDF.Parsing
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void ParsingBlockingVsNonBlocking4()
         {
             this.EnsureNIOData();
@@ -723,6 +726,7 @@ namespace VDS.RDF.Parsing
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void ParsingBlockingVsNonBlocking5()
         {
             this.EnsureNIOData();

--- a/Testing/unittest/Parsing/SpeedTesting.cs
+++ b/Testing/unittest/Parsing/SpeedTesting.cs
@@ -37,6 +37,7 @@ using VDS.RDF.XunitExtensions;
 
 namespace VDS.RDF.Parsing
 {
+    [Trait("Coverage", "Skip")]
     [Trait("Category", "parsing speed")]
     public class SpeedTesting
     {

--- a/Testing/unittest/Parsing/TriXTests.cs
+++ b/Testing/unittest/Parsing/TriXTests.cs
@@ -56,6 +56,7 @@ namespace VDS.RDF.Parsing
         }
 
         [Theory]
+        [Trait("Coverage", "Skip")]
         [InlineData(1000, 100)]
         public void ParsingTriXPerformance_LargeDataset(int numGraphs, int triplesPerGraph)
         {

--- a/Testing/unittest/Query/ParallelEvaluation.cs
+++ b/Testing/unittest/Query/ParallelEvaluation.cs
@@ -180,6 +180,7 @@ namespace VDS.RDF.Query
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void SparqlParallelEvaluationOptional1()
         {
             String data = @"<http://a> <http://p> <http://x> .

--- a/Testing/unittest/Query/PropertyPathEvaluationTests.cs
+++ b/Testing/unittest/Query/PropertyPathEvaluationTests.cs
@@ -390,6 +390,7 @@ WHERE
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void SparqlPropertyPathEvaluationDuplicates()
         {
             IGraph g = new Graph();

--- a/Testing/unittest/Query/SparqlTests2.cs
+++ b/Testing/unittest/Query/SparqlTests2.cs
@@ -866,6 +866,7 @@ WHERE
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void SparqlOrderByComplexLazyPerformance()
         {
             String query = "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?s DESC(?p) LIMIT 5";
@@ -1305,6 +1306,7 @@ WHERE
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void SparqlSubQueryGraphInteractionCore416_Serial()
         {
             try
@@ -1353,6 +1355,7 @@ WHERE
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void SparqlSubQueryGraphInteractionCore416_Parallel()
         {
             try

--- a/Testing/unittest/Writing/RdfXmlWriterTests.NetFull.cs
+++ b/Testing/unittest/Writing/RdfXmlWriterTests.NetFull.cs
@@ -51,6 +51,7 @@ namespace VDS.RDF.Writing
         }
 
         [Fact]
+        [Trait("Coverage", "Skip")]
         public void WritingRdfXmlComplex()
         {
             Graph g = new Graph();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,12 @@ install:
   - cmd: 7z x SHFBInstaller.zip -y
   - ps: msiexec /i InstallResources\SandcastleHelpFileBuilder.msi /quiet /qn /norestart /log install.log
 
+before_build:
+  - ps: gitversion /l console /output buildserver /updateassemblyinfo
+
 configuration: Release
 
 build_script:
-  - ps: gitversion /l console /output buildserver /updateassemblyinfo
   - ps: ./build.ps1 -Target Pack --configuration=Release --NuGetVersion=$env:GitVersion_NuGetVersion
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,40 +15,19 @@ install:
   - cmd: 7z x SHFBInstaller.zip -y
   - ps: msiexec /i InstallResources\SandcastleHelpFileBuilder.msi /quiet /qn /norestart /log install.log
 
-
-before_build:
-  - dotnet restore dotNetRDF.sln
-  - ps: gitversion /l console /output buildserver /updateassemblyinfo
-
 configuration: Release
 
 build_script:
-  - dotnet build -c Release dotNetRDF.sln
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF /p:Version=%GitVersion_NuGetVersion%
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF.Data.DataTables /p:Version=%GitVersion_NuGetVersion%
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF.Data.Virtuoso /p:Version=%GitVersion_NuGetVersion%
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF.Query.FullText /p:Version=%GitVersion_NuGetVersion%
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF.Query.Spin /p:Version=%GitVersion_NuGetVersion%
-  - dotnet pack -c Release -o %APPVEYOR_BUILD_FOLDER%\nugets Libraries/dotNetRDF.Web /p:Version=%GitVersion_NuGetVersion%
+  - ps: gitversion /l console /output buildserver /updateassemblyinfo
+  - ps: ./build.ps1 -Target Pack --configuration=Release --NuGetVersion=$env:GitVersion_NuGetVersion
 
 test_script:
-  - ps: |
-      cd Testing\unittest
-      dotnet xunit -configuration %CONFIGURATION% -notrait "Category=explicit" | Out-File test.log
-      Push-AppveyorArtifact test.log
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      dotnet xunit -configuration %CONFIGURATION% -trait "Category=fulltext" | Out-File fulltext.log
-      Push-AppveyorArtifact fulltext.log
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      cd ..\dotNetRdf.MockServerTests
-      dotnet xunit -configuration %CONFIGURATION% -notrait "Category=explicit" | Out-File mockservertests.log
-      Push-AppveyorArtifact mockservertests.log
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      cd ..\..\
+  - ps: ./build.ps1 -Target Cover --configuration=Release *> test.log
+  - ps: ./build.ps1 -Target Codecov --configuration=Release -no-build=true
 
 before_deploy:
   - cmd: msbuild Build\shfb\dotnetrdf.shfbproj /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=%CONFIGURATION% /p:HelpFileVersion=%GitVersion_NuGetVersion%
-      
+
 deploy:
   - provider: GitHub
     description: 'dotNetRDF $(GitVersion_SemVer)'
@@ -68,6 +47,7 @@ artifacts:
   - path: 'nugets\*.nupkg'
   - path: 'Build\shfb\Help\dotNetRDFApi.chm'
   - path: 'Build\shfb\Help'
-  - path: 'Testing\unittest\*.log'
-  - path: 'Testing\dotNetRdf.MockServerTests\*.log'
+  - path: 'opencover.xml'
 
+on_finish:
+  - ps: Push-AppveyorArtifact 'test.log'

--- a/build.cake
+++ b/build.cake
@@ -81,7 +81,8 @@ Task("Cover")
         if (DirectoryExists("coverage"))
             CleanDirectories("coverage");
     })
-    .Does(DotCover("net452", RunTests(unitTests, "net452")))
+    .Does(RunTests(unitTests, "net452", "Coverage=Skip"))
+    .Does(DotCover("net452", RunTests(unitTests, "net452", "Category!=explicit & Coverage!=Skip")))
     .Does(DotCover("fulltext", RunTests(unitTests, "net452", "Category=fulltext")))
     .Does(() => {
         DotCoverMerge(GetFiles("coverage\\*.dcvr"), "coverage\\merged.dcvr");

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 #tool nuget:?package=GitVersion.CommandLine&prerelease
 #addin nuget:?package=Cake.Codecov
 #tool "nuget:?package=JetBrains.dotCover.CommandLineTools"
-#tool "nuget:?package=ReportGenerator"
+#tool "nuget:?package=ReportGenerator&version=4.0.4"
 
 var target = Argument("target", "Build");
 var configuration = Argument("Configuration", "Debug");

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,125 @@
+#tool nuget:?package=codecov
+#tool nuget:?package=gitlink
+#tool nuget:?package=GitVersion.CommandLine&prerelease
+#addin nuget:?package=Cake.Codecov
+#tool "nuget:?package=JetBrains.dotCover.CommandLineTools"
+#tool "nuget:?package=ReportGenerator"
+
+var target = Argument("target", "Build");
+var configuration = Argument("Configuration", "Debug");
+var version = Argument("NuGetVersion", "");
+
+var libraryProjects = GetFiles("./Libraries/**/*.csproj");
+var unitTests = GetFiles("**\\unittest.csproj").Single();
+var mockServerTests = GetFiles("**\\dotNetRdf.MockServerTests.csproj").Single();
+
+Task("Pack")
+    .IsDependentOn("Build")
+    .DoesForEach(libraryProjects, path => {
+        var settings = new DotNetCorePackSettings
+        {
+            Configuration = configuration,
+            OutputDirectory = "./nugets/",
+            NoBuild = true,
+            MSBuildSettings = new DotNetCoreMSBuildSettings()
+        };
+
+        settings.MSBuildSettings.Properties["version"] = new [] { version };
+
+        DotNetCorePack(path.FullPath, settings);
+    });
+
+Task("GitVersion")
+    .WithCriteria(BuildSystem.IsLocalBuild && string.IsNullOrWhiteSpace(version))
+    .Does(() => {
+        version = GitVersion(new GitVersionSettings {
+            UpdateAssemblyInfo = true,
+        }).NuGetVersion;
+    });
+
+Task("Build")
+    .IsDependentOn("GitVersion")
+    .Does(() => {
+        DotNetCoreBuild("dotnetrdf.sln", new DotNetCoreBuildSettings {
+            Configuration = configuration
+        });
+    });
+
+Task("Codecov")
+    .Does(() => {
+        Codecov("coverage\\cobertura.xml");
+    });
+
+Task("TestNet452")
+    .IsDependentOn("Build")
+    .Does(RunTests(unitTests, "net452"))
+    .Does(RunTests(unitTests, "net452", "Category=fulltext"))
+    .Does(RunTests(mockServerTests, "net452"))
+    .ContinueOnError();
+
+Task("TestNetCore20")
+    .IsDependentOn("Build")
+    .Does(RunTests(unitTests, "netcoreapp2.0"))
+    .ContinueOnError();
+
+Task("TestNetCore11")
+    .IsDependentOn("Build")
+    .Does(RunTests(unitTests, "netcoreapp1.1"))
+    .Does(RunTests(mockServerTests, "netcoreapp1.1"))
+    .ContinueOnError();
+
+Task("Test")
+    .IsDependentOn("TestNet452")
+    .IsDependentOn("TestNetCore20")
+    .IsDependentOn("TestNetCore11")
+    .Does(() => { });
+
+Task("Cover")
+    .IsDependentOn("TestNetCore20")
+    .IsDependentOn("TestNetCore11")
+    .Does(() => {
+        if (DirectoryExists("coverage"))
+            CleanDirectories("coverage");
+    })
+    .Does(DotCover("net452", RunTests(unitTests, "net452")))
+    .Does(DotCover("fulltext", RunTests(unitTests, "net452", "Category=fulltext")))
+    .Does(() => {
+        DotCoverMerge(GetFiles("coverage\\*.dcvr"), "coverage\\merged.dcvr");
+    })
+    .Does(() => {        
+        DotCoverReport(
+          "./coverage/merged.dcvr",
+          "./coverage/dotcover.xml",
+          new DotCoverReportSettings {
+            ReportType = DotCoverReportType.DetailedXML,
+          });
+    })
+    .Does(() => {
+        StartProcess(
+          @".\tools\ReportGenerator.4.0.4\tools\net47\ReportGenerator.exe",
+          @"-reports:.\coverage\dotcover.xml -targetdir:.\coverage -reporttypes:Cobertura -assemblyfilters:-xunit*;-dotNetRDF.*Test");
+    })
+    .DeferOnError();
+
+public Action<ICakeContext> DotCover(string name, Action<ICakeContext> unitTestRun)
+{
+    return (ICakeContext c) =>
+        DotCoverCover(
+            unitTestRun,
+            $"./coverage/{name}.dcvr",
+            new DotCoverCoverSettings());
+}
+
+public Action<ICakeContext> RunTests(FilePath project, string framework, string filter = "Category!=explicit")
+{
+    return (ICakeContext ctx) => 
+        ctx.DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
+        {
+             Configuration = configuration,
+             Framework = framework,
+             NoBuild = true,
+             Filter = filter
+        });
+}
+
+RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,234 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER ShowDescription
+Shows description about tasks.
+.PARAMETER DryRun
+Performs a dry run.
+.PARAMETER Experimental
+Uses the nightly builds of the Roslyn script engine.
+.PARAMETER Mono
+Uses the Mono Compiler rather than the Roslyn script engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+https://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target,
+    [string]$Configuration,
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity,
+    [switch]$ShowDescription,
+    [Alias("WhatIf", "Noop")]
+    [switch]$DryRun,
+    [switch]$Experimental,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $wc.Proxy = $proxy
+    return $wc
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
+$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
+$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."    
+    try {        
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Restore addins from NuGet
+if (Test-Path $ADDINS_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $ADDINS_DIR
+
+    Write-Verbose -Message "Restoring addins from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet addins."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Restore modules from NuGet
+if (Test-Path $MODULES_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $MODULES_DIR
+
+    Write-Verbose -Message "Restoring modules from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet modules."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | out-string)
+
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+
+
+# Build Cake arguments
+$cakeArguments = @("$Script");
+if ($Target) { $cakeArguments += "-target=$Target" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+if ($Experimental) { $cakeArguments += "-experimental" }
+if ($Mono) { $cakeArguments += "-mono" }
+$cakeArguments += $ScriptArgs
+
+# Start Cake
+Write-Host "Running build script..."
+&$CAKE_EXE $cakeArguments
+exit $LASTEXITCODE

--- a/dotNetRDF.sln
+++ b/dotNetRDF.sln
@@ -20,7 +20,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotNetRDF.Web", "Libraries\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotNetRDF.Data.DataTables", "Libraries\dotNetRDF.Data.DataTables\dotNetRDF.Data.DataTables.csproj", "{63FDB648-1631-4452-8B60-E5A4225341FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotNetRDF.MockServerTests", "Testing\dotNetRDF.MockServerTests\dotNetRDF.MockServerTests.csproj", "{1BFD4521-51CF-4949-8C12-717BBA44D3FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotNetRDF.MockServerTests", "Testing\dotNetRDF.MockServerTests\dotNetRDF.MockServerTests.csproj", "{1BFD4521-51CF-4949-8C12-717BBA44D3FC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8A1831D5-14EF-4956-8F35-800960B16115}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
+		build.cake = build.cake
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
## Code coverage 

I switched to cake for build scripting in order to integrate code coverage (dotCover) and also simplified AppVeyor.yml a little bit in the process

Currently coverage is just above 48%. I'd hoped for more but that's what we got. 
The downside is that the CI build takes significantly longer, especially when executing the performance/large graph tests. I would try excluding some of those tests from coverage analysis as they most likely do no contribute (multiple same tests with datasets fo various sizes run through exact same code)

### PR status check

![like-a-boss-decal](https://user-images.githubusercontent.com/588128/48697452-ef05b680-ebe4-11e8-9324-36f014f106bb.jpeg)

@kal, some time ago I requested access to GitHub for codecov.io. Alternatively maybe you could log in there and authorise the app so that we can get nice PR status check like below:

<img width="685" alt="screen shot 2018-11-19 at 10 22 33" src="https://user-images.githubusercontent.com/588128/48697746-a3074180-ebe5-11e8-93b9-116da87e56ba.png">

Once integrated, the status check will compare branch with master and also warn us if the coverage drops too much. 