### PR TITLE
Changed sorting for TurtleWriter.GenerateOutput(TurtleWriterContext c…

### DIFF
--- a/Libraries/dotNetRDF/Writing/TurtleWriter.cs
+++ b/Libraries/dotNetRDF/Writing/TurtleWriter.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -43,7 +43,7 @@ namespace VDS.RDF.Writing
     /// </remarks>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     [Obsolete("Deprecated in favour of the CompressionTurtleWriter which uses a much fuller range of syntax compressions", false)]
-    public class TurtleWriter 
+    public class TurtleWriter
         : BaseRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
@@ -69,14 +69,8 @@ namespace VDS.RDF.Writing
         /// </summary>
         public bool PrettyPrintMode
         {
-            get
-            {
-                return _prettyprint;
-            }
-            set
-            {
-                _prettyprint = value;
-            }
+            get => _prettyprint;
+            set => _prettyprint = value;
         }
 
         /// <summary>
@@ -85,26 +79,14 @@ namespace VDS.RDF.Writing
         /// <remarks>High Speed Write Mode is engaged when the Writer determines that the contents of the Graph are not well suited to Turtle syntax compressions.  Usually the writer compresses triples into groups by Subject using Predicate-Object lists to output the Triples relating to each Subject.  If the number of distinct Subjects is greater than 75% of the Triples in the Graph then High Speed write mode will be used, in High Speed mode all Triples are written fully and no grouping of any sort is done.</remarks>
         public bool HighSpeedModePermitted
         {
-            get
-            {
-                return _allowhispeed;
-            }
-            set
-            {
-                _allowhispeed = value;
-            }
+            get => _allowhispeed;
+            set => _allowhispeed = value;
         }
 
         /// <summary>
         /// Gets the type of the Triple Formatter used by this writer
         /// </summary>
-        public Type TripleFormatterType
-        {
-            get
-            {
-                return (_syntax == TurtleSyntax.Original ? typeof(TurtleFormatter) : typeof(TurtleW3CFormatter));
-            }
-        }
+        public Type TripleFormatterType => (_syntax == TurtleSyntax.Original ? typeof(TurtleFormatter) : typeof(TurtleW3CFormatter));
 
         /// <summary>
         /// Saves a Graph to a File
@@ -144,12 +126,12 @@ namespace VDS.RDF.Writing
             }
 
             // Write Prefixes
-            foreach (String prefix in context.Graph.NamespaceMap.Prefixes)
+            foreach (string prefix in context.Graph.NamespaceMap.Prefixes)
             {
                 if (TurtleSpecsHelper.IsValidQName(prefix + ":", _syntax))
                 {
                     context.Output.Write("@prefix " + prefix + ": <");
-                    String nsUri = context.UriFormatter.FormatUri(context.Graph.NamespaceMap.GetNamespaceUri(prefix));
+                    string nsUri = context.UriFormatter.FormatUri(context.Graph.NamespaceMap.GetNamespaceUri(prefix));
                     context.Output.WriteLine(nsUri + ">.");
                 }
             }
@@ -159,7 +141,10 @@ namespace VDS.RDF.Writing
             bool hiSpeed = false;
             double subjNodes = context.Graph.Triples.SubjectNodes.Count();
             double triples = context.Graph.Triples.Count;
-            if ((subjNodes / triples) > 0.75) hiSpeed = true;
+            if ((subjNodes / triples) > 0.75)
+            {
+                hiSpeed = true;
+            }
 
             if (hiSpeed && context.HighSpeedModePermitted)
             {
@@ -182,13 +167,49 @@ namespace VDS.RDF.Writing
 
                 // Get the Triples as a Sorted List
                 List<Triple> ts = context.Graph.Triples.ToList();
-                ts.Sort(new FullTripleComparer(new FastNodeComparer()));
+                int capacity = ts.Count;
+                Dictionary<INode, Dictionary<INode, Dictionary<INode, List<Triple>>>> sortHelperDictionary = new Dictionary<INode, Dictionary<INode, Dictionary<INode, List<Triple>>>>(capacity);
+                // Fill dictionary
+                foreach (Triple triple in ts)
+                {
+                    if (!sortHelperDictionary.ContainsKey(triple.Subject)) { sortHelperDictionary.Add(triple.Subject, new Dictionary<INode, Dictionary<INode, List<Triple>>>()); }
+
+                    if (!sortHelperDictionary[triple.Subject].ContainsKey(triple.Predicate)) { sortHelperDictionary[triple.Subject].Add(triple.Predicate, new Dictionary<INode, List<Triple>>()); }
+
+                    if (!sortHelperDictionary[triple.Subject][triple.Predicate].ContainsKey(triple.Object)) { sortHelperDictionary[triple.Subject][triple.Predicate].Add(triple.Object, new List<Triple>()); }
+
+                    sortHelperDictionary[triple.Subject][triple.Predicate][triple.Object].Add(triple);
+                }
+
+                ts.Clear();
+                var keys = sortHelperDictionary.Keys.ToArray();
+                Array.Sort(keys, new FastNodeComparer());
+                foreach (var subjectKey in keys)
+                {
+                    var predicateKeys = sortHelperDictionary[subjectKey].Keys.ToArray();
+                    Array.Sort(predicateKeys, new FastNodeComparer());
+                    foreach (var predicatekey in predicateKeys)
+                    {
+                        var objectKeys = sortHelperDictionary[subjectKey][predicatekey].Keys.ToArray();
+                        Array.Sort(objectKeys, new FastNodeComparer());
+                        foreach (var objectKey in objectKeys)
+                        {
+                            var triplesSubset = sortHelperDictionary[subjectKey][predicatekey][objectKey];
+                            if (triplesSubset.Count > 1)
+                            {
+                                triplesSubset.Sort(new FullTripleComparer(new FastNodeComparer()));
+                            }
+
+                            ts.AddRange(triplesSubset);
+                        }
+                    }
+                }
 
                 // Variables we need to track our writing
                 INode lastSubj, lastPred;
                 lastSubj = lastPred = null;
                 int subjIndent = 0, predIndent = 0;
-                String temp;
+                string temp;
 
                 for (int i = 0; i < ts.Count; i++)
                 {
@@ -196,7 +217,10 @@ namespace VDS.RDF.Writing
                     if (lastSubj == null || !t.Subject.Equals(lastSubj))
                     {
                         // Terminate previous Triples
-                        if (lastSubj != null) context.Output.WriteLine(".");
+                        if (lastSubj != null)
+                        {
+                            context.Output.WriteLine(".");
+                        }
 
                         // Start a new set of Triples
                         temp = GenerateNodeOutput(context, t.Subject, TripleSegment.Subject);
@@ -217,7 +241,10 @@ namespace VDS.RDF.Writing
                         // Terminate previous Predicate Object list
                         context.Output.WriteLine(";");
 
-                        if (context.PrettyPrint) context.Output.Write(new String(' ', subjIndent));
+                        if (context.PrettyPrint)
+                        {
+                            context.Output.Write(new string(' ', subjIndent));
+                        }
 
                         // Write the next Predicate
                         temp = GenerateNodeOutput(context, t.Predicate, TripleSegment.Predicate);
@@ -231,7 +258,10 @@ namespace VDS.RDF.Writing
                         // Continue Object List
                         context.Output.WriteLine(",");
 
-                        if (context.PrettyPrint) context.Output.Write(new String(' ', subjIndent + predIndent));
+                        if (context.PrettyPrint)
+                        {
+                            context.Output.Write(new string(' ', subjIndent + predIndent));
+                        }
                     }
 
                     // Write the Object
@@ -239,7 +269,10 @@ namespace VDS.RDF.Writing
                 }
 
                 // Terminate Triples
-                if (ts.Count > 0) context.Output.WriteLine(".");
+                if (ts.Count > 0)
+                {
+                    context.Output.WriteLine(".");
+                }
             }
         }
 
@@ -250,20 +283,32 @@ namespace VDS.RDF.Writing
         /// <param name="n">Node to generate Output for</param>
         /// <param name="segment">Segment of the Triple being written</param>
         /// <returns></returns>
-        private String GenerateNodeOutput(TurtleWriterContext context, INode n, TripleSegment segment)
+        private string GenerateNodeOutput(TurtleWriterContext context, INode n, TripleSegment segment)
         {
             switch (n.NodeType)
             {
                 case NodeType.Blank:
-                    if (segment == TripleSegment.Predicate) throw new RdfOutputException(WriterErrorMessages.BlankPredicatesUnserializable("Turtle"));
+                    if (segment == TripleSegment.Predicate)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.BlankPredicatesUnserializable("Turtle"));
+                    }
+
                     return context.NodeFormatter.Format(n, segment);
 
                 case NodeType.GraphLiteral:
                     throw new RdfOutputException(WriterErrorMessages.GraphLiteralsUnserializable("Turtle"));
 
                 case NodeType.Literal:
-                    if (segment == TripleSegment.Subject) throw new RdfOutputException(WriterErrorMessages.LiteralSubjectsUnserializable("Turtle"));
-                    if (segment == TripleSegment.Predicate) throw new RdfOutputException(WriterErrorMessages.LiteralPredicatesUnserializable("Turtle"));
+                    if (segment == TripleSegment.Subject)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.LiteralSubjectsUnserializable("Turtle"));
+                    }
+
+                    if (segment == TripleSegment.Predicate)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.LiteralPredicatesUnserializable("Turtle"));
+                    }
+
                     return context.NodeFormatter.Format(n, segment);
 
                 case NodeType.Uri:
@@ -278,7 +323,7 @@ namespace VDS.RDF.Writing
         /// Helper method for raising the <see cref="Warning">Warning</see> event
         /// </summary>
         /// <param name="message">Warning Message</param>
-        private void RaiseWarning(String message)
+        private void RaiseWarning(string message)
         {
             RdfWriterWarning d = Warning;
             if (d != null)


### PR DESCRIPTION
…ontext)

Altered the List<triple>.Sort to use a layered dictionary (dictionary(subjectnode, dictionary( predicatenode, dictionary (objectnode, list<triple>))))
 and sorting the keys for each dictionary using the FastNodeComparer. Then use a list sort on each of the list<triples>, which is probable superfluous but if there are more than one it should sort, using FullTripleComparer(new FastNodeComparer()).

Because each of the sets are much smaller the sorting will be much faster.