### PR TITLE
Dynamic graphs and nodes

### DIFF
--- a/Libraries/dotNetRDF/Core/WrapperNode.NetFull.cs
+++ b/Libraries/dotNetRDF/Core/WrapperNode.NetFull.cs
@@ -1,0 +1,61 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF
+{
+    using System;
+    using System.Runtime.Serialization;
+    using System.Xml;
+    using System.Xml.Schema;
+    using System.Xml.Serialization;
+
+    public abstract partial class WrapperNode
+    {
+        /// <inheritdoc/>
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException("This INode implementation does not support Serialization.");
+        }
+
+        /// <inheritdoc/>
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            throw new NotImplementedException("This INode implementation does not support XML Serialization");
+        }
+
+        /// <inheritdoc/>
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            throw new NotImplementedException("This INode implementation does not support XML Serialization");
+        }
+
+        /// <inheritdoc/>
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            throw new NotImplementedException("This INode implementation does not support XML Serialization");
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Core/WrapperNode.cs
+++ b/Libraries/dotNetRDF/Core/WrapperNode.cs
@@ -1,0 +1,187 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF
+{
+    using System;
+    using VDS.RDF.Writing;
+    using VDS.RDF.Writing.Formatting;
+
+    /// <summary>
+    /// Abstract decorator for Nodes to make it easier to layer functionality on top of existing implementations.
+    /// </summary>
+    public abstract partial class WrapperNode : INode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WrapperNode"/> class.
+        /// </summary>
+        /// <param name="node">The node this is a wrapper around.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="node"/> is null.</exception>
+        protected WrapperNode(INode node)
+        {
+            Node = node ?? throw new ArgumentNullException(nameof(node));
+        }
+
+        /// <inheritdoc/>
+        public NodeType NodeType
+        {
+            get
+            {
+                return Node.NodeType;
+            }
+        }
+
+        /// <inheritdoc/>
+        public IGraph Graph
+        {
+            get
+            {
+                return Node.Graph;
+            }
+        }
+
+        /// <inheritdoc/>
+        public Uri GraphUri
+        {
+            get
+            {
+                return Node.GraphUri;
+            }
+
+            set
+            {
+                Node.GraphUri = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the underlying node this is a wrapper around.
+        /// </summary>
+        protected INode Node { get; private set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return Node.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return Node.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return Node.ToString();
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(INode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(IBlankNode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(IGraphLiteralNode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(ILiteralNode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(IUriNode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(IVariableNode other)
+        {
+            return Node.CompareTo(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(INode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(IBlankNode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(IGraphLiteralNode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(ILiteralNode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(IUriNode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(IVariableNode other)
+        {
+            return Node.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(INodeFormatter formatter)
+        {
+            return Node.ToString(formatter);
+        }
+
+        /// <inheritdoc/>
+        public string ToString(INodeFormatter formatter, TripleSegment segment)
+        {
+            return Node.ToString(formatter, segment);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DictionaryMetaObject.cs
+++ b/Libraries/dotNetRDF/Dynamic/DictionaryMetaObject.cs
@@ -1,0 +1,84 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+
+    internal class DictionaryMetaObject : EnumerableMetaObject
+    {
+        internal DictionaryMetaObject(Expression parameter, object value)
+            : base(parameter, value)
+        {
+        }
+
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            return binder.FallbackGetMember(
+                this,
+                CreateMetaObject(
+                    this.CreateIndexExpression(
+                        binder.Name)));
+        }
+
+        public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
+        {
+            return binder.FallbackSetMember(
+                this,
+                value,
+                CreateMetaObject(
+                    Expression.Assign(
+                        this.CreateIndexExpression(binder.Name),
+                        value.Expression)));
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return ((IDictionary<string, object>)Value).Keys;
+        }
+
+        private IndexExpression CreateIndexExpression(string name)
+        {
+            return Expression.Property(
+                Expression.Convert(
+                    this.Expression,
+                    this.RuntimeType),
+                "Item",
+                new[] { Expression.Constant(name) });
+        }
+
+        private DynamicMetaObject CreateMetaObject(Expression expression)
+        {
+            return new DynamicMetaObject(
+                expression,
+                BindingRestrictions.GetTypeRestriction(
+                    this.Expression,
+                    this.LimitType));
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicExtensions.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicExtensions.cs
@@ -1,0 +1,220 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Text.RegularExpressions;
+    using VDS.RDF.Nodes;
+
+    /// <summary>
+    /// Contains helper extension methods for dynamic graphs and nodes.
+    /// </summary>
+    public static class DynamicExtensions
+    {
+        /// <summary>
+        /// Dynamically wraps a graph.
+        /// </summary>
+        /// <param name="graph">The graph to wrap dynamically.</param>
+        /// <param name="subjectBaseUri">The Uri to use for resolving relative subject references.</param>
+        /// <param name="predicateBaseUri">The Uri used to resolve relative predicate references.</param>
+        /// <returns>A dynamic graph that wrappes <paramref name="graph"/>.</returns>
+        public static dynamic AsDynamic(this IGraph graph, Uri subjectBaseUri = null, Uri predicateBaseUri = null)
+        {
+            return new DynamicGraph(graph, subjectBaseUri, predicateBaseUri);
+        }
+
+        /// <summary>
+        /// Dynamically wraps a node.
+        /// </summary>
+        /// <param name="node">The node to wrap dynamically.</param>
+        /// <param name="baseUri">The Uri to use for resolving relative predicate references.</param>
+        /// <returns>A dynamic node that wraps <paramref name="node"/>.</returns>
+        public static dynamic AsDynamic(this INode node, Uri baseUri = null)
+        {
+            return new DynamicNode(node, baseUri);
+        }
+
+        internal static object AsObject(this INode node, Uri baseUri)
+        {
+            switch (node.AsValuedNode())
+            {
+                case IUriNode uriNode:
+                case IBlankNode blankNode:
+                    return node.AsDynamic(baseUri);
+
+                case DoubleNode doubleNode:
+                    return doubleNode.AsDouble();
+
+                case FloatNode floatNode:
+                    return floatNode.AsFloat();
+
+                case DecimalNode decimalNode:
+                    return decimalNode.AsDecimal();
+
+                case BooleanNode booleanNode:
+                    return booleanNode.AsBoolean();
+
+                case DateTimeNode dateTimeNode:
+                    return dateTimeNode.AsDateTimeOffset();
+
+                case TimeSpanNode timeSpanNode:
+                    return timeSpanNode.AsTimeSpan();
+
+                case NumericNode numericNode:
+                    return numericNode.AsInteger();
+
+                case StringNode stringNode when stringNode.DataType is null && string.IsNullOrEmpty(stringNode.Language):
+                    return stringNode.AsString();
+
+                default:
+                    return node;
+            }
+        }
+
+        internal static IUriNode AsUriNode(this string key, IGraph graph, Uri baseUri)
+        {
+            if (!TryResolveQName(key, graph, out var uri))
+            {
+                if (!Uri.TryCreate(key, UriKind.RelativeOrAbsolute, out uri))
+                {
+                    throw new FormatException("Illegal Uri.");
+                }
+            }
+
+            return uri.AsUriNode(graph, baseUri);
+        }
+
+        internal static IUriNode AsUriNode(this Uri key, IGraph graph, Uri baseUri)
+        {
+            if (!key.IsAbsoluteUri)
+            {
+                if (baseUri is null)
+                {
+                    throw new InvalidOperationException("Can't use relative uri without baseUri.");
+                }
+
+                if (baseUri.AbsoluteUri.EndsWith("#"))
+                {
+                    var builder = new UriBuilder(baseUri) { Fragment = key.ToString() };
+
+                    key = builder.Uri;
+                }
+                else
+                {
+                    key = new Uri(baseUri, key);
+                }
+            }
+
+            return graph.CreateUriNode(key);
+        }
+
+        internal static INode AsNode(this object value, IGraph graph)
+        {
+            switch (value)
+            {
+                case INode nodeValue:
+                    return nodeValue.CopyNode(graph);
+
+                case Uri uriValue:
+                    return graph.CreateUriNode(uriValue);
+
+                case bool boolValue:
+                    return new BooleanNode(graph, boolValue);
+
+                case byte byteValue:
+                    return new ByteNode(graph, byteValue);
+
+                case DateTime dateTimeValue:
+                    return new DateTimeNode(graph, dateTimeValue);
+
+                case DateTimeOffset dateTimeOffsetValue:
+                    return new DateTimeNode(graph, dateTimeOffsetValue);
+
+                case decimal decimalValue:
+                    return new DecimalNode(graph, decimalValue);
+
+                case double doubleValue:
+                    return new DoubleNode(graph, doubleValue);
+
+                case float floatValue:
+                    return new FloatNode(graph, floatValue);
+
+                case long longValue:
+                    return new LongNode(graph, longValue);
+
+                case int intValue:
+                    return new LongNode(graph, intValue);
+
+                case string stringValue:
+                    return new StringNode(graph, stringValue);
+
+                case char charValue:
+                    return new StringNode(graph, charValue.ToString());
+
+                case TimeSpan timeSpanValue:
+                    return new TimeSpanNode(graph, timeSpanValue);
+
+                default:
+                    throw new InvalidOperationException($"Can't convert type {value.GetType()}");
+            }
+        }
+
+        internal static string AsName(this IUriNode node, Uri baseUri)
+        {
+            var nodeUri = node.Uri;
+
+            if (node.Graph.NamespaceMap.ReduceToQName(nodeUri.AbsoluteUri, out var qname))
+            {
+                return qname;
+            }
+
+            if (baseUri is null)
+            {
+                return nodeUri.AbsoluteUri;
+            }
+
+            if (baseUri.AbsoluteUri.EndsWith("#"))
+            {
+                return nodeUri.Fragment.TrimStart('#');
+            }
+
+            return baseUri.MakeRelativeUri(nodeUri).ToString();
+        }
+
+        private static bool TryResolveQName(string index, IGraph graph, out Uri indexUri)
+        {
+            if (index.StartsWith("urn:") || !Regex.IsMatch(index, @"^\w*:\w+$"))
+            {
+                indexUri = null;
+                return false;
+            }
+
+            indexUri = graph.ResolveQName(index);
+            return true;
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicGraph.Dictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicGraph.Dictionary.cs
@@ -1,0 +1,74 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicGraph
+    {
+        /// <summary>
+        /// Gets a collection of <see cref="DynamicNode"/>s representing URI nodes in this graph.
+        /// </summary>
+        public ICollection<object> Values
+        {
+            get
+            {
+                return NodePairs.Values;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of URI nodes in this graph.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return UriNodes.Count();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this graph dictionary is read only (always false).
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.Cast<KeyValuePair<INode, object>>().GetEnumerator();
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicGraph.NodeDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicGraph.NodeDictionary.cs
@@ -1,0 +1,353 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    public partial class DynamicGraph : IDictionary<INode, object>
+    {
+        /// <inheritdoc/>
+        ICollection<INode> IDictionary<INode, object>.Keys
+        {
+            get
+            {
+                return UriNodes.Cast<INode>().ToList();
+            }
+        }
+
+        private IEnumerable<IUriNode> UriNodes
+        {
+            get
+            {
+                return Nodes.UriNodes();
+            }
+        }
+
+        private IDictionary<INode, object> NodePairs
+        {
+            get
+            {
+                return UriNodes.ToDictionary(
+                    node => (INode)node,
+                    node => this[node]);
+            }
+        }
+
+        /// <summary>
+        /// Gets nodes equal to <paramref name="node"/> or sets statements with subject equal to <paramref name="node"/> and predicate and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="node">The node to wrap dynamically.</param>
+        /// <returns>A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="node"/> is null.</exception>
+        public object this[INode node]
+        {
+            get
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                return new DynamicNode(node, PredicateBaseUri);
+            }
+
+            set
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                Remove(node);
+
+                if (value != null)
+                {
+                    Add(node, value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to assert.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="subject"/> or <paramref name="predicateAndObjects"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">When <paramref name="predicateAndObjects"/> is a dictionary with keys other than <see cref="INode"/>, <see cref="Uri"/> or <see cref="string"/>.</exception>
+        public void Add(INode subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                throw new ArgumentNullException(nameof(subject));
+            }
+
+            if (predicateAndObjects is null)
+            {
+                throw new ArgumentNullException(nameof(predicateAndObjects));
+            }
+
+            // Make a copy of the key node local to this graph
+            // so dynamic references are resolved correctly
+            // (they depend on node's graph)
+            // TODO: Which graph exactly are we copying into?
+            var targetNode = new DynamicNode(subject.CopyNode(this._g), PredicateBaseUri);
+
+            foreach (DictionaryEntry entry in ConvertToDictionary(predicateAndObjects))
+            {
+                switch (entry.Key)
+                {
+                    case string stringKey:
+                        targetNode.Add(stringKey, entry.Value);
+                        break;
+
+                    case Uri uriKey:
+                        targetNode.Add(uriKey, entry.Value);
+                        break;
+
+                    case INode nodeKey:
+                        targetNode.Add(nodeKey, entry.Value);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("Only INode, Uri and string keys are allowed.");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<INode, object>>.Add(KeyValuePair<INode, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to check.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to check.</param>
+        /// <returns>Whether statements exist equivalent to the parameters.</returns>
+        /// <exception cref="InvalidOperationException">When <paramref name="predicateAndObjects"/> is a dictionary with keys other than <see cref="INode"/>, <see cref="Uri"/> or <see cref="string"/>.</exception>
+        public bool Contains(INode subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            if (predicateAndObjects is null)
+            {
+                return false;
+            }
+
+            if (!TryGetValue(subject, out var value))
+            {
+                return false;
+            }
+
+            var node = (DynamicNode)value;
+
+            foreach (DictionaryEntry entry in ConvertToDictionary(predicateAndObjects))
+            {
+                var found = true;
+
+                switch (entry.Key)
+                {
+                    case string stringKey:
+                        found = node.Contains(stringKey, entry.Value);
+                        break;
+
+                    case Uri uriKey:
+                        found = node.Contains(uriKey, entry.Value);
+                        break;
+
+                    case INode nodeKey:
+                        found = node.Contains(nodeKey, entry.Value);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("Only INode, Uri and string keys are allowed.");
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<INode, object>>.Contains(KeyValuePair<INode, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether a URI node equal to <paramref name="key"/> exists.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether a URI node equal to <paramref name="key"/> exists.</returns>
+        public bool ContainsKey(INode key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return UriNodes.Contains(key);
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<INode, object>>.CopyTo(KeyValuePair<INode, object>[] array, int arrayIndex)
+        {
+            NodePairs.ToArray().CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<INode, object>> IEnumerable<KeyValuePair<INode, object>>.GetEnumerator()
+        {
+            return NodePairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with <paramref name="subject"/>.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(INode subject)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            return Retract(GetTriplesWithSubject(subject).ToList());
+        }
+
+        /// <summary>
+        /// Retracts statements equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(INode subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            if (predicateAndObjects is null)
+            {
+                return false;
+            }
+
+            if (!Contains(subject, predicateAndObjects))
+            {
+                return false;
+            }
+
+            var node = (DynamicNode)this[subject];
+
+            foreach (DictionaryEntry entry in ConvertToDictionary(predicateAndObjects))
+            {
+                switch (entry.Key)
+                {
+                    case string stringKey:
+                        node.Remove(stringKey, entry.Value);
+                        break;
+
+                    case Uri uriKey:
+                        node.Remove(uriKey, entry.Value);
+                        break;
+
+                    case INode nodeKey:
+                        node.Remove(nodeKey, entry.Value);
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<INode, object>>.Remove(KeyValuePair<INode, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get a node from the graph.
+        /// </summary>
+        /// <param name="node">The node to try.</param>
+        /// <param name="value">A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(INode node, out object value)
+        {
+            value = null;
+
+            if (node is null)
+            {
+                return false;
+            }
+
+            if (!ContainsKey(node))
+            {
+                return false;
+            }
+
+            value = this[node];
+            return true;
+        }
+
+        private static IDictionary ConvertToDictionary(object value)
+        {
+            if (value is IDictionary valueDictionary)
+            {
+                return valueDictionary;
+            }
+
+            return GetProperties(value)
+                .ToDictionary(
+                    p => p.Name,
+                    p => p.GetValue(value, null));
+        }
+
+        private static IEnumerable<PropertyInfo> GetProperties(object value)
+        {
+            return value
+                .GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => !p.GetIndexParameters().Any());
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicGraph.StringDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicGraph.StringDictionary.cs
@@ -1,0 +1,227 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicGraph : IDictionary<string, object>
+    {
+        /// <summary>
+        /// Gets an <see cref="ICollection{String}"/> containing Uri subject node names shortened as much as possible.
+        /// </summary>
+        public ICollection<string> Keys
+        {
+            get
+            {
+                return StringPairs.Keys;
+            }
+        }
+
+        private IDictionary<string, object> StringPairs
+        {
+            get
+            {
+                return UriNodes
+                    .ToDictionary(
+                        subject => subject.AsName(BaseUri),
+                        subject => this[subject]);
+            }
+        }
+
+        /// <summary>
+        /// Gets nodes equivalent to <paramref name="node"/> or sets statements with subject equivalent to <paramref name="node"/> and predicate and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="node">The node to wrap dynamically.</param>
+        /// <returns>A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="node"/> is null.</exception>
+        public object this[string node]
+        {
+            get
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                return this[Convert(node)];
+            }
+
+            set
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                this[Convert(node)] = value;
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to assert.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="subject"/> or <paramref name="predicateAndObjects"/> is null.</exception>
+        public void Add(string subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                throw new ArgumentNullException(nameof(subject));
+            }
+
+            if (predicateAndObjects is null)
+            {
+                throw new ArgumentNullException(nameof(predicateAndObjects));
+            }
+
+            Add(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to check.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to check.</param>
+        /// <returns>Whether statements exist equivalent to the parameters.</returns>
+        public bool Contains(string subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            if (predicateAndObjects is null)
+            {
+                return false;
+            }
+
+            return Contains(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether a URI node equivalent to <paramref name="key"/> exists.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether a URI node equivalent to <paramref name="key"/> exists.</returns>
+        public bool ContainsKey(string key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return ContainsKey(Convert(key));
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            StringPairs.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return StringPairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with <paramref name="subject"/>.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(string subject)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(subject));
+        }
+
+        /// <summary>
+        /// Retracts statements equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(string subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get a node from the graph.
+        /// </summary>
+        /// <param name="node">The node to try.</param>
+        /// <param name="value">A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(string node, out object value)
+        {
+            value = null;
+
+            if (node is null)
+            {
+                return false;
+            }
+
+            return TryGetValue(Convert(node), out value);
+        }
+
+        private INode Convert(string subject)
+        {
+            return subject.AsUriNode(this, SubjectBaseUri);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicGraph.UriDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicGraph.UriDictionary.cs
@@ -1,0 +1,216 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicGraph : IDictionary<Uri, object>
+    {
+        /// <inheritdoc/>
+        ICollection<Uri> IDictionary<Uri, object>.Keys
+        {
+            get
+            {
+                return UriPairs.Keys;
+            }
+        }
+
+        private IDictionary<Uri, object> UriPairs
+        {
+            get
+            {
+                return UriNodes
+                    .ToDictionary(
+                        subject => subject.Uri,
+                        subject => this[subject]);
+            }
+        }
+
+        /// <summary>
+        /// Gets nodes equivalent to <paramref name="node"/> or sets statements with subject equivalent to <paramref name="node"/> and predicate and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="node">The node to wrap dynamically.</param>
+        /// <returns>A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="node"/> is null.</exception>
+        public object this[Uri node]
+        {
+            get
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                return this[Convert(node)];
+            }
+
+            set
+            {
+                if (node is null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                this[Convert(node)] = value;
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to assert.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="subject"/>.</exception>
+        public void Add(Uri subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                throw new ArgumentNullException(nameof(subject));
+            }
+
+            Add(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<Uri, object>>.Add(KeyValuePair<Uri, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist equivalent to the parameters.
+        /// </summary>
+        /// <param name="subject">The subject to check.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to check.</param>
+        /// <returns>Whether statements exist equivalent to the parameters.</returns>
+        public bool Contains(Uri subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            return Contains(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<Uri, object>>.Contains(KeyValuePair<Uri, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether a URI node equivalent to <paramref name="key"/> exists.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether a URI node equivalent to <paramref name="key"/> exists.</returns>
+        public bool ContainsKey(Uri key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return ContainsKey(Convert(key));
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<Uri, object>>.CopyTo(KeyValuePair<Uri, object>[] array, int arrayIndex)
+        {
+            UriPairs.ToArray().CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<Uri, object>> IEnumerable<KeyValuePair<Uri, object>>.GetEnumerator()
+        {
+            return UriPairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with <paramref name="subject"/>.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="subject"/> is null</exception>
+        public bool Remove(Uri subject)
+        {
+            if (subject is null)
+            {
+                throw new ArgumentNullException(nameof(subject));
+            }
+
+            return Remove(Convert(subject));
+        }
+
+        /// <summary>
+        /// Retracts statements equivalent to  parameters.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <param name="predicateAndObjects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(Uri subject, object predicateAndObjects)
+        {
+            if (subject is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(subject), predicateAndObjects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<Uri, object>>.Remove(KeyValuePair<Uri, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get a node from the graph.
+        /// </summary>
+        /// <param name="node">The node to try.</param>
+        /// <param name="value">A <see cref="DynamicNode"/> wrapped around the <paramref name="node"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(Uri node, out object value)
+        {
+            value = null;
+
+            if (node is null)
+            {
+                return false;
+            }
+
+            return TryGetValue(Convert(node), out value);
+        }
+
+        private INode Convert(Uri subject)
+        {
+            return subject.AsUriNode(this, this.SubjectBaseUri);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicGraph.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicGraph.cs
@@ -1,0 +1,82 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// A <see cref="WrapperGraph">wrapper</see> that provides read/write dictionary and dynamic functionality.
+    /// </summary>
+    public partial class DynamicGraph : WrapperGraph, IDynamicMetaObjectProvider
+    {
+        private readonly Uri subjectBaseUri;
+        private readonly Uri predicateBaseUri;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicGraph"/> class.
+        /// </summary>
+        /// <param name="graph">The <see cref="IGraph"/> to wrap.</param>
+        /// <param name="subjectBaseUri">The <see cref="Uri"/> used for resolving relative subject references.</param>
+        /// <param name="predicateBaseUri">The <see cref="Uri"/> used for resolving relative predicate references.</param>
+        public DynamicGraph(IGraph graph = null, Uri subjectBaseUri = null, Uri predicateBaseUri = null)
+            : base(graph ?? new Graph())
+        {
+            this.subjectBaseUri = subjectBaseUri;
+            this.predicateBaseUri = predicateBaseUri;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Uri"/> used for resolving relative subject references.
+        /// </summary>
+        public Uri SubjectBaseUri
+        {
+            get
+            {
+                return this.subjectBaseUri ?? this.BaseUri;
+            }
+        }
+
+        /// <summary>
+        /// Gets the URI used for resolving relative predicate references.
+        /// </summary>
+        public Uri PredicateBaseUri
+        {
+            get
+            {
+                return this.predicateBaseUri ?? this.SubjectBaseUri;
+            }
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new DictionaryMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicNode.Dictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicNode.Dictionary.cs
@@ -1,0 +1,82 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicNode
+    {
+        /// <summary>
+        /// Gets a collection of <see cref="DynamicObjectCollection">dynamic object collections</see>, one per distinct outgoing predicate from this node.
+        /// </summary>
+        public ICollection<object> Values
+        {
+            get
+            {
+                return NodePairs.Values;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of distinct outgoing predicates from this node.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return PredicateNodes.Count();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this node is read only (always false).
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject.
+        /// </summary>
+        public void Clear()
+        {
+            new DynamicGraph(Graph).Remove(this);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.Cast<KeyValuePair<INode, object>>().GetEnumerator();
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicNode.NodeDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicNode.NodeDictionary.cs
@@ -1,0 +1,271 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicNode : IDictionary<INode, object>
+    {
+        /// <inheritdoc/>
+        ICollection<INode> IDictionary<INode, object>.Keys
+        {
+            get
+            {
+                return PredicateNodes.Cast<INode>().ToList();
+            }
+        }
+
+        private IEnumerable<IUriNode> PredicateNodes
+        {
+            get
+            {
+                var predicates =
+                    from t in Graph.GetTriplesWithSubject(this)
+                    select (IUriNode)t.Predicate;
+
+                return predicates.Distinct();
+            }
+        }
+
+        private IDictionary<INode, object> NodePairs
+        {
+            get
+            {
+                return PredicateNodes
+                    .ToDictionary(
+                        predicate => (INode)predicate,
+                        predicate => this[predicate]);
+            }
+        }
+
+        /// <summary>
+        /// Gets statement objects with this subject and <paramref name="predicate"/> or sets staements with this subject, <paramref name="predicate"/> and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <returns>A <see cref="DynamicObjectCollection"/> with this subject and <paramref name="predicate"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is null.</exception>
+        public object this[INode predicate]
+        {
+            get
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                return new DynamicObjectCollection(this, predicate);
+            }
+
+            set
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                Remove(predicate);
+
+                if (value != null)
+                {
+                    Add(predicate, value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements with this subject, <paramref name="predicate"/> and equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> or <paramref name="objects"/> is null.</exception>
+        public void Add(INode predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            if (objects is null)
+            {
+                throw new ArgumentNullException(nameof(objects));
+            }
+
+            Graph.Assert(ConvertToTriples(predicate, objects));
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<INode, object>>.Add(KeyValuePair<INode, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist with this subject, <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <returns>Whether statements exist with this subject, <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.</returns>
+        public bool Contains(INode predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            if (objects is null)
+            {
+                return false;
+            }
+
+            var g = new Graph();
+            g.Assert(ConvertToTriples(predicate, objects));
+            return Graph.HasSubGraph(g);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<INode, object>>.Contains(KeyValuePair<INode, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether this node has an outgoing predicate equal to <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether this node has an outgoing predicate equal to <paramref name="key"/>.</returns>
+        public bool ContainsKey(INode key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return PredicateNodes.Contains(key);
+        }
+
+        void ICollection<KeyValuePair<INode, object>>.CopyTo(KeyValuePair<INode, object>[] array, int arrayIndex)
+        {
+            NodePairs.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<INode, object>> IEnumerable<KeyValuePair<INode, object>>.GetEnumerator()
+        {
+            return NodePairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject and <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(INode predicate)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Graph.Retract(Graph.GetTriplesWithSubjectPredicate(this, predicate).ToList());
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject, <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <param name="objects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(INode predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            if (objects is null)
+            {
+                return false;
+            }
+
+            return Graph.Retract(ConvertToTriples(predicate, objects));
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<INode, object>>.Remove(KeyValuePair<INode, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get an object collection.
+        /// </summary>
+        /// <param name="predicate">The predicate to try.</param>
+        /// <param name="value">A <see cref="DynamicObjectCollection"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(INode predicate, out object value)
+        {
+            value = null;
+
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            if (!ContainsKey(predicate))
+            {
+                return false;
+            }
+
+            value = this[predicate];
+            return true;
+        }
+
+        private IEnumerable<Triple> ConvertToTriples(INode predicate, object value)
+        {
+            // Strings are enumerable but not for our case
+            if (value is string || value is DynamicNode || !(value is IEnumerable enumerable))
+            {
+                enumerable = value.AsEnumerable(); // When they're not enumerable, wrap them in an enumerable of one
+            }
+
+            foreach (var @object in enumerable)
+            {
+                // TODO: Maybe this should throw on null
+                if (@object != null)
+                {
+                    yield return new Triple(
+                        this.CopyNode(predicate.Graph),
+                        predicate,
+                        @object.AsNode(predicate.Graph));
+                }
+            }
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicNode.StringDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicNode.StringDictionary.cs
@@ -1,0 +1,216 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicNode : IDictionary<string, object>
+    {
+        /// <summary>
+        /// Gets an <see cref="ICollection{String}"/> containing outgoing predicate node names shortened as much as possible.
+        /// </summary>
+        public ICollection<string> Keys
+        {
+            get
+            {
+                return StringPairs.Keys;
+            }
+        }
+
+        private IDictionary<string, object> StringPairs
+        {
+            get
+            {
+                return PredicateNodes
+                    .ToDictionary(
+                        predicate => predicate.AsName(BaseUri),
+                        predicate => this[predicate]);
+            }
+        }
+
+        /// <summary>
+        /// Gets statement objects with this subject and predicate equivalent to <paramref name="predicate"/> or sets staements with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <returns>A <see cref="DynamicObjectCollection"/> with this subject and <paramref name="predicate"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is null.</exception>
+        public object this[string predicate]
+        {
+            get
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                return this[Convert(predicate)];
+            }
+
+            set
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                this[Convert(predicate)] = value;
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements with this subject and predicate and objects equivalent to parameters.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is null.</exception>
+        public void Add(string predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            Add(Convert(predicate), objects);
+        }
+
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <returns>Whether statements exist with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.</returns>
+        public bool Contains(string predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Contains(Convert(predicate), objects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether this node has an outgoing predicate equivalent to <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether this node has an outgoing predicate equivalent to <paramref name="key"/>.</returns>
+        public bool ContainsKey(string key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return ContainsKey(Convert(key));
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            StringPairs.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return StringPairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject and equivalent to <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(string predicate)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(predicate));
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <param name="objects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(string predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(predicate), objects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get an object collection.
+        /// </summary>
+        /// <param name="predicate">The predicate to try.</param>
+        /// <param name="value">A <see cref="DynamicObjectCollection"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(string predicate, out object value)
+        {
+            value = null;
+
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return TryGetValue(Convert(predicate), out value);
+        }
+
+        private INode Convert(string predicate)
+        {
+            return predicate.AsUriNode(this.Graph, BaseUri);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicNode.UriDictionary.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicNode.UriDictionary.cs
@@ -1,0 +1,215 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public partial class DynamicNode : IDictionary<Uri, object>
+    {
+        /// <inheritdoc/>
+        ICollection<Uri> IDictionary<Uri, object>.Keys
+        {
+            get
+            {
+                return UriPairs.Keys;
+            }
+        }
+
+        private IDictionary<Uri, object> UriPairs
+        {
+            get
+            {
+                return PredicateNodes
+                    .ToDictionary(
+                        predicate => predicate.Uri,
+                        predicate => this[predicate]);
+            }
+        }
+
+        /// <summary>
+        /// Gets statement objects with this subject and predicate equivalent to <paramref name="predicate"/> or sets staements with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <returns>A <see cref="DynamicObjectCollection"/> with this subject and <paramref name="predicate"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is null.</exception>
+        public object this[Uri predicate]
+        {
+            get
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                return this[Convert(predicate)];
+            }
+
+            set
+            {
+                if (predicate is null)
+                {
+                    throw new ArgumentNullException(nameof(predicate));
+                }
+
+                this[Convert(predicate)] = value;
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements with this subject and predicate and objects equivalent to parameters.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> is null.</exception>
+        public void Add(Uri predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            Add(Convert(predicate), objects);
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<Uri, object>>.Add(KeyValuePair<Uri, object> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether statements exist with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to assert.</param>
+        /// <param name="objects">An object or enumerable representing objects to assert.</param>
+        /// <returns>Whether statements exist with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.</returns>
+        public bool Contains(Uri predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Contains(Convert(predicate), objects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<Uri, object>>.Contains(KeyValuePair<Uri, object> item)
+        {
+            return Contains(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Checks whether this node has an outgoing predicate equivalent to <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The node to check.</param>
+        /// <returns>Whether this node has an outgoing predicate equivalent to <paramref name="key"/>.</returns>
+        public bool ContainsKey(Uri key)
+        {
+            if (key is null)
+            {
+                return false;
+            }
+
+            return ContainsKey(Convert(key));
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<Uri, object>>.CopyTo(KeyValuePair<Uri, object>[] array, int arrayIndex)
+        {
+            UriPairs.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<Uri, object>> IEnumerable<KeyValuePair<Uri, object>>.GetEnumerator()
+        {
+            return UriPairs.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject and equivalent to <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(Uri predicate)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(predicate));
+        }
+
+        /// <summary>
+        /// Retracts statements with this subject, predicate equivalent to <paramref name="predicate"/> and objects equivalent to <paramref name="objects"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate to retract.</param>
+        /// <param name="objects">An object with public properties or a dictionary representing predicates and objects to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(Uri predicate, object objects)
+        {
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return Remove(Convert(predicate), objects);
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<Uri, object>>.Remove(KeyValuePair<Uri, object> item)
+        {
+            return Remove(item.Key, item.Value);
+        }
+
+        /// <summary>
+        /// Tries to get an object collection.
+        /// </summary>
+        /// <param name="predicate">The predicate to try.</param>
+        /// <param name="value">A <see cref="DynamicObjectCollection"/>.</param>
+        /// <returns>A value representing whether a <paramref name="value"/> was set or not.</returns>
+        public bool TryGetValue(Uri predicate, out object value)
+        {
+            value = null;
+
+            if (predicate is null)
+            {
+                return false;
+            }
+
+            return TryGetValue(Convert(predicate), out value);
+        }
+
+        private INode Convert(Uri predicate)
+        {
+            return predicate.AsUriNode(this.Graph, this.BaseUri);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicNode.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicNode.cs
@@ -1,0 +1,97 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// A <see cref="WrapperNode">wrapper</see> that provides read/write dictionary and dynamic functionality.
+    /// </summary>
+    public partial class DynamicNode : WrapperNode, IUriNode, IBlankNode, IDynamicMetaObjectProvider
+    {
+        private readonly Uri baseUri;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicNode"/> class.
+        /// </summary>
+        /// <param name="node">The node to wrap.</param>
+        /// <param name="baseUri">The URI used to resolve relative predicate references.</param>
+        /// <exception cref="InvalidOperationException">When <paramref name="node"/> has no graph.</exception>
+        // TODO: Make sure all instantiations copy original node to appropriate host graph
+        public DynamicNode(INode node, Uri baseUri = null)
+            : base(node)
+        {
+            if (Graph is null)
+            {
+                throw new InvalidOperationException("Node must have graph");
+            }
+
+            this.baseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Gets the URI used to resolve relative predicate references.
+        /// </summary>
+        public Uri BaseUri
+        {
+            get
+            {
+                return this.baseUri ?? this.Graph.BaseUri;
+            }
+        }
+
+        /// <inheritdoc/>
+        Uri IUriNode.Uri
+        {
+            get
+            {
+                return this.Node is IUriNode uriNode ?
+                    uriNode.Uri :
+                    throw new InvalidOperationException("is not a uri node");
+            }
+        }
+
+        /// <inheritdoc/>
+        string IBlankNode.InternalID
+        {
+            get
+            {
+                return this.Node is IBlankNode blankNode ?
+                    blankNode.InternalID :
+                    throw new InvalidOperationException("is not a blank node");
+            }
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new DictionaryMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicObjectCollection.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicObjectCollection.cs
@@ -1,0 +1,163 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// Represents a read/write dynamic collection of objects by subject and predicate.
+    /// </summary>
+    public class DynamicObjectCollection : ICollection<object>, IDynamicMetaObjectProvider
+    {
+        private readonly DynamicNode subject;
+        private readonly INode predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicObjectCollection"/> class.
+        /// </summary>
+        /// <param name="subject">The subject to use.</param>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="subject"/> or <paramref name="predicate"/> are null.</exception>
+        public DynamicObjectCollection(DynamicNode subject, INode predicate)
+        {
+            this.subject = subject ?? throw new ArgumentNullException(nameof(subject));
+            this.predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        }
+
+        /// <summary>
+        /// Gets the number of statements with given subject and predicate.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return Objects.Count();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this collection is read only (always false).
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets objects of statements with given subject and predicate.
+        /// </summary>
+        /// <remarks>Known literal nodes are converted to native primitives, URI and blank nodes are wrapped in <see cref="DynamicNode"/>.</remarks>
+        protected IEnumerable<object> Objects
+        {
+            get
+            {
+                return
+                    from triple
+                    in subject.Graph.GetTriplesWithSubjectPredicate(subject, predicate)
+                    select triple.Object.AsObject(subject.BaseUri);
+            }
+        }
+
+        /// <summary>
+        /// Asserts statements equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to assert.</param>
+        public void Add(object @object)
+        {
+            subject.Add(predicate, @object);
+        }
+
+        /// <summary>
+        /// Retracts statements with given subject and predicate.
+        /// </summary>
+        public void Clear()
+        {
+            subject.Remove(predicate);
+        }
+
+        /// <summary>
+        /// Checks whether a statement exists equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to assert.</param>
+        /// <returns>Whether a statement exists equivalent to given subject and predicate and <paramref name="object"/>.</returns>
+        public bool Contains(object @object)
+        {
+            return Objects.Contains(@object);
+        }
+
+        /// <summary>
+        /// Copies objects of statements with given subject and predicate <paramref name="array"/> starting at <paramref name="index"/>.
+        /// </summary>
+        /// <param name="array">The destination of subjects copied.</param>
+        /// <param name="index">The index at which copying begins.</param>
+        /// <remarks>Known literal nodes are converted to native primitives, URI and blank nodes are wrapped in <see cref="DynamicNode"/>.</remarks>
+        public void CopyTo(object[] array, int index)
+        {
+            Objects.ToArray().CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through objects of statements with given subject and predicate.
+        /// </summary>
+        /// <returns>An enumerator that iterates through objects of statements with given subject and predicate.</returns>
+        /// <remarks>Known literal nodes are converted to native primitives, URI and blank nodes are wrapped in <see cref="DynamicNode"/>.</remarks>
+        public IEnumerator<object> GetEnumerator()
+        {
+            return Objects.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(object @object)
+        {
+            return subject.Remove(predicate, @object);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new EnumerableMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicObjectCollectionT.NetFull.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicObjectCollectionT.NetFull.cs
@@ -1,0 +1,110 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a strongly typed read/write dynamic collection of objects by subject and predicate.
+    /// </summary>
+    /// <typeparam name="T">The type of statement objects.</typeparam>
+    public class DynamicObjectCollection<T> : DynamicObjectCollection, ICollection<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicObjectCollection{T}"/> class.
+        /// </summary>
+        /// <param name="subject">The subject to use.</param>
+        /// <param name="predicate">The predicate to use.</param>
+        public DynamicObjectCollection(DynamicNode subject, string predicate)
+            : base(
+                subject,
+                predicate.AsUriNode(subject.Graph, subject.BaseUri))
+        {
+        }
+
+        /// <summary>
+        /// Asserts statements equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to assert.</param>
+        public void Add(T @object)
+        {
+            base.Add(@object);
+        }
+
+        /// <summary>
+        /// Checks whether a statement exists equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to assert.</param>
+        /// <returns>Whether a statement exists equivalent to given subject and predicate and <paramref name="object"/>.</returns>
+        public bool Contains(T @object)
+        {
+            return base.Contains(@object);
+        }
+
+        /// <summary>
+        /// Copies objects of statements with given subject and predicate <paramref name="array"/> starting at <paramref name="index"/>.
+        /// </summary>
+        /// <param name="array">The destination of subjects copied.</param>
+        /// <param name="index">The index at which copying begins.</param>
+        /// <remarks>Known literal nodes are converted to native primitives, URI and blank nodes are wrapped in <see cref="DynamicNode"/>.</remarks>
+        public void CopyTo(T[] array, int index)
+        {
+            this.Objects.Select(Convert).ToArray().CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Retracts statements equivalent to given subject and predicate and <paramref name="object"/>.
+        /// </summary>
+        /// <param name="object">The object to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(T @object)
+        {
+            return base.Remove(@object);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return this.Objects.Select(Convert).GetEnumerator();
+        }
+
+        private T Convert(object value)
+        {
+            var type = typeof(T);
+
+            if (type.IsSubclassOf(typeof(DynamicNode)))
+            {
+                // TODO: Exception handling
+                var ctor = type.GetConstructor(new[] { typeof(INode) });
+                value = ctor.Invoke(new[] { value });
+            }
+
+            return (T)value;
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicSparqlResult.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicSparqlResult.cs
@@ -1,0 +1,284 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using VDS.RDF.Query;
+
+    /// <summary>
+    /// Provides read/write dictionary and dynamic functionality for <see cref="SparqlResult">SPARQL results</see>.
+    /// </summary>
+    public class DynamicSparqlResult : IDictionary<string, object>, IDynamicMetaObjectProvider
+    {
+        private readonly SparqlResult original;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicSparqlResult"/> class.
+        /// </summary>
+        /// <param name="original">The SPARQL result to wrap.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="original"/> is null.</exception>
+        public DynamicSparqlResult(SparqlResult original)
+        {
+            if (original is null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+
+            this.original = original;
+        }
+
+        /// <summary>
+        /// Gets or sets values equivalent to bindings in the result.
+        /// </summary>
+        /// <param name="variable"></param>
+        /// <returns>The binding converted to a native object.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="variable"/> is null.</exception>
+        public object this[string variable]
+        {
+            get
+            {
+                if (variable is null)
+                {
+                    throw new ArgumentNullException(nameof(variable));
+                }
+
+                return this.original[variable].AsObject();
+            }
+
+            set
+            {
+                if (variable is null)
+                {
+                    throw new ArgumentNullException(nameof(variable));
+                }
+
+                this.original.SetValue(variable, value.AsNode());
+            }
+        }
+
+        /// <summary>
+        /// Gets the variable names in the SPARQL result.
+        /// </summary>
+        public ICollection<string> Keys
+        {
+            get
+            {
+                return (ICollection<string>)this.original.Variables;
+            }
+        }
+
+        /// <summary>
+        /// Gets native values equivalent to bindings in the result.
+        /// </summary>
+        public ICollection<object> Values
+        {
+            get
+            {
+                return this.original.Select(result => result.Value.AsObject()).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of variables in the result.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return this.original.Count;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this SPARQL result dictionary is read only (always false).
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Binds a variable to a node equivalent to <paramref name="value"/>.
+        /// </summary>
+        /// <param name="variable">The name of the variable to bind.</param>
+        /// <param name="value">An object that is converted to an equivalent node and bound to the variable.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="variable"/> is null.</exception>
+        public void Add(string variable, object value)
+        {
+            if (variable is null)
+            {
+                throw new ArgumentNullException(nameof(variable));
+            }
+
+            this[variable] = value.AsNode();
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+        {
+            this.Add(item.Key, item.Value.AsNode());
+        }
+
+        /// <summary>
+        /// Removes all variables in the result.
+        /// </summary>
+        public void Clear()
+        {
+            foreach (var variable in this.Keys)
+            {
+                this.Remove(variable);
+            }
+
+            this.original.Trim();
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+        {
+            if (!this.original.TryGetValue(item.Key, out var value))
+            {
+                return false;
+            }
+
+            return value.Equals(item.Value.AsNode());
+        }
+
+        /// <summary>
+        /// Checks whether a variable exists in the result.
+        /// </summary>
+        /// <param name="variable">The name of the variable to check.</param>
+        /// <returns>Whether a variable exists in the result.</returns>
+        public bool ContainsKey(string variable)
+        {
+            if (variable is null)
+            {
+                return false;
+            }
+
+            return this.original.HasValue(variable);
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            this.original.Select(pair => new KeyValuePair<string, object>(pair.Key, pair.Value.AsObject())).ToArray().CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return this.original.Select(pair => new KeyValuePair<string, object>(pair.Key, pair.Value.AsObject())).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Unbinds a variable from the result.
+        /// </summary>
+        /// <param name="variable">The variable to unbind.</param>
+        /// <returns>Whether a variable was removed.</returns>
+        public bool Remove(string variable)
+        {
+            if (variable is null)
+            {
+                return false;
+            }
+
+            if (!this.original.HasValue(variable))
+            {
+                return false;
+            }
+
+            this[variable] = null;
+            this.original.Trim();
+            return true;
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+        {
+            if (!this.original.TryGetValue(item.Key, out var value))
+            {
+                return false;
+            }
+
+            if (!value.Equals(item.Value.AsNode()))
+            {
+                return false;
+            }
+
+            this[item.Key] = null;
+            this.original.Trim();
+            return true;
+        }
+
+        /// <summary>
+        /// Tries to get a native value equivalent to a binding from the result.
+        /// </summary>
+        /// <param name="variable">The name of the variable to try.</param>
+        /// <param name="value">A native value equivalent to the binding.</param>
+        /// <returns>Whether <paramref name="value"/> was set.</returns>
+        public bool TryGetValue(string variable, out object value)
+        {
+            value = null;
+
+            if (variable is null)
+            {
+                return false;
+            }
+
+            if (!this.original.TryGetValue(variable, out var originalValue))
+            {
+                return false;
+            }
+
+            value = originalValue.AsObject();
+            return true;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through pairs of variable names and native values equivalent to bindings in the result.
+        /// </summary>
+        /// <returns>An enumerator that iterates through pairs of variable names and native values equivalent to bindings in the result.</returns>
+        public IEnumerator GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<string, object>>)this).GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new DictionaryMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicSparqlResultSet.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicSparqlResultSet.cs
@@ -1,0 +1,81 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+    using VDS.RDF.Query;
+
+    /// <summary>
+    /// Provides dynamic functionality for <see cref="SparqlResultSet">SPARQL result sets</see>.
+    /// </summary>
+    public class DynamicSparqlResultSet : IEnumerable<DynamicSparqlResult>, IDynamicMetaObjectProvider
+    {
+        private readonly SparqlResultSet original;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicSparqlResultSet"/> class.
+        /// </summary>
+        /// <param name="original">The SPARQL result set to wrap.</param>
+        public DynamicSparqlResultSet(SparqlResultSet original)
+        {
+            if (original is null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+
+            this.original = original;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through dynamic results in the set.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through dynamic results in the set.</returns>
+        public IEnumerator<DynamicSparqlResult> GetEnumerator()
+        {
+            foreach (var result in this.original)
+            {
+                yield return new DynamicSparqlResult(result);
+            }
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new EnumerableMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicSubjectCollection.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicSubjectCollection.cs
@@ -1,0 +1,173 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// Represents a read/write dynamic collection of subjects by predicate and object.
+    /// </summary>
+    public class DynamicSubjectCollection : ICollection<INode>, IDynamicMetaObjectProvider
+    {
+        private readonly DynamicNode @object;
+        private readonly INode predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicSubjectCollection"/> class.
+        /// </summary>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <param name="object">The object to use.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="predicate"/> or <paramref name="object"/> are null.</exception>
+        public DynamicSubjectCollection(INode predicate, DynamicNode @object)
+        {
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            if (@object is null)
+            {
+                throw new ArgumentNullException(nameof(@object));
+            }
+
+            this.@object = @object;
+            this.predicate = predicate;
+        }
+
+        /// <summary>
+        /// Gets the number of statements with given predicate and object.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return Subjects.Count();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this collection is read only (always false).
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets subjects of statements with given predicate and object.
+        /// </summary>
+        /// <remarks>Nodes are wrapped in a <see cref="DynamicNode"/>.</remarks>
+        protected IEnumerable<INode> Subjects
+        {
+            get
+            {
+                return
+                    from triple
+                    in @object.Graph.GetTriplesWithPredicateObject(predicate, @object)
+                    select (INode)triple.Subject.AsObject(@object.BaseUri);
+            }
+        }
+
+        /// <summary>
+        /// Asserts a statement with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to assert.</param>
+        public void Add(INode subject)
+        {
+            @object.Graph.Assert(subject.AsNode(@object.Graph), predicate, @object);
+        }
+
+        /// <summary>
+        /// Retracts statements with given predicate and object.
+        /// </summary>
+        public void Clear()
+        {
+            @object.Graph.Retract(@object.Graph.GetTriplesWithPredicateObject(predicate, @object).ToList());
+        }
+
+        /// <summary>
+        /// Checks whether a statement exists with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to check.</param>
+        /// <returns>Whether a statement exists with <paramref name="subject"/> and given predicate and object.</returns>
+        public bool Contains(INode subject)
+        {
+            return Subjects.Contains(subject);
+        }
+
+        /// <summary>
+        /// Copies subjects of statements with given predicate and object to <paramref name="array"/> starting at <paramref name="index"/>.
+        /// </summary>
+        /// <param name="array">The destination of subjects copied.</param>
+        /// <param name="index">The index at which copying begins.</param>
+        /// <remarks>Nodes are wrapped in a <see cref="DynamicNode"/>.</remarks>
+        public void CopyTo(INode[] array, int index)
+        {
+            Subjects.ToArray().CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through subjects of statements with given predicate and object.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through subjects of statements with given predicate and object.</returns>
+        /// <remarks>Nodes are wrapped in a <see cref="DynamicNode"/>.</remarks>
+        public IEnumerator<INode> GetEnumerator()
+        {
+            return Subjects.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Retracts statements with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(INode subject)
+        {
+            return @object.Graph.Retract(@object.Graph.GetTriplesWithPredicateObject(predicate, @object).WithSubject(subject.AsNode(@object.Graph)).ToList());
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
+        {
+            return new EnumerableMetaObject(parameter, this);
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/DynamicSubjectCollectionT.NetFull.cs
+++ b/Libraries/dotNetRDF/Dynamic/DynamicSubjectCollectionT.NetFull.cs
@@ -1,0 +1,111 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a strongly type read/write dynamic collection of subjects by predicate and object.
+    /// </summary>
+    /// <typeparam name="T">The type of subjects.</typeparam>
+    public class DynamicSubjectCollection<T> : DynamicSubjectCollection, ICollection<T>
+        where T : INode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicSubjectCollection{T}"/> class.
+        /// </summary>
+        /// <param name="predicate">The predicate to use.</param>
+        /// <param name="object">The object to use.</param>
+        public DynamicSubjectCollection(string predicate, DynamicNode @object)
+            : base(
+                predicate.AsUriNode(@object.Graph, @object.BaseUri),
+                @object)
+        {
+        }
+
+        /// <summary>
+        /// Asserts a statement with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to assert.</param>
+        public void Add(T subject)
+        {
+            base.Add(subject);
+        }
+
+        /// <summary>
+        /// Checks whether a statement exists with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to check.</param>
+        /// <returns>Whether a statement exists with <paramref name="subject"/> and given predicate and object.</returns>
+        public bool Contains(T subject)
+        {
+            return base.Contains(subject);
+        }
+
+        /// <summary>
+        /// Copies subjects of statements with given predicate and object to <paramref name="array"/> starting at <paramref name="index"/>.
+        /// </summary>
+        /// <param name="array">The destination of subjects copied.</param>
+        /// <param name="index">The index at which copying begins.</param>
+        /// <remarks>Nodes are wrapped in a <see cref="DynamicNode"/>.</remarks>
+        public void CopyTo(T[] array, int index)
+        {
+            this.Subjects.Select(Convert).ToArray().CopyTo(array, index);
+        }
+
+        /// <summary>
+        /// Retracts statements with <paramref name="subject"/> and given predicate and object.
+        /// </summary>
+        /// <param name="subject">The subject to retract.</param>
+        /// <returns>Whether any statements were retracted.</returns>
+        public bool Remove(T subject)
+        {
+            return base.Remove(subject);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return this.Subjects.Select(Convert).GetEnumerator();
+        }
+
+        private T Convert(INode value)
+        {
+            var type = typeof(T);
+
+            if (type.IsSubclassOf(typeof(DynamicNode)))
+            {
+                // TODO: Exception handling
+                var ctor = type.GetConstructor(new[] { typeof(INode) });
+                value = (DynamicNode)ctor.Invoke(new[] { value });
+            }
+
+            return (T)value;
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Dynamic/EnumerableMetaObject.cs
+++ b/Libraries/dotNetRDF/Dynamic/EnumerableMetaObject.cs
@@ -1,0 +1,73 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    internal class EnumerableMetaObject : DynamicMetaObject
+    {
+        internal EnumerableMetaObject(Expression parameter, object value)
+            : base(parameter, BindingRestrictions.Empty, value)
+        {
+        }
+
+        public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
+        {
+            var expression = this.FindMethod(binder, args);
+            var restrictions = BindingRestrictions.GetTypeRestriction(this.Expression, this.LimitType);
+            var errorSuggestion = new DynamicMetaObject(expression, restrictions);
+
+            return binder.FallbackInvokeMember(this, args, errorSuggestion);
+        }
+
+        private Expression FindMethod(InvokeMemberBinder binder, DynamicMetaObject[] args)
+        {
+            InvalidOperationException invalid = null;
+
+            for (var i = 1; i < 4; i++)
+            {
+                try
+                {
+                    var arguments = Expression.Convert(this.Expression, this.RuntimeType).AsEnumerable().Union(args.Select(arg => arg.Expression)).ToArray();
+                    var typeArguments = Enumerable.Repeat(typeof(object), i).ToArray();
+                    var expression = Expression.Call(typeof(Enumerable), binder.Name, typeArguments, arguments);
+
+                    return Expression.Convert(expression, binder.ReturnType);
+                }
+                catch (InvalidOperationException e)
+                {
+                    invalid = e;
+                }
+            }
+
+            return Expression.Throw(Expression.Constant(invalid), typeof(object));
+        }
+    }
+}

--- a/Testing/unittest/Core/MockWrapperNode.cs
+++ b/Testing/unittest/Core/MockWrapperNode.cs
@@ -1,0 +1,38 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF
+{
+    using System;
+
+    [Serializable]
+    public class MockWrapperNode : WrapperNode
+    {
+        public MockWrapperNode(INode node)
+            : base(node)
+        {
+        }
+    }
+}

--- a/Testing/unittest/Core/WrapperNodeTests.NetFull.cs
+++ b/Testing/unittest/Core/WrapperNodeTests.NetFull.cs
@@ -1,0 +1,82 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Xml;
+    using System.Xml.Serialization;
+    using Xunit;
+
+    public partial class WrapperNodeTests
+    {
+        [Fact]
+        public void Doesnt_implement_GetObjectData()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+            var serializer = new BinaryFormatter(null, default(StreamingContext));
+
+            using (var stream = new MemoryStream())
+            {
+                Assert.Throws<NotImplementedException>(() =>
+                    serializer.Serialize(stream, wrapper));
+            }
+        }
+
+        [Fact]
+        public void Doesnt_implement_GetSchema()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            IXmlSerializable wrapper = new MockWrapperNode(node);
+
+            Assert.Throws<NotImplementedException>(() =>
+                wrapper.GetSchema());
+        }
+
+        [Fact]
+        public void Doesnt_implement_ReadXml()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            IXmlSerializable wrapper = new MockWrapperNode(node);
+
+            Assert.Throws<NotImplementedException>(() =>
+                wrapper.ReadXml(XmlReader.Create(Stream.Null)));
+        }
+
+        [Fact]
+        public void Doesnt_implement_WriteXml()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            IXmlSerializable wrapper = new MockWrapperNode(node);
+
+            Assert.Throws<NotImplementedException>(() =>
+                wrapper.WriteXml(XmlWriter.Create(Stream.Null)));
+        }
+    }
+}

--- a/Testing/unittest/Core/WrapperNodeTests.cs
+++ b/Testing/unittest/Core/WrapperNodeTests.cs
@@ -1,0 +1,286 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF
+{
+    using System;
+    using VDS.RDF.Writing;
+    using VDS.RDF.Writing.Formatting;
+    using Xunit;
+
+    public partial class WrapperNodeTests
+    {
+        [Fact]
+        public void Requires_underlying_node()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new MockWrapperNode(null));
+        }
+
+        [Fact]
+        public void Delegates_Equals_object()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var nodeObject = node as object;
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(nodeObject);
+            var actual = wrapper.Equals(nodeObject);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_GetHashCode()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.GetHashCode();
+            var actual = wrapper.GetHashCode();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_ToString()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.ToString();
+            var actual = wrapper.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_NodeType()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.NodeType;
+            var actual = wrapper.NodeType;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Graph()
+        {
+            var node = new Graph().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Graph;
+            var actual = wrapper.Graph;
+
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_GraphUri()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            wrapper.GraphUri = UriFactory.Create("http://example.com/");
+
+            var expected = node.GraphUri;
+            var actual = wrapper.GraphUri;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_CompareTo_node()
+        {
+            var node = new NodeFactory().CreateBlankNode() as INode;
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates__CompareTo_blank()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates__CompareTo_graphLiteral()
+        {
+            var node = new NodeFactory().CreateGraphLiteralNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates__CompareTo_literal()
+        {
+            var node = new NodeFactory().CreateLiteralNode(string.Empty);
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates__CompareTo_uri()
+        {
+            var node = new NodeFactory().CreateUriNode(UriFactory.Create("http://example.com/"));
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates__CompareTo_variable()
+        {
+            var node = new NodeFactory().CreateVariableNode(string.Empty);
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.CompareTo(node);
+            var actual = wrapper.CompareTo(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_node()
+        {
+            var node = new NodeFactory().CreateBlankNode() as INode;
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_blank()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_graphLiteral()
+        {
+            var node = new NodeFactory().CreateGraphLiteralNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_literal()
+        {
+            var node = new NodeFactory().CreateLiteralNode(string.Empty);
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_uri()
+        {
+            var node = new NodeFactory().CreateUriNode(UriFactory.Create("http://example.com/"));
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_Equal_variable()
+        {
+            var node = new NodeFactory().CreateVariableNode(string.Empty);
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.Equals(node);
+            var actual = wrapper.Equals(node);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_ToString_formatter()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+
+            var expected = node.ToString(new CsvFormatter());
+            var actual = wrapper.ToString(new CsvFormatter());
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Delegates_ToString_formatter_segment()
+        {
+            var node = new NodeFactory().CreateBlankNode();
+            var wrapper = new MockWrapperNode(node);
+            var formatter = new CsvFormatter();
+
+            var expected = node.ToString(formatter, TripleSegment.Subject);
+            var actual = wrapper.ToString(formatter, TripleSegment.Subject);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DictionaryMetaObjectTests.cs
+++ b/Testing/unittest/Dynamic/DictionaryMetaObjectTests.cs
@@ -1,0 +1,130 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DictionaryMetaObjectTests
+    {
+        [Fact]
+        public void Handles_get_member()
+        {
+            var g = new DynamicGraph(subjectBaseUri: new Uri("urn:"));
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            dynamic d = g;
+
+            Assert.Equal(s, d.s);
+        }
+
+        [Fact]
+        public void Handles_set_member()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var g = new DynamicGraph(subjectBaseUri: new Uri("urn:"));
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            dynamic d = g;
+
+            d.s = new { p = "o" };
+
+            Assert.Equal<IGraph>(expected, g);
+        }
+
+        [Fact]
+        public void Handles_member_names()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var provider = g as IDynamicMetaObjectProvider;
+            var meta = provider.GetMetaObject(Expression.Parameter(typeof(object), "debug"));
+
+            var names = meta.GetDynamicMemberNames();
+
+            Assert.Equal(new[] { "urn:s", "urn:o" }, names);
+        }
+
+        [Fact]
+        public void Existing_get_members_pass_through()
+        {
+            var g = new DynamicGraph { BaseUri = new Uri("urn:") };
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            dynamic d = g;
+
+            Assert.Equal<object>(new Uri("urn:"), d.BaseUri);
+        }
+
+        [Fact]
+        public void Existing_set_members_pass_through()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            dynamic d = g;
+
+            d.BaseUri = new Uri("urn:");
+
+            Assert.Equal(new Uri("urn:"), g.BaseUri);
+        }
+
+        [Fact]
+        public void Existing_methods_pass_through()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            dynamic d = g;
+
+            d.Clear();
+
+            Assert.True(g.IsEmpty);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicExtensionTests.cs
+++ b/Testing/unittest/Dynamic/DynamicExtensionTests.cs
@@ -1,0 +1,306 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicExtensionTests
+    {
+        [Fact]
+        public void Augments_graph()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+            var d = g.AsDynamic();
+
+            Assert.Equal<IGraph>(g, d);
+            Assert.IsType<DynamicGraph>(d);
+        }
+
+        [Fact]
+        public void Augments_node()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = s.AsDynamic();
+
+            Assert.Equal<INode>(s, d);
+            Assert.IsType<DynamicNode>(d);
+        }
+
+        [Fact]
+        public void Converts_objects_to_native_datatypes()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+@prefix : <urn:> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:s
+    :p
+        :x ,
+        _:blank ,
+        0E0 ,
+        ""0""^^xsd:float ,
+        0.0 ,
+        false ,
+        ""1900-01-01""^^xsd:dateTime ,
+        ""P1D""^^xsd:duration ,
+        0 ,
+        """" ,
+        """"^^:datatype ,
+        """"@en .
+");
+
+            var s = g.CreateUriNode(":s");
+            var p = g.CreateUriNode(":p");
+            var d = new DynamicNode(s);
+            var objects = new DynamicObjectCollection(d, p);
+
+            Assert.Collection(
+                objects,
+                item => Assert.IsType<DynamicNode>(item),
+                item => Assert.IsType<DynamicNode>(item),
+                item => Assert.IsType<double>(item),
+                item => Assert.IsType<float>(item),
+                item => Assert.IsType<decimal>(item),
+                item => Assert.IsType<bool>(item),
+                item => Assert.IsType<DateTimeOffset>(item),
+                item => Assert.IsType<TimeSpan>(item),
+                item => Assert.IsType<long>(item),
+                item => Assert.IsType<string>(item),
+                item => Assert.IsAssignableFrom<ILiteralNode>(item),
+                item => Assert.IsAssignableFrom<ILiteralNode>(item));
+        }
+
+        [Fact]
+        public void Ignores_URNs_for_QName_parsing()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            Assert.Equal(s, d["urn:s"]);
+        }
+
+        [Fact]
+        public void Ignores_URIs_for_QName_parsing()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<http://example.com/s> <http://example.com/p> <http://example.com/o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("http://example.com/s"));
+
+            Assert.Equal(s, d["http://example.com/s"]);
+        }
+
+        [Fact]
+        public void Expands_QNames()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+@prefix u: <urn:> .
+
+u:s u:p u:o .
+");
+
+            var s = d.CreateUriNode("u:s");
+
+            Assert.Equal(s, d["u:s"]);
+        }
+
+        [Fact]
+        public void Rejects_invalid_URIs()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<FormatException>(() =>
+                d["http:///"]);
+        }
+
+        [Fact]
+        public void Rejects_relative_URI_without_base()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                Assert.Equal(s, d["/s"]));
+        }
+
+        [Fact]
+        public void Expands_hash_URI_base()
+        {
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("http://example.com/#") };
+            d.LoadFromString(@"
+<http://example.com/#s> <http://example.com/#p> <http://example.com/#o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("http://example.com/#s"));
+
+            Assert.Equal(s, d["s"]);
+        }
+
+        [Fact]
+        public void Expands_slash_URI_base()
+        {
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("http://example.com/") };
+            d.LoadFromString(@"
+<http://example.com/s> <http://example.com/p> <http://example.com/o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("http://example.com/s"));
+
+            Assert.Equal(s, d["s"]);
+        }
+
+        [Fact]
+        public void Converts_native_data_types()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:> .
+
+:s
+    :p
+        _:o ,
+        :o ,
+        true ,
+        ""255""^^xsd:unsignedByte ,
+        ""9999-12-31T23:59:59.999999""^^xsd:dateTime ,
+        ""9999-12-31T23:59:59.999999+00:00""^^xsd:dateTime ,
+        ""79228162514264337593543950335""^^xsd:decimal ,
+        ""1.79769313486232E+308""^^xsd:double ,
+        ""3.402823E+38""^^xsd:float ,
+        ""9223372036854775807""^^xsd:integer ,
+        ""2147483647""^^xsd:integer ,
+        """" ,
+        ""\uFFFF"" ,
+        ""P10675199DT2H48M5.4775807S""^^xsd:duration .
+");
+
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("urn:") };
+
+            d["s"] = new
+            {
+                p = new object[]
+                {
+                    new NodeFactory().CreateBlankNode(),
+                    UriFactory.Create("urn:o"),
+                    true,
+                    byte.MaxValue,
+                    DateTime.MaxValue,
+                    DateTimeOffset.MaxValue,
+                    decimal.MaxValue,
+                    double.MaxValue,
+                    float.MaxValue,
+                    long.MaxValue,
+                    int.MaxValue,
+                    string.Empty,
+                    char.MaxValue,
+                    TimeSpan.MaxValue
+                }
+            };
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Rejects_unknown_data_types()
+        {
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("urn:") };
+
+            Assert.Throws<InvalidOperationException>(() =>
+                d["s"] = new
+                {
+                    p = new { }
+                });
+        }
+
+        [Fact]
+        public void Reduces_QNames()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+@prefix : <urn:> .
+
+:s :p :o .
+");
+
+            Assert.Equal(new[] { ":s", ":o" }, d.Keys);
+        }
+
+        [Fact]
+        public void Leaves_absoulte_URIs_without_base()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            Assert.Equal(new[] { "urn:s", "urn:o" }, d.Keys);
+        }
+
+        [Fact]
+        public void Reduces_hash_base_URIs()
+        {
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("http://example.com/#") };
+            d.LoadFromString(@"
+<http://example.com/#s> <http://example.com/#p> <http://example.com/#o> .
+");
+
+            Assert.Equal(new[] { "s", "o" }, d.Keys);
+        }
+
+        [Fact]
+        public void Reduces_base_URIs()
+        {
+            var d = new DynamicGraph { BaseUri = UriFactory.Create("urn:") };
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            Assert.Equal(new[] { "s", "o" }, d.Keys);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicGraphDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicGraphDictionaryTests.cs
@@ -1,0 +1,144 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class DynamicGraphDictionaryTests
+    {
+        [Fact]
+        public void Values_are_dynamic_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o01> .
+<urn:s1> <urn:p1> <urn:o02> .
+<urn:s1> <urn:p2> <urn:o03> .
+<urn:s1> <urn:p2> <urn:o04> .
+<urn:s2> <urn:p3> <urn:o05> .
+<urn:s2> <urn:p3> <urn:o06> .
+<urn:s2> <urn:p4> <urn:o07> .
+<urn:s2> <urn:p4> <urn:o08> .
+_:s3 <urn:p5> <urn:o9> .
+_:s3 <urn:p5> <urn:o10> .
+_:s3 <urn:p6> <urn:o11> .
+_:s3 <urn:p6> <urn:o12> .
+");
+
+            Assert.Equal(d.Nodes.UriNodes(), d.Values);
+
+            foreach (var value in d.Values)
+            {
+                Assert.IsType<DynamicNode>(value);
+            }
+        }
+
+        [Fact]
+        public void Counts_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o01> .
+<urn:s1> <urn:p1> <urn:o02> .
+<urn:s1> <urn:p2> <urn:o03> .
+<urn:s1> <urn:p2> <urn:o04> .
+<urn:s2> <urn:p3> <urn:o05> .
+<urn:s2> <urn:p3> <urn:o06> .
+<urn:s2> <urn:p4> <urn:o07> .
+<urn:s2> <urn:p4> <urn:o08> .
+_:s3 <urn:p5> <urn:o9> .
+_:s3 <urn:p5> <urn:o10> .
+_:s3 <urn:p6> <urn:o11> .
+_:s3 <urn:p6> <urn:o12> .
+");
+
+            Assert.Equal(d.Nodes.UriNodes().Count(), d.Count);
+        }
+
+        [Fact]
+        public void Is_writable()
+        {
+            var g = new DynamicGraph();
+
+            Assert.False(g.IsReadOnly);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_uri_key_and_dynamic_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = (IEnumerable)g;
+            var spo = new[] { s, p, o };
+
+            var actual = d.GetEnumerator();
+            var expected = spo.GetEnumerator();
+            while (expected.MoveNext() | actual.MoveNext())
+            {
+                var current = (KeyValuePair<INode, object>)actual.Current;
+
+                Assert.Equal(expected.Current, current.Key);
+                Assert.IsType<DynamicNode>(current.Value);
+                Assert.Equal(expected.Current, current.Value);
+            }
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicGraphNodeDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicGraphNodeDictionaryTests.cs
@@ -1,0 +1,917 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class DynamicGraphNodeDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as INode]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            Assert.Equal(s, d[s]);
+            Assert.IsType<DynamicNode>(d[s]);
+        }
+
+        [Fact]
+        public void Set_index_requires_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as INode] = null);
+        }
+
+        [Fact]
+        public void Set_index_with_null_value_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+# <urn:s> <urn:s> <urn:s> .
+# <urn:s> <urn:s> <urn:p> .
+# <urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+# <urn:s> <urn:o> <urn:s> .
+# <urn:s> <urn:o> <urn:p> .
+# <urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # should retract
+<urn:s> <urn:s> <urn:p> . # should retract
+<urn:s> <urn:s> <urn:o> . # should retract
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> . # should retract
+<urn:s> <urn:o> <urn:p> . # should retract
+<urn:s> <urn:o> <urn:o> . # should retract
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            d[s] = null;
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Set_index_overwrites_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> ""s"" .
+<urn:s> <urn:s> ""p"" .
+<urn:s> <urn:s> ""o"" .
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+<urn:s> <urn:p> ""o"" .
+<urn:s> <urn:o> ""s"" .
+<urn:s> <urn:o> ""p"" .
+<urn:s> <urn:o> ""o"" .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            d[s] = new
+            {
+                s = new[] { "s", "p", "o" },
+                p = new[] { "s", "p", "o" },
+                o = new[] { "s", "p", "o" },
+            };
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Keys_are_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            Assert.Equal(d.Nodes.UriNodes(), ((IDictionary<INode, object>)d).Keys);
+        }
+
+        [Fact]
+        public void Add_requires_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as INode, null));
+        }
+
+        [Fact]
+        public void Add_requires_value()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(s, null));
+        }
+
+        [Fact]
+        public void Add_handles_public_properties()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+");
+
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = d.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = d.CreateUriNode(UriFactory.Create("urn:o"));
+            var predicateAndObjects = new
+            {
+                s = new[] { s, p, o },
+                p = new[] { s, p, o },
+                o = new[] { s, p, o },
+            };
+
+            d.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Add_handles_dictionaries()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+");
+
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = d.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = d.CreateUriNode(UriFactory.Create("urn:o"));
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { "s", new[] { s, p, o } },
+                { new Uri("urn:p"), new[] { s, p, o } },
+                { d.CreateUriNode(new Uri("urn:o")), new[] { s, p, o } }
+            };
+
+            d.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Add_fails_unknown_key_type()
+        {
+            var g = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = g.CreateBlankNode();
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { 0, "o" }
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+                g.Add(s, predicateAndObjects));
+        }
+
+        [Fact]
+        public void Add_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+");
+
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = d.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = d.CreateUriNode(UriFactory.Create("urn:o"));
+
+            var value = new
+            {
+                s = new[] { s, p, o },
+                p = new[] { s, p, o },
+                o = new[] { s, p, o }
+            };
+
+            ((IDictionary<INode, object>)d).Add(
+                new KeyValuePair<INode, object>(s, value));
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Add_handles_foreign_nodes()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:o>.
+");
+
+            var d = new DynamicGraph(subjectBaseUri: UriFactory.Create("urn:"));
+            var s = expected.CreateUriNode(UriFactory.Create("urn:s"));
+            var o = expected.CreateUriNode(UriFactory.Create("urn:o"));
+
+            d.Add(s, new { p = o });
+
+            Assert.Equal<IGraph>(expected, d);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.Contains(null as INode, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_value()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+
+            Assert.False(d.Contains(s, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_subject()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+
+            Assert.False(d.Contains(s, 0));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_statement()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+
+            Assert.False(d.Contains(s, new { p = s }));
+        }
+
+        [Fact]
+        public void Contains_searches_exisiting_statements()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+            var o = d.CreateUriNode(UriFactory.Create("urn:o"));
+
+            Assert.True(d.Contains(s, new { p = o }));
+        }
+
+        [Fact]
+        public void Contains_fails_unknown_key_type()
+        {
+            var g = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { 0, "o" }
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+                g.Contains(s, predicateAndObjects));
+        }
+
+        [Fact]
+        public void Contains_handles_pairs()
+        {
+            var g = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+
+            Assert.Contains(new KeyValuePair<INode, object>(s, new { p = o }), g);
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_null_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.ContainsKey(null as INode));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = d.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = d.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = d.CreateUriNode(UriFactory.Create("urn:o"));
+
+            Assert.True(d.ContainsKey(s));
+            Assert.False(d.ContainsKey(p));
+            Assert.True(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+
+            var array = new KeyValuePair<INode, object>[5];
+
+            void isEmpty(KeyValuePair<INode, object> actual)
+            {
+                Assert.Equal(default(KeyValuePair<INode, object>), actual);
+            }
+
+            Action<KeyValuePair<INode, object>> isKVWith(INode expected)
+            {
+                return actual =>
+                {
+                    Assert.Equal(new KeyValuePair<INode, object>(expected, expected), actual);
+                    Assert.IsType<DynamicNode>(actual.Value);
+                };
+            }
+
+            (g as IDictionary<INode, object>).CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isKVWith(s),
+                isKVWith(p),
+                isKVWith(o),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+
+            using (var actual = g.Cast<KeyValuePair<INode, object>>().GetEnumerator())
+            {
+                using (var expected = new[] { s, p, o }.Cast<INode>().GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        Assert.Equal(new KeyValuePair<INode, object>(expected.Current, expected.Current), actual.Current);
+                        Assert.IsType<DynamicNode>(actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_p_rejects_null_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.Remove(null as INode));
+        }
+
+        [Fact]
+        public void Remove_p_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = actual.Nodes.First();
+
+            actual.Remove(s1);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_p_reports_retraction_success()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = d.Nodes.First();
+
+            Assert.True(d.Remove(s));
+            Assert.False(d.Remove(s));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_null_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.Remove(null as INode, null));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_null_predicate_and_object()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+
+            Assert.False(d.Remove(s, null));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_missing_statements()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+            var p = d.CreateBlankNode();
+
+            Assert.False(d.Remove(s, p));
+        }
+
+        [Fact]
+        public void Remove_po_handles_public_properties()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p2> ""o2"" .
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = actual.Nodes.First();
+            var predicateAndObjects = new
+            {
+                p1 = "o1",
+                p2 = "o2"
+            };
+
+            actual.Remove(s1, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_dictionaries()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+# <urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+# <urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # should retract
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> . # should retract
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { s, s },
+                { p.Uri, p },
+                { o.Uri.AbsoluteUri, o }
+            };
+
+            actual.Remove(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new DynamicGraph(predicateBaseUri: new Uri("urn:"));
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = (IDictionary<INode, object>)g;
+
+            d.Remove(new KeyValuePair<INode, object>(s, new { p = o }));
+
+            Assert.Equal<IGraph>(expected, g);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_subject()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.TryGetValue(null as INode, out var value));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_subject()
+        {
+            var d = new DynamicGraph();
+            var s = d.CreateBlankNode();
+
+            var condition = d.TryGetValue(s, out var value);
+
+            Assert.False(condition);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetValue_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = d.Nodes.First();
+
+            Assert.True(d.TryGetValue(s, out var value));
+            Assert.Equal(value, s);
+            Assert.NotNull(value);
+            Assert.IsType<DynamicNode>(value);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicGraphStringDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicGraphStringDictionaryTests.cs
@@ -1,0 +1,571 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class DynamicGraphStringDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as string]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = "urn:s";
+
+            var expected = d.CreateUriNode(UriFactory.Create(s));
+            var actual = d[s];
+
+            Assert.Equal(expected, actual);
+            Assert.IsType<DynamicNode>(actual);
+        }
+
+        [Fact]
+        public void Set_index_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as string] = null);
+        }
+
+        [Fact]
+        public void Set_index_with_null_value_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s1> <urn:p2> ""o5"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = "urn:s1";
+
+            actual[s1] = null;
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Set_index_overwrites_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p1> ""o"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s1> <urn:p2> ""o5"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = "urn:s1";
+
+            actual[s1] = new { p1 = "o" };
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Keys_are_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o1> .
+<urn:s1> <urn:p1> <urn:o2> .
+<urn:s1> <urn:p2> <urn:o3> .
+<urn:s1> <urn:p2> <urn:o4> .
+<urn:s2> <urn:p3> <urn:o5> .
+<urn:s2> <urn:p3> <urn:o6> .
+<urn:s2> <urn:p4> <urn:o7> .
+<urn:s2> <urn:p4> <urn:o8> .
+");
+
+            var actual = d.Keys;
+            var expected = d.Nodes.UriNodes().Select(n => n.Uri.AbsoluteUri);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Add_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as string, null));
+        }
+
+        [Fact]
+        public void Add_requires_value()
+        {
+            var d = new DynamicGraph();
+            var s = "urn:s";
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(s, null));
+        }
+
+        [Fact]
+        public void Add_handles_public_properties()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = "urn:s";
+
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p1> ""o1"" .
+<urn:s> <urn:p2> ""o2"" .
+");
+
+            var predicateAndObjects = new
+            {
+                p1 = "o1",
+                p2 = "o2"
+            };
+
+            actual.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Add_handles_dictionaries()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = "urn:s";
+
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p1> ""o1"" .
+<urn:s> <urn:p2> ""o2"" .
+");
+
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { "p1", "o1" },
+                { "p2", "o2" }
+            };
+
+            actual.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Add_handles_key_value_pairs()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = "urn:s";
+
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+
+            var value = new
+            {
+                p = "o"
+            };
+
+            ((IDictionary<string, object>)actual).Add(
+                new KeyValuePair<string, object>(s, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_key()
+        {
+            var d = new DynamicGraph() as IDictionary<string, object>;
+
+            Assert.False(d.Contains(new KeyValuePair<string, object>(null, null)));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_value()
+        {
+            var d = new DynamicGraph() as IDictionary<string, object>;
+            var s = "urn:s";
+
+            Assert.False(d.Contains(new KeyValuePair<string, object>(s, null)));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_key()
+        {
+            var d = new DynamicGraph() as IDictionary<string, object>;
+            var s = "urn:s";
+
+            Assert.False(d.Contains(new KeyValuePair<string, object>(s, 0)));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_statement()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var dict = (IDictionary<string, object>)d;
+            var s = "urn:s";
+
+            Assert.False(dict.Contains(new KeyValuePair<string, object>(s, new { p = "o1" })));
+        }
+
+        [Fact]
+        public void Contains_searches_exisiting_statements()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var dict = (IDictionary<string, object>)d;
+            var s = "urn:s";
+
+            Assert.True(dict.Contains(new KeyValuePair<string, object>(s, new { p = "o" })));
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_null_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.ContainsKey(null as string));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = "urn:s";
+            var p = "urn:p";
+            var o = "urn:o";
+
+            Assert.True(d.ContainsKey(s));
+            Assert.False(d.ContainsKey(p));
+            Assert.True(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = "urn:s";
+            var p = "urn:p";
+            var o = "urn:o";
+
+            var array = new KeyValuePair<string, object>[5];
+
+            void isEmpty(KeyValuePair<string, object> expected)
+            {
+                Assert.Equal(default(KeyValuePair<string, object>), expected);
+            }
+
+            Action<KeyValuePair<string, object>> isKVWith(string expected)
+            {
+                return actual =>
+                {
+                    var expectedNode = g.CreateUriNode(UriFactory.Create(expected));
+
+                    Assert.Equal(new KeyValuePair<string, object>(expected, expectedNode), actual);
+                    Assert.IsType<DynamicNode>(actual.Value);
+                };
+            }
+
+            ((IDictionary<string, object>)g).CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isKVWith(s),
+                isKVWith(p),
+                isKVWith(o),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = "urn:s";
+            var p = "urn:p";
+            var o = "urn:o";
+
+            using (var actual = g.Cast<KeyValuePair<string, object>>().GetEnumerator())
+            {
+                using (var expected = new[] { s, p, o }.Cast<string>().GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        var keyNode = g.CreateUriNode(UriFactory.Create(expected.Current));
+
+                        Assert.Equal(new KeyValuePair<string, object>(expected.Current, keyNode), actual.Current);
+                        Assert.IsType<DynamicNode>(actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_rejects_null_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.Remove(null as string));
+        }
+
+        [Fact]
+        public void Remove_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = "urn:s1";
+
+            actual.Remove(s1);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_reports_retraction_success()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = "urn:s";
+
+            Assert.True(d.Remove(s));
+            Assert.False(d.Remove(s));
+        }
+
+        [Fact]
+        public void Remove_pair_requires_key()
+        {
+            var d = new DynamicGraph() as IDictionary<string, object>;
+
+            Assert.False(d.Remove(new KeyValuePair<string, object>(null, null)));
+        }
+
+        [Fact]
+        public void Remove_pair_ignores_missing_statements()
+        {
+            var d = new DynamicGraph() as IDictionary<string, object>;
+            var s = "urn:s";
+
+            Assert.False(d.Remove(new KeyValuePair<string, object>(s, null)));
+        }
+
+        [Fact]
+        public void Remove_pair_handles_public_properties()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p2> ""o2"" .
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = "urn:s1";
+            var value = new
+            {
+                p1 = "o1",
+                p2 = "o2"
+            };
+
+            ((IDictionary<string, object>)actual).Remove(new KeyValuePair<string, object>(s1, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_pair_handles_public_dictionaries()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p2> ""o2"" .
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = "urn:s1";
+            var value = new Dictionary<object, object>
+            {
+                { "p1", "o1" },
+                { "p2", "o2" }
+            };
+
+            ((IDictionary<string, object>)actual).Remove(new KeyValuePair<string, object>(s1, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.TryGetValue(null as string, out var value));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_key()
+        {
+            var d = new DynamicGraph();
+            var s = "urn:s";
+
+            Assert.False(d.TryGetValue(s, out var value));
+        }
+
+        [Fact]
+        public void TryGetValue_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = "urn:s";
+
+            Assert.True(d.TryGetValue(s, out var value));
+            Assert.Equal(value, d.CreateUriNode(UriFactory.Create(s)));
+            Assert.IsType<DynamicNode>(value);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicGraphTests.cs
+++ b/Testing/unittest/Dynamic/DynamicGraphTests.cs
@@ -1,0 +1,65 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Dynamic;
+    using System.Linq.Expressions;
+    using Xunit;
+
+    public class DynamicGraphTests
+    {
+        [Fact]
+        public void Subject_base_uri_defaults_to_graph_base_uri()
+        {
+            var d = new DynamicGraph();
+            d.BaseUri = UriFactory.Create("urn:");
+
+            Assert.Equal(d.BaseUri, d.SubjectBaseUri);
+        }
+
+        [Fact]
+        public void Predicate_base_uri_defaults_to_subject_base_uri()
+        {
+            var d = new DynamicGraph(new Graph(), UriFactory.Create("urn:s"));
+
+            Assert.Equal(d.SubjectBaseUri, d.PredicateBaseUri);
+        }
+
+        [Fact]
+        public void Provides_dictionary_meta_object()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var p = (IDynamicMetaObjectProvider)d;
+            var mo = p.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicGraphUriDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicGraphUriDictionaryTests.cs
@@ -1,0 +1,583 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class DynamicGraphUriDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as Uri]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = UriFactory.Create("urn:s");
+
+            var expected = d.CreateUriNode(s);
+            var actual = d[s];
+
+            Assert.Equal(expected, actual);
+            Assert.IsType<DynamicNode>(actual);
+        }
+
+        [Fact]
+        public void Set_index_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as Uri] = null);
+        }
+
+        [Fact]
+        public void Set_index_with_null_value_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s1> <urn:p2> ""o5"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = UriFactory.Create("urn:s1");
+
+            actual[s1] = null;
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Set_index_overwrites_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p1> ""o"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s1> <urn:p2> ""o5"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = UriFactory.Create("urn:s1");
+
+            actual[s1] = new { p1 = "o" };
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Keys_are_uri_nodes()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o1> .
+<urn:s1> <urn:p1> <urn:o2> .
+<urn:s1> <urn:p2> <urn:o3> .
+<urn:s1> <urn:p2> <urn:o4> .
+<urn:s2> <urn:p3> <urn:o5> .
+<urn:s2> <urn:p3> <urn:o6> .
+<urn:s2> <urn:p4> <urn:o7> .
+<urn:s2> <urn:p4> <urn:o8> .
+");
+
+            var actual = ((IDictionary<Uri, object>)g).Keys;
+            var expected = g.Nodes.UriNodes().Select(n => n.Uri);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Add_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as Uri, null));
+        }
+
+        [Fact]
+        public void Add_requires_value()
+        {
+            var d = new DynamicGraph();
+            var s = UriFactory.Create("urn:s");
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(s, null));
+        }
+
+        [Fact]
+        public void Add_handles_public_properties()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = UriFactory.Create("urn:s");
+
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p1> ""o1"" .
+<urn:s> <urn:p2> ""o2"" .
+");
+
+            var predicateAndObjects = new
+            {
+                p1 = "o1",
+                p2 = "o2"
+            };
+
+            actual.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Add_handles_dictionaries()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = UriFactory.Create("urn:s");
+
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p1> ""o1"" .
+<urn:s> <urn:p2> ""o2"" .
+");
+
+            var predicateAndObjects = new Dictionary<object, object>
+            {
+                { "p1", "o1" },
+                { "p2", "o2" }
+            };
+
+            actual.Add(s, predicateAndObjects);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Add_handles_key_value_pairs()
+        {
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            var s = UriFactory.Create("urn:s");
+
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+
+            var value = new
+            {
+                p = "o"
+            };
+
+            ((IDictionary<Uri, object>)actual).Add(new KeyValuePair<Uri, object>(s, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_key()
+        {
+            var d = new DynamicGraph() as IDictionary<Uri, object>;
+
+            Assert.False(d.Contains(new KeyValuePair<Uri, object>(null, null)));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_value()
+        {
+            var d = new DynamicGraph() as IDictionary<Uri, object>;
+            var s = UriFactory.Create("urn:s");
+
+            Assert.False(d.Contains(new KeyValuePair<Uri, object>(s, null)));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_key()
+        {
+            var d = new DynamicGraph() as IDictionary<Uri, object>;
+            var s = UriFactory.Create("urn:s");
+
+            var condition = d.Contains(new KeyValuePair<Uri, object>(s, 0));
+
+            Assert.False(condition);
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_statement()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var dict = (IDictionary<Uri, object>)d;
+            var s = UriFactory.Create("urn:s");
+
+            var condition = dict.Contains(new KeyValuePair<Uri, object>(s, new { p = "o1" }));
+
+            Assert.False(condition);
+        }
+
+        [Fact]
+        public void Contains_searches_exisiting_statements()
+        {
+            var d = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            d.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var dict = (IDictionary<Uri, object>)d;
+            var s = UriFactory.Create("urn:s");
+
+            Assert.True(dict.Contains(new KeyValuePair<Uri, object>(s, new { p = "o" })));
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_null_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.ContainsKey(null as Uri));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_uri_nodes()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+
+            Assert.True(d.ContainsKey(s));
+            Assert.False(d.ContainsKey(p));
+            Assert.True(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+
+            var array = new KeyValuePair<Uri, object>[5];
+
+            void isEmpty(KeyValuePair<Uri, object> expected)
+            {
+                Assert.Equal(default(KeyValuePair<Uri, object>), expected);
+            }
+
+            Action<KeyValuePair<Uri, object>> isKVWith(Uri expectedKey)
+            {
+                return actual =>
+                {
+                    var expectedNode = g.CreateUriNode(expectedKey);
+
+                    Assert.Equal(new KeyValuePair<Uri, object>(expectedKey, expectedNode), actual);
+                    Assert.IsType<DynamicNode>(actual.Value);
+                };
+            }
+
+            (g as IDictionary<Uri, object>).CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isKVWith(s),
+                isKVWith(p),
+                isKVWith(o),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_subject_key_and_dynamic_subject_value()
+        {
+            var g = new DynamicGraph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1 (subject)
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> . # 2 (subject)
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> . # 3 (subject)
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+
+            using (var actual = g.Cast<KeyValuePair<Uri, object>>().GetEnumerator())
+            {
+                using (var expected = new[] { s, p, o }.Cast<Uri>().GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        var keyNode = g.CreateUriNode(expected.Current);
+
+                        Assert.Equal(new KeyValuePair<Uri, object>(expected.Current, keyNode), actual.Current);
+                        Assert.IsType<DynamicNode>(actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_requires_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Remove(null as Uri));
+        }
+
+        [Fact]
+        public void Remove_retracts_by_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s1> <urn:p2> ""o4"" .
+<urn:s2> <urn:s1> ""o5"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = UriFactory.Create("urn:s1");
+
+            actual.Remove(s1);
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_reports_retraction_success()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = UriFactory.Create("urn:s");
+
+            Assert.True(d.Remove(s));
+            Assert.False(d.Remove(s));
+        }
+
+        [Fact]
+        public void Remove_pair_requires_key()
+        {
+            var d = new DynamicGraph() as IDictionary<Uri, object>;
+
+            var condition = d.Remove(new KeyValuePair<Uri, object>(null, null));
+
+            Assert.False(condition);
+        }
+
+        [Fact]
+        public void Remove_pair_ignores_missing_statements()
+        {
+            var d = new DynamicGraph() as IDictionary<Uri, object>;
+            var s = UriFactory.Create("urn:s");
+
+            var condition = d.Remove(new KeyValuePair<Uri, object>(s, null));
+
+            Assert.False(condition);
+        }
+
+        [Fact]
+        public void Remove_pair_handles_public_properties()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p2> ""o2"" .
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = UriFactory.Create("urn:s1");
+
+            var value = new
+            {
+                p1 = "o1",
+                p2 = "o2"
+            };
+
+            ((IDictionary<Uri, object>)actual).Remove(new KeyValuePair<Uri, object>(s1, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_pair_handles_public_dictionaries()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new DynamicGraph(predicateBaseUri: UriFactory.Create("urn:"));
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p2> ""o2"" .
+<urn:s2> <urn:s1> ""o3"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s1 = UriFactory.Create("urn:s1");
+
+            var value = new Dictionary<object, object>
+            {
+                { "p1", "o1" },
+                { "p2", "o2" }
+            };
+
+            ((IDictionary<Uri, object>)actual).Remove(new KeyValuePair<Uri, object>(s1, value));
+
+            Assert.Equal<IGraph>(expected, actual);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_key()
+        {
+            var d = new DynamicGraph();
+
+            Assert.False(d.TryGetValue(null as Uri, out var value));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_key()
+        {
+            var d = new DynamicGraph();
+            var s = UriFactory.Create("urn:s");
+
+            var condition = d.TryGetValue(s, out var value);
+
+            Assert.False(condition);
+        }
+
+        [Fact]
+        public void TryGetValue_returns_dynamic_subject()
+        {
+            var d = new DynamicGraph();
+            d.LoadFromString("<urn:s> <urn:p> <urn:o> .");
+
+            var s = UriFactory.Create("urn:s");
+
+            Assert.True(d.TryGetValue(s, out var value));
+            Assert.Equal(value, d.CreateUriNode(s));
+            Assert.IsType<DynamicNode>(value);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicNodeDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeDictionaryTests.cs
@@ -1,0 +1,262 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using Xunit;
+
+    public class DynamicNodeDictionaryTests
+    {
+        [Fact]
+        public void Values_are_objects_per_predicate_for_this_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var expected = new[] { s, p, o };
+
+            void isSPO(object actual)
+            {
+                Assert.Equal(expected, actual);
+                Assert.IsType<DynamicObjectCollection>(actual);
+            }
+
+            Assert.Collection(
+                d.Values,
+                isSPO,
+                isSPO,
+                isSPO);
+        }
+
+        [Fact]
+        public void Counts_predicates_for_this_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1
+<urn:s> <urn:s> <urn:p> . # 1
+<urn:s> <urn:s> <urn:o> . # 1
+<urn:s> <urn:p> <urn:s> . # 2
+<urn:s> <urn:p> <urn:p> . # 2
+<urn:s> <urn:p> <urn:o> . # 2
+<urn:s> <urn:o> <urn:s> . # 3
+<urn:s> <urn:o> <urn:p> . # 3
+<urn:s> <urn:o> <urn:o> . # 3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            Assert.Equal(3, d.Count);
+        }
+
+        [Fact]
+        public void Is_writable()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.IsReadOnly);
+        }
+
+        [Fact]
+        public void Clear_retracts_statements_with_this_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+# <urn:s> <urn:s> <urn:s> .
+# <urn:s> <urn:s> <urn:p> .
+# <urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+# <urn:s> <urn:o> <urn:s> .
+# <urn:s> <urn:o> <urn:p> .
+# <urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # should retract
+<urn:s> <urn:s> <urn:p> . # should retract
+<urn:s> <urn:s> <urn:o> . # should retract
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> . # should retract
+<urn:s> <urn:o> <urn:p> . # should retract
+<urn:s> <urn:o> <urn:o> . # should retract
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            d.Clear();
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = (IEnumerable)new DynamicNode(s);
+            var spo = new[] { s, p, o };
+
+            var actual = d.GetEnumerator();
+            var expected = spo.GetEnumerator();
+            while (expected.MoveNext() | actual.MoveNext())
+            {
+                var current = (KeyValuePair<INode, object>)actual.Current;
+
+                Assert.Equal(expected.Current, current.Key);
+                Assert.IsType<DynamicObjectCollection>(current.Value);
+                Assert.Equal(spo, current.Value);
+            }
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicNodeNodeDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeNodeDictionaryTests.cs
@@ -912,6 +912,21 @@ namespace VDS.RDF.Dynamic
 ");
 
             var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var x = g.CreateUriNode(UriFactory.Create("urn:x"));
+            var d = new DynamicNode(s);
+
+            Assert.False(d.TryGetValue(x, out var objects));
+        }
+
+        [Fact]
+        public void TryGetValue_outputs_objects_by_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
             var p = g.CreateUriNode(UriFactory.Create("urn:p"));
             var d = new DynamicNode(s);
 

--- a/Testing/unittest/Dynamic/DynamicNodeNodeDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeNodeDictionaryTests.cs
@@ -1,0 +1,922 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicNodeNodeDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as INode]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            var actual = d[p];
+
+            var objects = Assert.IsType<DynamicObjectCollection>(actual);
+            Assert.Collection(
+                objects,
+                @object => Assert.Equal(o, @object));
+        }
+
+        [Fact]
+        public void Set_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as INode] = null);
+        }
+
+        [Fact]
+        public void Set_index_removes_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p1"));
+            var d = new DynamicNode(s);
+
+            d[p] = null;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Set_index_adds_predicate_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p1> ""o"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p1"));
+            var d = new DynamicNode(s);
+
+            d[p] = "o";
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Keys_are_predicates()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o1> .
+<urn:s1> <urn:p1> <urn:o2> .
+<urn:s1> <urn:p2> <urn:o3> .
+<urn:s2> <urn:s1> <urn:o5> .
+<urn:s3> <urn:p3> <urn:s1> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s1"));
+            var d = new DynamicNode(s);
+
+            var actual = ((IDictionary<INode, object>)d).Keys;
+            var expected = g.GetTriplesWithSubject(s).Select(triple => triple.Predicate).Distinct();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Add_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as INode, null));
+        }
+
+        [Fact]
+        public void Add_requires_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(p, null));
+        }
+
+        [Fact]
+        public void Add_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Add(p, new[] { s, p, o });
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""abc"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            d.Add(p, "abc");
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s) as IDictionary<INode, object>;
+
+            d.Add(new KeyValuePair<INode, object>(p, "o"));
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(null as INode, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = g.CreateBlankNode();
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_searches_objects_by_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_handles_enumerables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, new[] { s, p }));
+        }
+
+        [Fact]
+        public void Contains_handles_strings()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, "o"));
+        }
+
+        [Fact]
+        public void Contains_handles_pairs()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.Contains(new KeyValuePair<INode, object>(p, o), d);
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_missing_key()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.ContainsKey(null as INode));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_predicates_by_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.False(d.ContainsKey(s));
+            Assert.True(d.ContainsKey(p));
+            Assert.False(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var array = new KeyValuePair<INode, object>[5];
+            var spo = new[] { s, p, o };
+            void isEmpty(KeyValuePair<INode, object> actual)
+            {
+                Assert.Equal(default(KeyValuePair<INode, object>), actual);
+            }
+
+            Action<KeyValuePair<INode, object>> isSPOWith(INode expected)
+            {
+                return actual =>
+                {
+                    Assert.Equal(expected, actual.Key);
+                    Assert.IsType<DynamicObjectCollection>(actual.Value);
+                    Assert.Equal(spo, actual.Value);
+                };
+            }
+
+            ((IDictionary<INode, object>)d).CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isSPOWith(s),
+                isSPOWith(p),
+                isSPOWith(o),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var spo = new[] { s, p, o };
+
+            using (var actual = d.Cast<KeyValuePair<INode, object>>().GetEnumerator())
+            {
+                using (var expected = spo.Cast<INode>().GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        Assert.Equal(expected.Current, actual.Current.Key);
+                        Assert.IsType<DynamicObjectCollection>(actual.Current.Value);
+                        Assert.Equal(spo, actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_p_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as INode));
+        }
+
+        [Fact]
+        public void Remove_p_retracts_by_subject_and_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_p_reports_retraction_success()
+        {
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Remove(p));
+            Assert.False(d.Remove(p));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as INode, null));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_null_object()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(p, null));
+        }
+
+        [Fact]
+        public void Remove_po_retracts_by_subject_predicate_and_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p, o);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p, new[] { s, p, o });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+# <urn:s> <urn:p> ""o"" .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+<urn:s> <urn:p> ""o"" . # should retract
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p, "o");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            ((IDictionary<INode, object>)d).Remove(new KeyValuePair<INode, object>(p, o));
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.TryGetValue(null as INode, out var objects));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.TryGetValue(p, out var objects));
+            Assert.IsType<DynamicObjectCollection>(objects);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicNodeStringDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeStringDictionaryTests.cs
@@ -904,7 +904,7 @@ namespace VDS.RDF.Dynamic
         }
 
         [Fact]
-        public void TryGetValue_rejects_missing_predicate()
+        public void TryGetValue_outputs_objects_by_predicate()
         {
             var g = new Graph();
             g.LoadFromString(@"

--- a/Testing/unittest/Dynamic/DynamicNodeStringDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeStringDictionaryTests.cs
@@ -1,0 +1,922 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicNodeStringDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as string]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            var actual = d[p];
+
+            var objects = Assert.IsType<DynamicObjectCollection>(actual);
+            Assert.Collection(
+                objects,
+                @object => Assert.Equal(o, @object));
+        }
+
+        [Fact]
+        public void Set_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as string] = null);
+        }
+
+        [Fact]
+        public void Set_index_removes_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = UriFactory.Create("urn:p1");
+            var d = new DynamicNode(s);
+
+            d[p] = null;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Set_index_adds_predicate_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p1> ""o"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = "urn:p1";
+            var d = new DynamicNode(s);
+
+            d[p] = "o";
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Keys_are_predicates()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o1> .
+<urn:s1> <urn:p1> <urn:o2> .
+<urn:s1> <urn:p2> <urn:o3> .
+<urn:s2> <urn:s1> <urn:o5> .
+<urn:s3> <urn:p3> <urn:s1> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s1"));
+            var d = new DynamicNode(s) as IDictionary<string, object>;
+
+            var actual = d.Keys;
+            var expected = g.GetTriplesWithSubject(s).Select(triple => (triple.Predicate as IUriNode).Uri.AbsoluteUri).Distinct();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Add_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as string, null));
+        }
+
+        [Fact]
+        public void Add_requires_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(p, null));
+        }
+
+        [Fact]
+        public void Add_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+            var d = new DynamicNode(g.CreateUriNode(s));
+
+            d.Add(p.AbsoluteUri, new[] { s, p, o });
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""abc"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            d.Add(p, "abc");
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s) as IDictionary<string, object>;
+
+            d.Add(new KeyValuePair<string, object>(p, "o"));
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(null as string, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = "urn:p";
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_searches_objects_by_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_handles_enumerables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(g.CreateUriNode(s));
+
+            Assert.True(d.Contains(p.AbsoluteUri, new[] { s, p }));
+        }
+
+        [Fact]
+        public void Contains_handles_strings()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, "o"));
+        }
+
+        [Fact]
+        public void Contains_handles_pairs()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.Contains(new KeyValuePair<string, object>(p, o), d);
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_missing_key()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.ContainsKey(null as string));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_predicates_by_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = "urn:s";
+            var p = "urn:p";
+            var o = "urn:o";
+            var d = new DynamicNode(g.CreateUriNode(UriFactory.Create(s)));
+
+            Assert.False(d.ContainsKey(s));
+            Assert.True(d.ContainsKey(p));
+            Assert.False(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s) as IDictionary<string, object>;
+            var array = new KeyValuePair<string, object>[5];
+            var spo = new[] { s, p, o };
+            void isEmpty(KeyValuePair<string, object> actual)
+            {
+                Assert.Equal(default(KeyValuePair<string, object>), actual);
+            }
+
+            Action<KeyValuePair<string, object>> isSPOWith(string expected)
+            {
+                return actual =>
+                {
+                    Assert.Equal(expected, actual.Key);
+                    Assert.IsType<DynamicObjectCollection>(actual.Value);
+                    Assert.Equal(spo, actual.Value);
+                };
+            }
+
+            d.CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isSPOWith(s.Uri.AbsoluteUri),
+                isSPOWith(p.Uri.AbsoluteUri),
+                isSPOWith(o.Uri.AbsoluteUri),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var spo = new[] { s, p, o };
+
+            using (var actual = d.Cast<KeyValuePair<string, object>>().GetEnumerator())
+            {
+                using (var expected = spo.Select(n => n.Uri.AbsoluteUri).GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        Assert.Equal(expected.Current, actual.Current.Key);
+                        Assert.IsType<DynamicObjectCollection>(actual.Current.Value);
+                        Assert.Equal(spo, actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_p_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as string));
+        }
+
+        [Fact]
+        public void Remove_p_retracts_by_subject_and_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            d.Remove(p);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_p_reports_retraction_success()
+        {
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Remove(p));
+            Assert.False(d.Remove(p));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as string, null));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_missing_object()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(p, null));
+        }
+
+        [Fact]
+        public void Remove_po_retracts_by_subject_predicate_and_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p, o);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = actual.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p.Uri.AbsoluteUri, new[] { s, p, o });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+# <urn:s> <urn:p> ""o"" .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+<urn:s> <urn:p> ""o"" . # should retract
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            d.Remove(p, "o");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s) as IDictionary<string, object>;
+
+            d.Remove(new KeyValuePair<string, object>(p, o));
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.TryGetValue(null as string, out var objects));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = "urn:p";
+            var d = new DynamicNode(s);
+
+            Assert.True(d.TryGetValue(p, out var objects));
+            Assert.IsType<DynamicObjectCollection>(objects);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicNodeTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeTests.cs
@@ -1,0 +1,114 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+    using Xunit;
+
+    public class DynamicNodeTests
+    {
+        [Fact]
+        public void Requires_node_with_graph()
+        {
+            var s = new NodeFactory().CreateBlankNode();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new DynamicNode(s));
+        }
+
+        [Fact]
+        public void BaseUri_defaults_to_graph_base_uri()
+        {
+            var g = new Graph { BaseUri = new Uri("urn:g") };
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            Assert.Equal(g.BaseUri, d.BaseUri);
+        }
+
+        [Fact]
+        public void Can_act_like_uri_node()
+        {
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            Assert.IsAssignableFrom<IUriNode>(d);
+            Assert.Equal(((IUriNode)d).Uri, s.Uri);
+        }
+
+        [Fact]
+        public void Uri_fails_if_underlying_node_is_not_uri()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<InvalidOperationException>(() =>
+                ((IUriNode)d).Uri);
+        }
+
+        [Fact]
+        public void Can_act_like_blank_node()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.IsAssignableFrom<IBlankNode>(d);
+            Assert.Equal(((IBlankNode)d).InternalID, s.InternalID);
+        }
+
+        [Fact]
+        public void InternalId_fails_if_underlying_node_is_not_blank()
+        {
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            Assert.Throws<InvalidOperationException>(() =>
+                ((IBlankNode)d).InternalID);
+        }
+
+        [Fact]
+        public void Provides_dictionary_meta_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+            var p = (IDynamicMetaObjectProvider)d;
+            var mo = p.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicNodeUriDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeUriDictionaryTests.cs
@@ -904,7 +904,7 @@ namespace VDS.RDF.Dynamic
         }
 
         [Fact]
-        public void TryGetValue_rejects_missing_predicate()
+        public void TryGetValue_outputs_objects_by_predicate()
         {
             var g = new Graph();
             g.LoadFromString(@"

--- a/Testing/unittest/Dynamic/DynamicNodeUriDictionaryTests.cs
+++ b/Testing/unittest/Dynamic/DynamicNodeUriDictionaryTests.cs
@@ -1,0 +1,922 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicNodeUriDictionaryTests
+    {
+        [Fact]
+        public void Get_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as Uri]);
+        }
+
+        [Fact]
+        public void Get_index_returns_dynamic_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            var actual = d[p];
+
+            var objects = Assert.IsType<DynamicObjectCollection>(actual);
+            Assert.Collection(
+                objects,
+                @object => Assert.Equal(o, @object));
+        }
+
+        [Fact]
+        public void Set_index_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null as Uri] = null);
+        }
+
+        [Fact]
+        public void Set_index_removes_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = UriFactory.Create("urn:p1");
+            var d = new DynamicNode(s);
+
+            d[p] = null;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Set_index_adds_predicate_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s1> <urn:p1> ""o"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s1> <urn:p1> ""o1"" .
+<urn:s1> <urn:p1> ""o2"" .
+<urn:s1> <urn:p2> ""o3"" .
+<urn:s2> <urn:s1> ""o6"" .
+<urn:s2> <urn:p3> <urn:s1> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s1"));
+            var p = UriFactory.Create("urn:p1");
+            var d = new DynamicNode(s);
+
+            d[p] = "o";
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Keys_are_predicates()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s1> <urn:p1> <urn:o1> .
+<urn:s1> <urn:p1> <urn:o2> .
+<urn:s1> <urn:p2> <urn:o3> .
+<urn:s2> <urn:s1> <urn:o5> .
+<urn:s3> <urn:p3> <urn:s1> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s1"));
+            var d = new DynamicNode(s);
+
+            var actual = ((IDictionary<Uri, object>)d).Keys;
+            var expected = g.GetTriplesWithSubject(s).Select(triple => (triple.Predicate as IUriNode).Uri).Distinct();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Add_requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null as Uri, null));
+        }
+
+        [Fact]
+        public void Add_requires_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(p, null));
+        }
+
+        [Fact]
+        public void Add_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+            var d = new DynamicNode(g.CreateUriNode(s));
+
+            d.Add(p, new[] { s, p, o });
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""abc"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            d.Add(p, "abc");
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Add_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s) as IDictionary<Uri, object>;
+
+            d.Add(new KeyValuePair<Uri, object>(p, "o"));
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(null as Uri, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_null_objects()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, null));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = UriFactory.Create("urn:p");
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_objects()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_searches_objects_by_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, o));
+        }
+
+        [Fact]
+        public void Contains_handles_enumerables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(g.CreateUriNode(s));
+
+            Assert.True(d.Contains(p, new[] { s, p }));
+        }
+
+        [Fact]
+        public void Contains_handles_strings()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Contains(p, "o"));
+        }
+
+        [Fact]
+        public void Contains_handles_pairs()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            Assert.Contains(new KeyValuePair<Uri, object>(p, o), d);
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_missing_key()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.ContainsKey(null as Uri));
+        }
+
+        [Fact]
+        public void ContainsKey_searches_predicates_by_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var o = UriFactory.Create("urn:o");
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(g.CreateUriNode(s));
+
+            Assert.False(d.ContainsKey(s));
+            Assert.True(d.ContainsKey(p));
+            Assert.False(d.ContainsKey(o));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var array = new KeyValuePair<Uri, object>[5];
+            var spo = new[] { s, p, o };
+            void isEmpty(KeyValuePair<Uri, object> actual)
+            {
+                Assert.Equal(default(KeyValuePair<Uri, object>), actual);
+            }
+
+            Action<KeyValuePair<Uri, object>> isSPOWith(Uri expected)
+            {
+                return actual =>
+                {
+                    Assert.Equal(expected, actual.Key);
+                    Assert.IsType<DynamicObjectCollection>(actual.Value);
+                    Assert.Equal(spo, actual.Value);
+                };
+            }
+
+            ((IDictionary<Uri, object>)d).CopyTo(array, 1);
+
+            Assert.Collection(
+                array,
+                isEmpty,
+                isSPOWith(s.Uri),
+                isSPOWith(p.Uri),
+                isSPOWith(o.Uri),
+                isEmpty);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_predicate_key_and_dynamic_objects_value()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> . # 1.1
+<urn:s> <urn:s> <urn:p> . # 1.2
+<urn:s> <urn:s> <urn:o> . # 1.3
+<urn:s> <urn:p> <urn:s> . # 2.1
+<urn:s> <urn:p> <urn:p> . # 2.2
+<urn:s> <urn:p> <urn:o> . # 2.3
+<urn:s> <urn:o> <urn:s> . # 3.1
+<urn:s> <urn:o> <urn:p> . # 3.2
+<urn:s> <urn:o> <urn:o> . # 3.3
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var spo = new[] { s, p, o };
+
+            using (var actual = d.Cast<KeyValuePair<Uri, object>>().GetEnumerator())
+            {
+                using (var expected = spo.Select(n => n.Uri).GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        Assert.Equal(expected.Current, actual.Current.Key);
+                        Assert.IsType<DynamicObjectCollection>(actual.Current.Value);
+                        Assert.Equal(spo, actual.Current.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_p_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as Uri));
+        }
+
+        [Fact]
+        public void Remove_p_retracts_by_subject_and_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            d.Remove(p);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_p_reports_retraction_success()
+        {
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.True(d.Remove(p));
+            Assert.False(d.Remove(p));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(null as Uri, null));
+        }
+
+        [Fact]
+        public void Remove_po_rejects_missing_object()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.False(d.Remove(p, null));
+        }
+
+        [Fact]
+        public void Remove_po_retracts_by_subject_predicate_and_objects()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            d.Remove(p, o);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_enumerables()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = UriFactory.Create("urn:s");
+            var p = UriFactory.Create("urn:p");
+            var o = UriFactory.Create("urn:o");
+            var d = new DynamicNode(actual.CreateUriNode(s));
+
+            d.Remove(p, new[] { s, p, o });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_strings()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+# <urn:s> <urn:p> ""o"" .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:p> ""s"" .
+<urn:s> <urn:p> ""p"" .
+<urn:s> <urn:p> ""o"" . # should retract
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            d.Remove(p, "o");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Remove_po_handles_pairs()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var actual = new Graph();
+            actual.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = actual.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var o = actual.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+
+            ((IDictionary<Uri, object>)d).Remove(new KeyValuePair<Uri, object>(p, o));
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_null_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+
+            Assert.False(d.TryGetValue(null as Uri, out var objects));
+        }
+
+        [Fact]
+        public void TryGetValue_rejects_missing_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = UriFactory.Create("urn:p");
+            var d = new DynamicNode(s);
+
+            Assert.True(d.TryGetValue(p, out var objects));
+            Assert.IsType<DynamicObjectCollection>(objects);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicObjectCollectionTTests.NetFull.cs
+++ b/Testing/unittest/Dynamic/DynamicObjectCollectionTTests.NetFull.cs
@@ -1,0 +1,152 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamiObjectCollectionTTests
+    {
+        [Fact]
+        public void Add_asserts_with_subject_predicate_and_argument_object()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:primitive> ""o"" .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            test.PrimitiveProperty.Add("o");
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_reports_by_subject_predicate_and_argument_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:primitive> ""s"" .
+<urn:s> <urn:primitive> ""p"" .
+<urn:s> <urn:primitive> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            Assert.Contains("s", test.PrimitiveProperty);
+            Assert.Contains("p", test.PrimitiveProperty);
+            Assert.Contains("o", test.PrimitiveProperty);
+        }
+
+        [Fact]
+        public void Copies_objects_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:primitive> ""s"" .
+<urn:s> <urn:primitive> ""p"" .
+<urn:s> <urn:primitive> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            var objects = new string[5]; // +2 for padding on each side
+            test.PrimitiveProperty.CopyTo(objects, 1); // start at the second item at destination
+
+            Assert.Equal(
+                new[] { null, "s", "p", "o", null },
+                objects);
+        }
+
+        [Fact]
+        public void Enumerates_objects_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:complex> <urn:s> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            var expected = new[] { s }.GetEnumerator();
+            using (var actual = test.ComplexProperty.GetEnumerator())
+            {
+                while (expected.MoveNext() | actual.MoveNext())
+                {
+                    Assert.Equal(
+                        expected.Current,
+                        actual.Current);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_retracts_by_subject_predicate_and_argument_object()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:primitive> ""s"" .
+<urn:s> <urn:primitive> ""p"" .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:primitive> ""s"" .
+<urn:s> <urn:primitive> ""p"" .
+<urn:s> <urn:primitive> ""o"" .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            test.PrimitiveProperty.Remove("o");
+
+            Assert.Equal(
+                expected,
+                g);
+        }
+
+        internal class Test : DynamicNode
+        {
+            public Test(INode node)
+                : base(node, new Uri("urn:"))
+            {
+            }
+
+            public ICollection<Test> ComplexProperty => new DynamicObjectCollection<Test>(this, "complex");
+
+            public ICollection<string> PrimitiveProperty => new DynamicObjectCollection<string>(this, "primitive");
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicObjectCollectionTests.cs
+++ b/Testing/unittest/Dynamic/DynamicObjectCollectionTests.cs
@@ -1,0 +1,501 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicObjectCollectionTests
+    {
+        [Fact]
+        public void Requires_subject()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicObjectCollection(null, null));
+        }
+
+        [Fact]
+        public void Requires_predicate()
+        {
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var d = new DynamicNode(s);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicObjectCollection(d, null));
+        }
+
+        [Fact]
+        public void Counts_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # 1
+<urn:s> <urn:p> <urn:p> . # 2
+<urn:s> <urn:p> <urn:o> . # 3
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            Assert.Equal(3, c.Count());
+        }
+
+        [Fact]
+        public void Is_writable()
+        {
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            Assert.False(c.IsReadOnly);
+        }
+
+        [Fact]
+        public void Add_asserts_with_subject_predicate_and_argument_object()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            c.Add(o);
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Clear_retracts_by_subject_and_predicate()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+# <urn:s> <urn:p> <urn:s> .
+# <urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # should retract
+<urn:s> <urn:p> <urn:p> . # should retract
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            c.Clear();
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_reports_by_subject_predicate_and_argument_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # true
+<urn:s> <urn:p> <urn:p> . # true
+<urn:s> <urn:p> <urn:o> . # true
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            Assert.Contains(s, c);
+            Assert.Contains(p, c);
+            Assert.Contains(o, c);
+            Assert.Equal(3, c.Count());
+        }
+
+        [Fact]
+        public void Copies_objects_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> . # 1
+<urn:s> <urn:p> <urn:p> . # 2
+<urn:s> <urn:p> <urn:o> . # 3
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            var objects = new object[5]; // +2 for padding on each side
+            c.CopyTo(objects, 1); // start at the second item at destination
+
+            Assert.Equal(
+                new[] { null, s, p, o, null },
+                objects);
+        }
+
+        [Fact]
+        public void Enumerates_objects_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> . # 1
+<urn:s> <urn:p> <urn:o> . # 2
+<urn:s> <urn:o> <urn:s> . # 3
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            var expected = new[] { s, p, o }.GetEnumerator();
+            using (var actual = c.GetEnumerator())
+            {
+                while (expected.MoveNext())
+                {
+                    actual.MoveNext();
+
+                    Assert.Equal(
+                        expected.Current,
+                        actual.Current);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_retracts_by_subject_predicate_and_argument_object()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p);
+
+            c.Remove(o);
+
+            Assert.Equal(
+                expected,
+                g);
+        }
+
+        [Fact]
+        public void IEnumerable_enumerates_objects_by_subject_and_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> . # 1
+<urn:s> <urn:p> <urn:o> . # 2
+<urn:s> <urn:o> <urn:s> . # 3
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicObjectCollection(d, p) as IEnumerable;
+
+            var expected = new[] { s, p, o }.GetEnumerator();
+            var actual = c.GetEnumerator();
+            while (expected.MoveNext())
+            {
+                actual.MoveNext();
+
+                Assert.Equal(
+                    expected.Current,
+                    actual.Current);
+            }
+        }
+
+        [Fact]
+        public void Provides_meta_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var l = new DynamicObjectCollection(d, p) as IDynamicMetaObjectProvider;
+            var mo = l.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicSparqlResultSetTests.cs
+++ b/Testing/unittest/Dynamic/DynamicSparqlResultSetTests.cs
@@ -1,0 +1,91 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Dynamic;
+    using System.Linq.Expressions;
+    using VDS.RDF;
+    using VDS.RDF.Query;
+    using Xunit;
+
+    public class DynamicSparqlResultSetTests
+    {
+        [Fact]
+        public void Requires_original()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicSparqlResultSet(null));
+        }
+
+        [Fact]
+        public void Enumerates_dynamic_results()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> <urn:o> .");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"SELECT * WHERE { ?s ?p ?o }");
+            var d = new DynamicSparqlResultSet(results);
+
+            foreach (var x in d)
+            {
+                Assert.NotNull(x);
+            }
+        }
+
+        [Fact]
+        public void IEnumerable_Enumerates_dynamic_results()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> <urn:o> .");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"SELECT * WHERE { ?s ?p ?o }");
+            var d = (IEnumerable)new DynamicSparqlResultSet(results);
+
+            foreach (DynamicSparqlResult x in d)
+            {
+                Assert.NotNull(x);
+            }
+        }
+
+        [Fact]
+        public void Provides_enumerable_meta_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> <urn:o> .");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"SELECT * WHERE { ?s ?p ?o }");
+            var d = new DynamicSparqlResultSet(results);
+
+            var p = (IDynamicMetaObjectProvider)d;
+            var mo = p.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+            Assert.IsType<EnumerableMetaObject>(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicSparqlResultTests.cs
+++ b/Testing/unittest/Dynamic/DynamicSparqlResultTests.cs
@@ -1,0 +1,710 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using VDS.RDF.Query;
+    using Xunit;
+
+    public class DynamicSparqlResultTests
+    {
+        [Fact]
+        public void Constructor_requires_original()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicSparqlResult(null));
+        }
+
+        [Fact]
+        public void Get_index_requires_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null]);
+        }
+
+        [Fact]
+        public void Get_index_returns_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Equal(UriFactory.Create("urn:s"), d["s"]);
+        }
+
+        [Fact]
+        public void Set_index_requires_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d[null] = null);
+        }
+
+        [Fact]
+        public void Set_index_binds_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+            var s2 = UriFactory.Create("urn:s2");
+            var expected = new NodeFactory().CreateUriNode(s2);
+
+            d["s"] = s2;
+
+            Assert.Equal(expected, result["s"]);
+        }
+
+        [Fact]
+        public void Keys_are_variables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Equal(results.Variables, d.Keys);
+        }
+
+        [Fact]
+        public void Values_are_native_bindings()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Equal(result.Select(pair => ((IUriNode)pair.Value).Uri), d.Values.Cast<Uri>());
+        }
+
+        [Fact]
+        public void Counts_bound_variables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Equal(result.Count, d.Count);
+        }
+
+        [Fact]
+        public void Is_writable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.IsReadOnly);
+        }
+
+        [Fact]
+        public void Add_requires_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                d.Add(null, null));
+        }
+
+        [Fact]
+        public void Add_binds_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            d.Add("x", "y");
+
+            Assert.Equal("y", ((ILiteralNode)result["x"]).Value);
+        }
+
+        [Fact]
+        public void Add_handles_pairs()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            d.Add(new KeyValuePair<string, object>("x", "y"));
+
+            Assert.Equal("y", ((ILiteralNode)result["x"]).Value);
+        }
+
+        [Fact]
+        public void Clear_unbinds_all_variables()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            d.Clear();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Contains_rejects_missing_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.DoesNotContain(new KeyValuePair<string, object>("x", null), d);
+        }
+
+        [Fact]
+        public void Contains_matches_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.Contains(new KeyValuePair<string, object>("s", UriFactory.Create("urn:s")), d);
+        }
+
+        [Fact]
+        public void ContainsKey_rejects_null_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.ContainsKey(null));
+        }
+
+        [Fact]
+        public void ContainsKey_matches_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.True(d.ContainsKey("s"));
+        }
+
+        [Fact]
+        public void Copies_pairs_with_variable_key_and_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            var objects = new KeyValuePair<string, object>[5]; // +2 for padding on each side
+            d.CopyTo(objects, 1); // start at the second item at destination
+
+            Assert.Equal(
+                new[]
+                {
+                    default,
+                    new KeyValuePair<string, object>("s", UriFactory.Create("urn:s")),
+                    new KeyValuePair<string, object>("p", UriFactory.Create("urn:p")),
+                    new KeyValuePair<string, object>("o", UriFactory.Create("urn:o")),
+                    default
+                },
+                objects);
+        }
+
+        [Fact]
+        public void Enumerates_pairs_with_variable_key_and_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            using (var actual = d.GetEnumerator())
+            {
+                using (var expected = result.GetEnumerator())
+                {
+                    while (expected.MoveNext() | actual.MoveNext())
+                    {
+                        Assert.Equal(
+                            new KeyValuePair<string, object>(
+                                expected.Current.Key,
+                                ((IUriNode)expected.Current.Value).Uri),
+                            actual.Current);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void IEnumerable_enumerates_pairs_with_variable_key_and_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            var actual = d.GetEnumerator();
+            using (var expected = result.GetEnumerator())
+            {
+                while (expected.MoveNext() | actual.MoveNext())
+                {
+                    Assert.Equal(
+                        new KeyValuePair<string, object>(
+                            expected.Current.Key,
+                            ((IUriNode)expected.Current.Value).Uri),
+                        actual.Current);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_rejects_null_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.Remove(null));
+        }
+
+        [Fact]
+        public void Remove_rejects_missing_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.Remove("x"));
+        }
+
+        [Fact]
+        public void Remove_unbinds_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.True(d.Remove("s"));
+            Assert.False(result.HasValue("s"));
+        }
+
+        [Fact]
+        public void Remove_pair_rejects_missing_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            Assert.False(d.Remove(new KeyValuePair<string, object>("x", null)));
+        }
+
+        [Fact]
+        public void Remove_pair_rejects_missing_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            Assert.False(d.Remove(new KeyValuePair<string, object>("s", UriFactory.Create("urn:x"))));
+            Assert.True(result.HasValue("s"));
+        }
+
+        [Fact]
+        public void Remove_pair_unbinds_variable_with_existing_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = (ICollection<KeyValuePair<string, object>>)new DynamicSparqlResult(result);
+
+            Assert.True(d.Remove(new KeyValuePair<string, object>("s", UriFactory.Create("urn:s"))));
+            Assert.False(result.HasValue("s"));
+        }
+
+        [Fact]
+        public void TryGetVaue_rejects_null_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.TryGetValue(null, out var value));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetVaue_rejects_missing_variable()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.False(d.TryGetValue("x", out var value));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetVaue_outputs_native_binding()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+
+            Assert.True(d.TryGetValue("s", out var value));
+            Assert.Equal(UriFactory.Create("urn:s"), value);
+        }
+
+        [Fact]
+        public void Provides_dictionary_meta_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var results = (SparqlResultSet)g.ExecuteQuery(@"
+SELECT *
+WHERE {
+    ?s ?p ?o .
+}
+");
+
+            var result = results.Single();
+            var d = new DynamicSparqlResult(result);
+            var p = (IDynamicMetaObjectProvider)d;
+            var mo = p.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+            Assert.IsType<DictionaryMetaObject>(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicSubjectCollectionTTests.NetFull.cs
+++ b/Testing/unittest/Dynamic/DynamicSubjectCollectionTTests.NetFull.cs
@@ -1,0 +1,152 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamiSubjectCollectionTTests
+    {
+        [Fact]
+        public void Add_asserts_with_predicate_object_and_argument_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = new Test(g.CreateUriNode(UriFactory.Create("urn:s")));
+            var o = new Test(g.CreateUriNode(UriFactory.Create("urn:o")));
+
+            o.P.Add(s);
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_reports_by_predicate_object_and_argument_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+<urn:p> <urn:p> <urn:o> .
+<urn:o> <urn:p> <urn:o> .
+");
+
+            var s = new Test(g.CreateUriNode(UriFactory.Create("urn:s")));
+            var p = new Test(g.CreateUriNode(UriFactory.Create("urn:p")));
+            var o = new Test(g.CreateUriNode(UriFactory.Create("urn:o")));
+
+            Assert.Contains(s, o.P);
+            Assert.Contains(p, o.P);
+            Assert.Contains(o, o.P);
+        }
+
+        [Fact]
+        public void Copies_subjects_by_predicate_and_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+<urn:p> <urn:p> <urn:o> .
+<urn:o> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var testO = new Test(o);
+
+            var subjects = new Test[5]; // +2 for padding on each side
+            testO.P.CopyTo(subjects, 1); // start at the second item at destination
+
+            Assert.Equal(
+                new[] { null, s, p, o, null },
+                subjects);
+        }
+
+        [Fact]
+        public void Enumerates_subjects_by_predicate_and_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:s> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var test = new Test(s);
+
+            var expected = new[] { s }.GetEnumerator();
+            using (var actual = test.P.GetEnumerator())
+            {
+                while (expected.MoveNext() | actual.MoveNext())
+                {
+                    Assert.Equal(
+                        expected.Current,
+                        actual.Current);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_retracts_by_predicate_object_and_argument_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+<urn:p> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+<urn:p> <urn:p> <urn:o> .
+<urn:o> <urn:p> <urn:o> .
+");
+
+            var o = new Test(g.CreateUriNode(UriFactory.Create("urn:o")));
+
+            o.P.Remove(o);
+
+            Assert.Equal(
+                expected,
+                g);
+        }
+
+        internal class Test : DynamicNode
+        {
+            public Test(INode node)
+                : base(node, new Uri("urn:"))
+            {
+            }
+
+            public ICollection<Test> P => new DynamicSubjectCollection<Test>("p", this);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/DynamicSubjectCollectionTests.cs
+++ b/Testing/unittest/Dynamic/DynamicSubjectCollectionTests.cs
@@ -1,0 +1,498 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections;
+    using System.Dynamic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using VDS.RDF;
+    using Xunit;
+
+    public class DynamicSubjectCollectionTests
+    {
+        [Fact]
+        public void Requires_predicate()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicSubjectCollection(null, null));
+        }
+
+        [Fact]
+        public void Requires_object()
+        {
+            var g = new Graph();
+            var p = g.CreateBlankNode();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new DynamicSubjectCollection(p, null));
+        }
+
+        [Fact]
+        public void Counts_by_predicate_and_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # 1
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # 2
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # 3
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            Assert.Equal(3, c.Count());
+        }
+
+        [Fact]
+        public void Is_writable()
+        {
+            var g = new Graph();
+            var p = g.CreateBlankNode();
+            var o = g.CreateBlankNode();
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            Assert.False(c.IsReadOnly);
+        }
+
+        [Fact]
+        public void Add_asserts_with_predicate_object_and_argument_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var g = new Graph();
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            c.Add(s);
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Clear_retracts_by_predicate_and_object()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+# <urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+# <urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # should retract
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # should retract
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            c.Clear();
+
+            Assert.Equal(expected, g);
+        }
+
+        [Fact]
+        public void Contains_reports_by_predicate_object_and_argument_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # true
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # true
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # true
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicSubjectCollection(p, d);
+
+            Assert.Contains(s, c);
+            Assert.Contains(p, c);
+            Assert.Contains(o, c);
+            Assert.Equal(3, c.Count());
+        }
+
+        [Fact]
+        public void Copies_subjects_by_predicate_and_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # 1
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # 2
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # 3
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            var objects = new INode[5]; // +2 for padding on each side
+            c.CopyTo(objects, 1); // start at the second item at destination
+
+            Assert.Equal(
+                new[] { null, s, p, o, null },
+                objects);
+        }
+
+        [Fact]
+        public void Enumerates_subjects_by_predicate_and_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # 1
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # 2
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # 3
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicSubjectCollection(p, d);
+
+            var expected = new[] { s, p, o }.GetEnumerator();
+            using (var actual = c.GetEnumerator())
+            {
+                while (expected.MoveNext())
+                {
+                    actual.MoveNext();
+
+                    Assert.Equal(
+                        expected.Current,
+                        actual.Current);
+                }
+            }
+        }
+
+        [Fact]
+        public void Remove_retracts_by_predicate_object_and_argument_subject()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+# <urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # should retract
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> .
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> .
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var c = new DynamicSubjectCollection(p, d);
+
+            c.Remove(s);
+
+            Assert.Equal(
+                expected,
+                g);
+        }
+
+        [Fact]
+        public void IEnumerable_enumerates_subjects_by_predicate_and_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:s> <urn:s> .
+<urn:s> <urn:s> <urn:p> .
+<urn:s> <urn:s> <urn:o> .
+<urn:s> <urn:p> <urn:s> .
+<urn:s> <urn:p> <urn:p> .
+<urn:s> <urn:p> <urn:o> . # 1
+<urn:s> <urn:o> <urn:s> .
+<urn:s> <urn:o> <urn:p> .
+<urn:s> <urn:o> <urn:o> .
+<urn:p> <urn:s> <urn:s> .
+<urn:p> <urn:s> <urn:p> .
+<urn:p> <urn:s> <urn:o> .
+<urn:p> <urn:p> <urn:s> .
+<urn:p> <urn:p> <urn:p> .
+<urn:p> <urn:p> <urn:o> . # 2
+<urn:p> <urn:o> <urn:s> .
+<urn:p> <urn:o> <urn:p> .
+<urn:p> <urn:o> <urn:o> .
+<urn:o> <urn:s> <urn:s> .
+<urn:o> <urn:s> <urn:p> .
+<urn:o> <urn:s> <urn:o> .
+<urn:o> <urn:p> <urn:s> .
+<urn:o> <urn:p> <urn:p> .
+<urn:o> <urn:p> <urn:o> . # 3
+<urn:o> <urn:o> <urn:s> .
+<urn:o> <urn:o> <urn:p> .
+<urn:o> <urn:o> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            var c = new DynamicSubjectCollection(p, d) as IEnumerable;
+
+            var expected = new[] { s, p, o }.GetEnumerator();
+            var actual = c.GetEnumerator();
+            while (expected.MoveNext())
+            {
+                actual.MoveNext();
+
+                Assert.Equal(
+                    expected.Current,
+                    actual.Current);
+            }
+        }
+
+        [Fact]
+        public void Provides_meta_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> <urn:o> .");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(o);
+            var l = new DynamicSubjectCollection(p, d) as IDynamicMetaObjectProvider;
+            var mo = l.GetMetaObject(Expression.Empty());
+
+            Assert.NotNull(mo);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/EnumerableMetaObjectTests.cs
+++ b/Testing/unittest/Dynamic/EnumerableMetaObjectTests.cs
@@ -1,0 +1,143 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using VDS.RDF;
+    using Xunit;
+
+    public class EnumerableMetaObjectTests
+    {
+        [Fact]
+        public void Fails_no_generic_type_arguments()
+        {
+            var g = new Graph();
+            var s = g.CreateBlankNode();
+            var p = g.CreateBlankNode();
+            var d = new DynamicNode(s);
+            dynamic objects = new DynamicObjectCollection(d, p);
+
+            Assert.Throws<InvalidOperationException>(() =>
+                objects.Average());
+        }
+
+        [Fact]
+        public void Handles_one_generic_type_argument()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var o = g.CreateUriNode(UriFactory.Create("urn:o"));
+            var d = new DynamicNode(s);
+            dynamic objects = new DynamicObjectCollection(d, p);
+
+            Assert.Equal(o, objects.Single());
+        }
+
+        [Fact]
+        public void Handles_two_generic_type_arguments()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            dynamic objects = new DynamicObjectCollection(d, p);
+
+            Func<object, object> selector = n => n.ToString();
+
+            Assert.Equal(new[] { "urn:o" }, objects.Select(selector));
+        }
+
+        [Fact]
+        public void Handles_three_generic_type_arguments()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> ""a""@en .
+<urn:s> <urn:p> ""b""@en .
+<urn:s> <urn:p> ""c""@fr .
+<urn:s> <urn:p> ""d""@fr .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            dynamic objects = new DynamicObjectCollection(d, p);
+
+            Func<object, string> keySelector = n => ((ILiteralNode)n).Language;
+            Func<object, string> elementSelector = n => ((ILiteralNode)n).Value;
+
+            var result = objects.GroupBy(keySelector, elementSelector);
+
+            Assert.Collection(
+                (IEnumerable<IGrouping<object, object>>)result,
+                group =>
+                {
+                    Assert.Equal("en", group.Key);
+                    Assert.Equal(new[] { "a", "b" }, group);
+                },
+                group =>
+                {
+                    Assert.Equal("fr", group.Key);
+                    Assert.Equal(new[] { "c", "d" }, group);
+                });
+        }
+
+        [Fact]
+        public void Existing_methods_pass_through()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"
+<urn:s> <urn:s> <urn:o> .
+");
+
+            var g = new Graph();
+            g.LoadFromString(@"
+<urn:s> <urn:p> <urn:o> .
+<urn:s> <urn:s> <urn:o> .
+");
+
+            var s = g.CreateUriNode(UriFactory.Create("urn:s"));
+            var p = g.CreateUriNode(UriFactory.Create("urn:p"));
+            var d = new DynamicNode(s);
+            dynamic objects = new DynamicObjectCollection(d, p);
+
+            objects.Clear();
+
+            Assert.Equal(expected, g);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/Examples.NetFull.cs
+++ b/Testing/unittest/Dynamic/Examples.NetFull.cs
@@ -1,0 +1,135 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using Xunit;
+
+    public partial class Examples
+    {
+        [Fact]
+        public void Example3()
+        {
+            var expected = new Graph();
+            expected.LoadFromFile(@"resources\rvesse.ttl");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("http://www.dotnetrdf.org/people#"));
+
+            var rvesse = new FoafPerson(d.rvesse);
+            rvesse.Names.Add("Rob Vesse");
+            rvesse.FirstNames.Add("Rob");
+            rvesse.LastNames.Add("Vesse");
+            rvesse.Homepages.Add(UriFactory.Create("http://www.dotnetrdf.org/"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rav08r@ecs.soton.ac.uk"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rvesse@apache.org"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rvesse@cray.com"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rvesse@dotnetrdf.org"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rvesse@vdesign-studios.com"));
+            rvesse.Emails.Add(UriFactory.Create("mailto:rvesse@yarcdata.com"));
+
+            var account = new FoafAccount(d.CreateBlankNode());
+            account.Names.Add("RobVesse");
+            account.Profiles.Add(UriFactory.Create("http://twitter.com/RobVesse"));
+            account.Services.Add(UriFactory.Create("http://twitter.com/"));
+            rvesse.Accounts.Add(account);
+
+            var jena = new DoapProject(d.CreateBlankNode());
+            jena.Names.Add("Apache Jena");
+            jena.Homepages.Add(UriFactory.Create("http://incubator.apache.org/jena"));
+            rvesse.Projects.Add(jena);
+
+            var dnr = new DoapProject(d.CreateBlankNode());
+            dnr.Names.Add("dotNetRDF");
+            dnr.Homepages.Add(UriFactory.Create("http://www.dotnetrdf.org/"));
+            rvesse.Projects.Add(dnr);
+
+            var key = new WotKey(d.CreateBlankNode());
+            key.Ids.Add("6E2497EB");
+            key.Fingerprints.Add("7C4C 2916 BF74 E242 53BC  C5B7 764D FB13 6E24 97EB");
+            rvesse.Keys.Add(key);
+
+            Assert.Equal(expected, actual);
+        }
+
+        private class FoafPerson : DynamicNode
+        {
+            public FoafPerson(INode node)
+                : base(node, UriFactory.Create("http://xmlns.com/foaf/0.1/"))
+                => this.Add("rdf:type", UriFactory.Create("http://xmlns.com/foaf/0.1/Person"));
+
+            public ICollection<string> Names => new DynamicObjectCollection<string>(this, "name");
+
+            public ICollection<string> FirstNames => new DynamicObjectCollection<string>(this, "givenname");
+
+            public ICollection<string> LastNames => new DynamicObjectCollection<string>(this, "family_name");
+
+            public ICollection<Uri> Homepages => new DynamicObjectCollection<Uri>(this, "homepage");
+
+            public ICollection<Uri> Emails => new DynamicObjectCollection<Uri>(this, "mbox");
+
+            public ICollection<FoafAccount> Accounts => new DynamicObjectCollection<FoafAccount>(this, "OnlineAccount");
+
+            public ICollection<DoapProject> Projects => new DynamicObjectCollection<DoapProject>(this, "currentProject");
+
+            public ICollection<WotKey> Keys => new DynamicObjectCollection<WotKey>(this, "http://xmlns.com/wot/0.1/hasKey");
+        }
+
+        private class FoafAccount : DynamicNode
+        {
+            public FoafAccount(INode node)
+                : base(node, UriFactory.Create("http://xmlns.com/foaf/0.1/")) { }
+
+            public ICollection<string> Names => new DynamicObjectCollection<string>(this, "accountName");
+
+            public ICollection<Uri> Profiles => new DynamicObjectCollection<Uri>(this, "accountProfilePage");
+
+            public ICollection<Uri> Services => new DynamicObjectCollection<Uri>(this, "accountServiceHomepage");
+        }
+
+        private class DoapProject : DynamicNode
+        {
+            public DoapProject(INode node)
+                : base(node, UriFactory.Create("http://www.web-semantics.org/ns/pm#"))
+                => this.Add("rdf:type", UriFactory.Create("http://usefulinc.com/ns/doap#Project"));
+
+            public ICollection<string> Names => new DynamicObjectCollection<string>(this, "name");
+
+            public ICollection<Uri> Homepages => new DynamicObjectCollection<Uri>(this, "homepage");
+        }
+
+        private class WotKey : DynamicNode
+        {
+            public WotKey(INode node)
+                : base(node, UriFactory.Create("http://xmlns.com/wot/0.1/"))
+                => this.Add("rdf:type", UriFactory.Create("http://xmlns.com/wot/0.1/PubKey"));
+
+            public ICollection<string> Ids => new DynamicObjectCollection<string>(this, "hex_id");
+
+            public ICollection<string> Fingerprints => new DynamicObjectCollection<string>(this, "fingerprint");
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/Examples.cs
+++ b/Testing/unittest/Dynamic/Examples.cs
@@ -100,7 +100,7 @@ namespace VDS.RDF.Dynamic
             Assert.Equal("6E2497EB", hex_id);
         }
 
-        [Fact]
+        //[Fact]
         public void Example2()
         {
             var expected = new Graph();

--- a/Testing/unittest/Dynamic/Examples.cs
+++ b/Testing/unittest/Dynamic/Examples.cs
@@ -1,0 +1,550 @@
+﻿/*
+dotNetRDF is free and open source software licensed under the MIT License
+
+-----------------------------------------------------------------------------
+
+Copyright (c) 2009-2013 dotNetRDF Project (dotnetrdf-developer@lists.sf.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// 1. Allowed values for subjects and predicates (see DynamicExtensions.AsUriNode()):
+// - empty strings
+// - QName strings
+// - relative URI strings
+// - absolute URI strings
+// - relative URIs
+// - absolute URIs
+// - nodes
+
+// 2. Allowed types for objects (see DynamicExtensions.AsNode()):
+// - null
+// - INode
+// - Uri
+// - bool
+// - byte
+// - DateTime
+// - DateTimeOffset
+// - decimal
+// - double
+// - float
+// - long
+// - int
+// - string
+// - char
+// - TimeSpan
+// - IEnumerables with items of the above types
+
+// 3. Allowed values for predicateAndObjects
+// - null
+// - dictionary instances with keys from 1. and values from 2.
+// - anonymous class instances with values from 2.
+// - custom class instances with public properties with values from 2.
+
+namespace VDS.RDF.Dynamic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using VDS.RDF;
+    using VDS.RDF.Parsing;
+    using Xunit;
+
+    public partial class Examples
+    {
+        [Fact]
+        public void Example1()
+        {
+            var g = new Graph();
+            g.LoadFromFile(@"resources\rvesse.ttl");
+
+            var d = g.AsDynamic(UriFactory.Create("http://www.dotnetrdf.org/people#"), predicateBaseUri: UriFactory.Create("http://xmlns.com/foaf/0.1/"));
+
+            var rvesse = d.rvesse;
+            var onlineAccount = rvesse.OnlineAccount.Single();
+            var accountName = onlineAccount.accountName.Single();
+            var currentProjects = rvesse.currentProject;
+            var mbox = rvesse.mbox;
+            var hex_id = rvesse["wot:hasKey"].Single()["wot:hex_id"].Single();
+
+            Assert.Equal(g.CreateUriNode(UriFactory.Create("http://www.dotnetrdf.org/people#rvesse")), rvesse);
+            Assert.IsAssignableFrom<IBlankNode>(onlineAccount);
+            Assert.Equal("RobVesse", accountName);
+            Assert.Equal(2, currentProjects.Count());
+            Assert.Equal(
+                new[]
+                {
+                    "mailto:rav08r@ecs.soton.ac.uk",
+                    "mailto:rvesse@apache.org",
+                    "mailto:rvesse@cray.com",
+                    "mailto:rvesse@dotnetrdf.org",
+                    "mailto:rvesse@vdesign-studios.com",
+                    "mailto:rvesse@yarcdata.com"
+                },
+                ((IEnumerable<object>)mbox).Select(mb => mb.ToString()));
+            Assert.Equal("6E2497EB", hex_id);
+        }
+
+        [Fact]
+        public void Example2()
+        {
+            var expected = new Graph();
+            expected.LoadFromFile(@"resources\Turtle.ttl");
+
+            var g = new Graph();
+            g.BaseUri = UriFactory.Create("http://example.org/");
+            g.NamespaceMap.AddNamespace(string.Empty, UriFactory.Create("http://example.org/"));
+            g.NamespaceMap.AddNamespace("rdfs", UriFactory.Create("http://www.w3.org/2000/01/rdf-schema#"));
+
+            var d = g.AsDynamic();
+
+            d.one = new Dictionary<object, object>
+            {
+                {
+                    "rdf:type",
+                    d.CreateUriNode("rdfs:Class")
+                },
+                {
+                    "rdfs:label",
+                    new[]
+                    {
+                        "Example Literal",
+                        @"Example
+     
+Long Literal"
+                    }
+                },
+            };
+
+            d.two = new
+            {
+                age = new object[]
+                {
+                    23,
+                    23.6m
+                }
+            };
+
+            d.three = new
+            {
+                name = new object[]
+                {
+                    "Name",
+                    d.CreateLiteralNode("Nom", "fr")
+                }
+            };
+
+            d.four = new
+            {
+                male = false,
+                female = true
+            };
+
+            d.five = new
+            {
+                property = d.CreateUriNode(":value")
+            };
+
+            d.six = new
+            {
+                property = new object[]
+                {
+                    d.CreateLiteralNode("value", d.CreateUriNode(":customDataType").Uri),
+                    
+                    // Can't use DateTime because DateTimeNode default serialization is not as source
+                    d.CreateLiteralNode("2009-08-25T13:15:00+01:00", d.CreateUriNode("xsd:dateTime").Uri)
+                }
+            };
+
+            d[d.CreateBlankNode()]["rdf:type"] = d.CreateUriNode(":BlankNode");
+
+            var blankNodeCollection = d[d.CreateBlankNode()];
+            blankNodeCollection.property = new[]
+            {
+                d.CreateUriNode(":value"),
+                d.CreateUriNode(":otherValue")
+            };
+            blankNodeCollection["rdf:type"] = d.CreateUriNode(":BlankNodeCollection");
+
+            var collection = g.AssertList(new[]
+            {
+                g.CreateUriNode(":item1"),
+                g.CreateUriNode(":item2"),
+                g.CreateUriNode(":item3")
+            });
+            d[collection]["rdf:type"] = d.CreateUriNode(":Collection");
+
+            Assert.Equal<IGraph>(expected, g);
+        }
+
+        [Fact]
+        public void Graph_get_index()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var expected = g.CreateUriNode(UriFactory.Create("urn:s"));
+
+            // See 1. for other key options
+            var actual = d["s"];
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Graph_get_member()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var expected = g.CreateUriNode(UriFactory.Create("urn:s"));
+
+            var actual = d.s;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Graph_set_index()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 1. for other key options
+            // See 3. for other value options
+            d["s"] = new { p = "o" };
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Graph_set_member()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 3. for other value options
+            d.s = new { p = "o" };
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Graph_add()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph { BaseUri = UriFactory.Create("urn:") };
+            var d = actual.AsDynamic();
+
+            // See 1. for other key options
+            // See 3. for other value options
+            d.Add("s", new { p = "o" });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Graph_contains()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 1. for other key options
+            // See 3. for other value options
+            var condition = d.Contains("s", new { p = "o" });
+
+            Assert.True(condition);
+        }
+
+        [Fact]
+        public void Graph_contains_key()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 1. for other key options
+            var condition = d.ContainsKey("s");
+
+            Assert.True(condition);
+        }
+
+        [Fact]
+        public void Graph_remove_subject()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 1. for other key options
+            d.Remove("s");
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Graph_remove_subject_predicate_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+
+            // See 1. for other key options
+            // See 3. for other value options
+            d.Remove("s", new { p = "o" });
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Node_get_index()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var expected = "o".AsEnumerable();
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            var actual = s["p"];
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Node_get_member()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var expected = "o".AsEnumerable();
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            var actual = s.p;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Node_set_index()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            // See 2. for other value options
+            s["p"] = "o";
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Node_set_member()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 2. for other value options
+            s.p = "o";
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Node_add()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            // See 2. for other value options
+            s.Add("p", "o");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Node_contains()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            // See 2. for other value options
+            var condition = s.Contains("p", "o");
+
+            Assert.True(condition);
+        }
+
+        [Fact]
+        public void Node_contains_key()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            var condition = s.ContainsKey("p");
+
+            Assert.True(condition);
+        }
+
+        [Fact]
+        public void Node_clear()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            s.Clear();
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Node_remove_predicate()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            s.Remove("p");
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Node_remove_predicate_object()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var s = d.s;
+
+            // See 1. for other key options
+            // See 2. for other value options
+            s.Remove("p", "o");
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Object_collection_count()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var expected = 1;
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var sp = d.s.p;
+
+            var actual = sp.Count;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Object_collection_add()
+        {
+            var expected = new Graph();
+            expected.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var actual = new Graph();
+            var d = actual.AsDynamic(UriFactory.Create("urn:"));
+            var sp = d.s.p;
+
+            // See 2. for other value options
+            sp.Add("o");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Object_collection_clear()
+        {
+            var g = new Graph();
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var sp = d.s.p;
+
+            sp.Clear();
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Object_collection_contains()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var sp = d.s.p;
+
+            // See 2. for other value options
+            var condition = sp.Contains("o");
+
+            Assert.True(condition);
+        }
+
+        [Fact]
+        public void Object_collection_remove()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var sp = d.s.p;
+
+            // See 2. for other value options
+            sp.Remove("o");
+
+            Assert.True(g.IsEmpty);
+        }
+
+        [Fact]
+        public void Object_collection_linq()
+        {
+            var g = new Graph();
+            g.LoadFromString(@"<urn:s> <urn:p> ""o"" .");
+            var d = g.AsDynamic(UriFactory.Create("urn:"));
+            var expected = "o";
+            var sp = d.s.p;
+
+            var actual = sp.Single();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Testing/unittest/Dynamic/Examples.cs
+++ b/Testing/unittest/Dynamic/Examples.cs
@@ -100,7 +100,7 @@ namespace VDS.RDF.Dynamic
             Assert.Equal("6E2497EB", hex_id);
         }
 
-        //[Fact]
+        [Fact]
         public void Example2()
         {
             var expected = new Graph();
@@ -124,9 +124,7 @@ namespace VDS.RDF.Dynamic
                     new[]
                     {
                         "Example Literal",
-                        @"Example
-     
-Long Literal"
+                        "Example\r\n     \r\nLong Literal"
                     }
                 },
             };


### PR DESCRIPTION
Inspired by @mattrayner's [GROM](https://github.com/ukparliament/grom), which is used extensively in @ukparliament's [new website](https://beta.parliament.uk/). Used in [this ASP.NET Core SKOS viewer](https://github.com/ukparliament/VocabularyBrowser) for [Parliament's Controlled Vocabulary](https://api.parliament.uk/vocabulary/browser)

---
# Dynamic graphs and nodes
This feature adds read/write dictionary and dynamic capabilities to `IGraph` and `INode` by implementing `IDictionary<>` and `IDynamicMetaObjectProvider` on `WrapperGraph` and `WrapperNode`.

## Examples
Tests in the Example class ([1](https://github.com/langsamu/dotnetrdf/blob/4b5dcc0a70c5480e99c0876604de4b30bc4787e0/Testing/unittest/Dynamic/Examples.cs), [2](https://github.com/langsamu/dotnetrdf/blob/4b5dcc0a70c5480e99c0876604de4b30bc4787e0/Testing/unittest/Dynamic/Examples.NetFull.cs)) give an overview of feature details.

---
**I'd appreciate feedback and help making this PR better.**