### PR TITLE
Feature/triple collection performance

### DIFF
--- a/Libraries/dotNetRDF/Core/BaseTripleCollection.cs
+++ b/Libraries/dotNetRDF/Core/BaseTripleCollection.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -44,7 +44,7 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="t">Triple to add</param>
         /// <remarks>Adding a Triple that already exists should be permitted though it is not necessary to persist the duplicate to underlying storage</remarks>
-        protected abstract internal bool Add(Triple t);
+        protected internal abstract bool Add(Triple t);
 
         /// <summary>
         /// Determines whether a given Triple is in the Triple Collection
@@ -56,9 +56,9 @@ namespace VDS.RDF
         /// <summary>
         /// Gets the Number of Triples in the Triple Collection
         /// </summary>
-        public abstract int Count 
-        { 
-            get; 
+        public abstract int Count
+        {
+            get;
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="t">Triple to remove</param>
         /// <remarks>Deleting something that doesn't exist should have no effect and give no error</remarks>
-        protected abstract internal bool Delete(Triple t);
+        protected internal abstract bool Delete(Triple t);
 
         /// <summary>
         /// Gets the given Triple
@@ -82,24 +82,24 @@ namespace VDS.RDF
         /// <summary>
         /// Gets all the Nodes which are Objects of Triples in the Triple Collection
         /// </summary>
-        public abstract IEnumerable<INode> ObjectNodes 
-        { 
-            get; 
+        public abstract IEnumerable<INode> ObjectNodes
+        {
+            get;
         }
 
         /// <summary>
         /// Gets all the Nodes which are Predicates of Triples in the Triple Collection
         /// </summary>
-        public abstract IEnumerable<INode> PredicateNodes 
+        public abstract IEnumerable<INode> PredicateNodes
         {
-            get; 
+            get;
         }
 
         /// <summary>
         /// Gets all the Nodes which are Subjects of Triples in the Triple Collection
         /// </summary>
-        public abstract IEnumerable<INode> SubjectNodes 
-        { 
+        public abstract IEnumerable<INode> SubjectNodes
+        {
             get;
         }
 
@@ -110,9 +110,14 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithSubject(INode subj)
         {
-            return (from t in this
-                    where t.Subject.Equals(subj)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Subject.Equals(subj))
+                {
+                    yield return t;
+                }
+            }
+            yield break;
         }
 
         /// <summary>
@@ -122,9 +127,15 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithPredicate(INode pred)
         {
-            return (from t in this
-                    where t.Predicate.Equals(pred)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Predicate.Equals(pred))
+                {
+                    yield return t;
+                }
+            }
+
+            yield break;
         }
 
         /// <summary>
@@ -134,9 +145,15 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithObject(INode obj)
         {
-            return (from t in this
-                    where t.Object.Equals(obj)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Object.Equals(obj))
+                {
+                    yield return t;
+                }
+            }
+
+            yield break;
         }
 
         /// <summary>
@@ -147,9 +164,15 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithSubjectPredicate(INode subj, INode pred)
         {
-            return (from t in WithSubject(subj)
-                    where t.Predicate.Equals(pred)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Subject.Equals(subj) && t.Predicate.Equals(pred))
+                {
+                    yield return t;
+                }
+            }
+
+            yield break;
         }
 
         /// <summary>
@@ -160,9 +183,15 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithPredicateObject(INode pred, INode obj)
         {
-            return (from t in WithPredicate(pred)
-                    where t.Object.Equals(obj)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Predicate.Equals(pred) && t.Object.Equals(obj))
+                {
+                    yield return t;
+                }
+            }
+
+            yield break;
         }
 
         /// <summary>
@@ -173,9 +202,15 @@ namespace VDS.RDF
         /// <returns></returns>
         public virtual IEnumerable<Triple> WithSubjectObject(INode subj, INode obj)
         {
-            return (from t in WithSubject(subj)
-                    where t.Object.Equals(obj)
-                    select t);
+            foreach (var t in this)
+            {
+                if (t.Subject.Equals(subj) && t.Object.Equals(obj))
+                {
+                    yield return t;
+                }
+            }
+
+            yield break;
         }
 
         /// <summary>

--- a/Libraries/dotNetRDF/Core/TripleCollection.cs
+++ b/Libraries/dotNetRDF/Core/TripleCollection.cs
@@ -170,16 +170,28 @@ namespace VDS.RDF
                 if (_triplesSubjects.ContainsKey(t.Subject))
                 {
                     _triplesSubjects[t.Subject].Remove(t);
+                    if (_triplesSubjects[t.Subject].Count == 0)
+                    {
+                        _triplesSubjects.Remove(t.Subject);
+                    }
                 }
 
                 if (_triplesObjects.ContainsKey(t.Object))
                 {
                     _triplesObjects[t.Object].Remove(t);
+                    if (_triplesObjects[t.Object].Count == 0)
+                    {
+                        _triplesObjects.Remove(t.Object);
+                    }
                 }
 
                 if (_triplesPredicates.ContainsKey(t.Predicate))
                 {
                     _triplesPredicates[t.Predicate].Remove(t);
+                    if (_triplesPredicates[t.Predicate].Count == 0)
+                    {
+                        _triplesPredicates.Remove(t.Predicate);
+                    }
                 }
 
                 if (_triplesSubjectsPredicates.ContainsKey(t.Subject))
@@ -187,6 +199,15 @@ namespace VDS.RDF
                     if (_triplesSubjectsPredicates[t.Subject].ContainsKey(t.Predicate))
                     {
                         _triplesSubjectsPredicates[t.Subject][t.Predicate].Remove(t);
+                        if (_triplesSubjectsPredicates[t.Subject][t.Predicate].Count == 0)
+                        {
+                            _triplesSubjectsPredicates[t.Subject].Remove(t.Predicate);
+                        }
+
+                        if (_triplesSubjectsPredicates[t.Subject].Count == 0)
+                        {
+                            _triplesSubjectsPredicates.Remove(t.Subject);
+                        }
                     }
                 }
 
@@ -195,6 +216,15 @@ namespace VDS.RDF
                     if (_triplesPredicatesObjects[t.Predicate].ContainsKey(t.Object))
                     {
                         _triplesPredicatesObjects[t.Predicate][t.Object].Remove(t);
+                        if (_triplesPredicatesObjects[t.Predicate][t.Object].Count == 0)
+                        {
+                            _triplesPredicatesObjects[t.Predicate].Remove(t.Object);
+                        }
+
+                        if (_triplesPredicatesObjects[t.Predicate].Count == 0)
+                        {
+                            _triplesPredicatesObjects.Remove(t.Predicate);
+                        }
                     }
                 }
 
@@ -203,6 +233,15 @@ namespace VDS.RDF
                     if (_triplesSubjectsObjects[t.Subject].ContainsKey(t.Object))
                     {
                         _triplesSubjectsObjects[t.Subject][t.Object].Remove(t);
+                        if (_triplesSubjectsObjects[t.Subject][t.Object].Count == 0)
+                        {
+                            _triplesSubjectsObjects[t.Subject].Remove(t.Object);
+                        }
+
+                        if (_triplesSubjectsObjects[t.Subject].Count == 0)
+                        {
+                            _triplesSubjectsObjects.Remove(t.Subject);
+                        }
                     }
                 }
                 RaiseTripleRemoved(t);

--- a/Libraries/dotNetRDF/Core/TripleComparers.cs
+++ b/Libraries/dotNetRDF/Core/TripleComparers.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -46,7 +46,10 @@ namespace VDS.RDF
         /// <returns></returns>
         public int Compare(INode x, INode y)
         {
-            if (ReferenceEquals(x, y)) return 0;
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
 
             if (x == null)
             {
@@ -66,12 +69,15 @@ namespace VDS.RDF
 
             if (x is IVirtualIdComparable && y is IVirtualIdComparable)
             {
-                if ((x as IVirtualIdComparable).TryCompareVirtualId(y, out int result)) return result;
+                if ((x as IVirtualIdComparable).TryCompareVirtualId(y, out int result))
+                {
+                    return result;
+                }
             }
 
             if (x.NodeType == NodeType.Literal && y.NodeType == NodeType.Literal)
             {
-                // Use faster comparison for literals - standard comparison is valued based 
+                // Use faster comparison for literals - standard comparison is valued based
                 // and so gets slower as amount of nodes to compare gets larger
 
                 // Sort order for literals is as follows
@@ -100,9 +106,9 @@ namespace VDS.RDF
                         return 1;
                     }
                 }
-                else if (!a.Language.Equals(String.Empty))
+                else if (!a.Language.Equals(string.Empty))
                 {
-                    if (!b.Language.Equals(String.Empty))
+                    if (!b.Language.Equals(string.Empty))
                     {
                         // Compare language specifiers
                         int c = a.Language.CompareTo(b.Language);
@@ -165,7 +171,10 @@ namespace VDS.RDF
         /// <returns></returns>
         public int Compare(INode x, INode y)
         {
-            if (ReferenceEquals(x, y)) return 0;
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
 
             if (x == null)
             {
@@ -185,7 +194,7 @@ namespace VDS.RDF
 
             if (x.NodeType == NodeType.Literal && y.NodeType == NodeType.Literal)
             {
-                // Use faster comparison for literals - standard comparison is valued based 
+                // Use faster comparison for literals - standard comparison is valued based
                 // and so gets slower as amount of nodes to compare gets larger
 
                 // Sort order for literals is as follows
@@ -214,9 +223,9 @@ namespace VDS.RDF
                         return 1;
                     }
                 }
-                else if (!a.Language.Equals(String.Empty))
+                else if (!a.Language.Equals(string.Empty))
                 {
-                    if (!b.Language.Equals(String.Empty))
+                    if (!b.Language.Equals(string.Empty))
                     {
                         // Compare language specifiers
                         int c = a.Language.CompareTo(b.Language);
@@ -250,7 +259,7 @@ namespace VDS.RDF
         /// <inheritdoc />
         public bool Equals(INode x, INode y)
         {
-            return Compare(x,y)==0;
+            return Compare(x, y) == 0;
         }
 
         /// <inheritdoc />
@@ -264,7 +273,7 @@ namespace VDS.RDF
     /// Compares triples for equality
     /// </summary>
     public class TripleEqualityComparer : IEqualityComparer<Triple>
-    { 
+    {
 
         /// <summary>
         /// Returns whether two Triples are equal
@@ -292,7 +301,7 @@ namespace VDS.RDF
     /// Abstract base class for Triple Comparers which provide for comparisons using different node comparers
     /// </summary>
     public abstract class BaseTripleComparer
-        : IComparer<Triple>
+        : TripleEqualityComparer, IComparer<Triple>
     {
         /// <summary>
         /// Node Comparer
@@ -430,7 +439,7 @@ namespace VDS.RDF
     /// <summary>
     /// Triple comparer which compares only on objects
     /// </summary>
-    public class ObjectComparer 
+    public class ObjectComparer
         : BaseTripleComparer
     {
         /// <summary>

--- a/Libraries/dotNetRDF/Writing/TurtleWriter.cs
+++ b/Libraries/dotNetRDF/Writing/TurtleWriter.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -43,7 +43,7 @@ namespace VDS.RDF.Writing
     /// </remarks>
     /// <threadsafety instance="true">Designed to be Thread Safe - should be able to call the Save() method from multiple threads on different Graphs without issue</threadsafety>
     [Obsolete("Deprecated in favour of the CompressionTurtleWriter which uses a much fuller range of syntax compressions", false)]
-    public class TurtleWriter 
+    public class TurtleWriter
         : BaseRdfWriter, IPrettyPrintingWriter, IHighSpeedWriter, IFormatterBasedWriter
     {
         private bool _prettyprint = true;
@@ -69,14 +69,8 @@ namespace VDS.RDF.Writing
         /// </summary>
         public bool PrettyPrintMode
         {
-            get
-            {
-                return _prettyprint;
-            }
-            set
-            {
-                _prettyprint = value;
-            }
+            get => _prettyprint;
+            set => _prettyprint = value;
         }
 
         /// <summary>
@@ -85,26 +79,14 @@ namespace VDS.RDF.Writing
         /// <remarks>High Speed Write Mode is engaged when the Writer determines that the contents of the Graph are not well suited to Turtle syntax compressions.  Usually the writer compresses triples into groups by Subject using Predicate-Object lists to output the Triples relating to each Subject.  If the number of distinct Subjects is greater than 75% of the Triples in the Graph then High Speed write mode will be used, in High Speed mode all Triples are written fully and no grouping of any sort is done.</remarks>
         public bool HighSpeedModePermitted
         {
-            get
-            {
-                return _allowhispeed;
-            }
-            set
-            {
-                _allowhispeed = value;
-            }
+            get => _allowhispeed;
+            set => _allowhispeed = value;
         }
 
         /// <summary>
         /// Gets the type of the Triple Formatter used by this writer
         /// </summary>
-        public Type TripleFormatterType
-        {
-            get
-            {
-                return (_syntax == TurtleSyntax.Original ? typeof(TurtleFormatter) : typeof(TurtleW3CFormatter));
-            }
-        }
+        public Type TripleFormatterType => (_syntax == TurtleSyntax.Original ? typeof(TurtleFormatter) : typeof(TurtleW3CFormatter));
 
         /// <summary>
         /// Saves a Graph to a File
@@ -144,12 +126,12 @@ namespace VDS.RDF.Writing
             }
 
             // Write Prefixes
-            foreach (String prefix in context.Graph.NamespaceMap.Prefixes)
+            foreach (string prefix in context.Graph.NamespaceMap.Prefixes)
             {
                 if (TurtleSpecsHelper.IsValidQName(prefix + ":", _syntax))
                 {
                     context.Output.Write("@prefix " + prefix + ": <");
-                    String nsUri = context.UriFormatter.FormatUri(context.Graph.NamespaceMap.GetNamespaceUri(prefix));
+                    string nsUri = context.UriFormatter.FormatUri(context.Graph.NamespaceMap.GetNamespaceUri(prefix));
                     context.Output.WriteLine(nsUri + ">.");
                 }
             }
@@ -159,7 +141,10 @@ namespace VDS.RDF.Writing
             bool hiSpeed = false;
             double subjNodes = context.Graph.Triples.SubjectNodes.Count();
             double triples = context.Graph.Triples.Count;
-            if ((subjNodes / triples) > 0.75) hiSpeed = true;
+            if ((subjNodes / triples) > 0.75)
+            {
+                hiSpeed = true;
+            }
 
             if (hiSpeed && context.HighSpeedModePermitted)
             {
@@ -182,13 +167,49 @@ namespace VDS.RDF.Writing
 
                 // Get the Triples as a Sorted List
                 List<Triple> ts = context.Graph.Triples.ToList();
-                ts.Sort(new FullTripleComparer(new FastNodeComparer()));
+                int capacity = ts.Count;
+                Dictionary<INode, Dictionary<INode, Dictionary<INode, List<Triple>>>> sortHelperDictionary = new Dictionary<INode, Dictionary<INode, Dictionary<INode, List<Triple>>>>(capacity);
+                // Fill dictionary
+                foreach (Triple triple in ts)
+                {
+                    if (!sortHelperDictionary.ContainsKey(triple.Subject)) { sortHelperDictionary.Add(triple.Subject, new Dictionary<INode, Dictionary<INode, List<Triple>>>()); }
+
+                    if (!sortHelperDictionary[triple.Subject].ContainsKey(triple.Predicate)) { sortHelperDictionary[triple.Subject].Add(triple.Predicate, new Dictionary<INode, List<Triple>>()); }
+
+                    if (!sortHelperDictionary[triple.Subject][triple.Predicate].ContainsKey(triple.Object)) { sortHelperDictionary[triple.Subject][triple.Predicate].Add(triple.Object, new List<Triple>()); }
+
+                    sortHelperDictionary[triple.Subject][triple.Predicate][triple.Object].Add(triple);
+                }
+
+                ts.Clear();
+                var keys = sortHelperDictionary.Keys.ToArray();
+                Array.Sort(keys, new FastNodeComparer());
+                foreach (var subjectKey in keys)
+                {
+                    var predicateKeys = sortHelperDictionary[subjectKey].Keys.ToArray();
+                    Array.Sort(predicateKeys, new FastNodeComparer());
+                    foreach (var predicatekey in predicateKeys)
+                    {
+                        var objectKeys = sortHelperDictionary[subjectKey][predicatekey].Keys.ToArray();
+                        Array.Sort(objectKeys, new FastNodeComparer());
+                        foreach (var objectKey in objectKeys)
+                        {
+                            var triplesSubset = sortHelperDictionary[subjectKey][predicatekey][objectKey];
+                            if (triplesSubset.Count > 1)
+                            {
+                                triplesSubset.Sort(new FullTripleComparer(new FastNodeComparer()));
+                            }
+
+                            ts.AddRange(triplesSubset);
+                        }
+                    }
+                }
 
                 // Variables we need to track our writing
                 INode lastSubj, lastPred;
                 lastSubj = lastPred = null;
                 int subjIndent = 0, predIndent = 0;
-                String temp;
+                string temp;
 
                 for (int i = 0; i < ts.Count; i++)
                 {
@@ -196,7 +217,10 @@ namespace VDS.RDF.Writing
                     if (lastSubj == null || !t.Subject.Equals(lastSubj))
                     {
                         // Terminate previous Triples
-                        if (lastSubj != null) context.Output.WriteLine(".");
+                        if (lastSubj != null)
+                        {
+                            context.Output.WriteLine(".");
+                        }
 
                         // Start a new set of Triples
                         temp = GenerateNodeOutput(context, t.Subject, TripleSegment.Subject);
@@ -217,7 +241,10 @@ namespace VDS.RDF.Writing
                         // Terminate previous Predicate Object list
                         context.Output.WriteLine(";");
 
-                        if (context.PrettyPrint) context.Output.Write(new String(' ', subjIndent));
+                        if (context.PrettyPrint)
+                        {
+                            context.Output.Write(new string(' ', subjIndent));
+                        }
 
                         // Write the next Predicate
                         temp = GenerateNodeOutput(context, t.Predicate, TripleSegment.Predicate);
@@ -231,7 +258,10 @@ namespace VDS.RDF.Writing
                         // Continue Object List
                         context.Output.WriteLine(",");
 
-                        if (context.PrettyPrint) context.Output.Write(new String(' ', subjIndent + predIndent));
+                        if (context.PrettyPrint)
+                        {
+                            context.Output.Write(new string(' ', subjIndent + predIndent));
+                        }
                     }
 
                     // Write the Object
@@ -239,7 +269,10 @@ namespace VDS.RDF.Writing
                 }
 
                 // Terminate Triples
-                if (ts.Count > 0) context.Output.WriteLine(".");
+                if (ts.Count > 0)
+                {
+                    context.Output.WriteLine(".");
+                }
             }
         }
 
@@ -250,20 +283,32 @@ namespace VDS.RDF.Writing
         /// <param name="n">Node to generate Output for</param>
         /// <param name="segment">Segment of the Triple being written</param>
         /// <returns></returns>
-        private String GenerateNodeOutput(TurtleWriterContext context, INode n, TripleSegment segment)
+        private string GenerateNodeOutput(TurtleWriterContext context, INode n, TripleSegment segment)
         {
             switch (n.NodeType)
             {
                 case NodeType.Blank:
-                    if (segment == TripleSegment.Predicate) throw new RdfOutputException(WriterErrorMessages.BlankPredicatesUnserializable("Turtle"));
+                    if (segment == TripleSegment.Predicate)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.BlankPredicatesUnserializable("Turtle"));
+                    }
+
                     return context.NodeFormatter.Format(n, segment);
 
                 case NodeType.GraphLiteral:
                     throw new RdfOutputException(WriterErrorMessages.GraphLiteralsUnserializable("Turtle"));
 
                 case NodeType.Literal:
-                    if (segment == TripleSegment.Subject) throw new RdfOutputException(WriterErrorMessages.LiteralSubjectsUnserializable("Turtle"));
-                    if (segment == TripleSegment.Predicate) throw new RdfOutputException(WriterErrorMessages.LiteralPredicatesUnserializable("Turtle"));
+                    if (segment == TripleSegment.Subject)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.LiteralSubjectsUnserializable("Turtle"));
+                    }
+
+                    if (segment == TripleSegment.Predicate)
+                    {
+                        throw new RdfOutputException(WriterErrorMessages.LiteralPredicatesUnserializable("Turtle"));
+                    }
+
                     return context.NodeFormatter.Format(n, segment);
 
                 case NodeType.Uri:
@@ -278,7 +323,7 @@ namespace VDS.RDF.Writing
         /// Helper method for raising the <see cref="Warning">Warning</see> event
         /// </summary>
         /// <param name="message">Warning Message</param>
-        private void RaiseWarning(String message)
+        private void RaiseWarning(string message)
         {
             RdfWriterWarning d = Warning;
             if (d != null)

--- a/Testing/unittest/Update/LoadTests.cs
+++ b/Testing/unittest/Update/LoadTests.cs
@@ -25,9 +25,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 using System;
 using System.IO;
 using System.Linq;
-using Xunit;
 using VDS.RDF.Parsing;
 using VDS.RDF.Writing;
+using Xunit;
 
 namespace VDS.RDF.Update
 {
@@ -98,8 +98,8 @@ namespace VDS.RDF.Update
         {
             var tripleStore = new TripleStore();
 
-            String g1 = Path.GetFullPath(@"resources\core-421\g1.nq").Replace('\\','/');
-            String g2 = Path.GetFullPath(@"resources\core-421\g2.nq").Replace('\\','/');
+            string g1 = Path.GetFullPath(@"resources\core-421\g1.nq").Replace('\\', '/').Replace(" ", "%20");
+            string g2 = Path.GetFullPath(@"resources\core-421\g2.nq").Replace('\\', '/').Replace(" ", "%20");
 
             tripleStore.ExecuteUpdate("LOAD <file:///" + g1 + "> into graph <http://test.org/user>");
             tripleStore.ExecuteUpdate("LOAD <file:///" + g2 + "> into graph <http://test.org/prodList/>");


### PR DESCRIPTION
Changed the default selection options on BaseTripleCollection for the triples containing nodes from using Linq where to foreach loop with yield return. This has a better performance with large sets.

Also removed the double enumeration when selecting for two nodes.

Added 6 multidictionarys to the TripleCollection. 
Triples are also stored in these and can be accessed by their nodes.
Three dictionaries for single node access (subject, predicate, object)
and three dictionaries for multi node access (subject-predicate, predicate-object, subject-object).

Changed Node getters for TripleCollection to return the keyCollections from the first set of dictionaries instead of running two linq queries (massive performance gain)
Added overrides for default queries for triple list containing specific nodes. Now returns dictionary value for node key(s) => HashSet<Triple>  (massive performance gain)

Added correctly adding and removing of triples for extra dictionaries (slight performance hit)

