### PR TITLE
Change Save method to use FileMode.Create

### DIFF
--- a/Libraries/dotNetRDF/Writing/JsonLdWriter.cs
+++ b/Libraries/dotNetRDF/Writing/JsonLdWriter.cs
@@ -65,7 +65,7 @@ namespace VDS.RDF.Writing
         public void Save(ITripleStore store, string filename)
         {
             var jsonArray = SerializeStore(store);
-            using (var writer = new StreamWriter(File.Open(filename, FileMode.CreateNew, FileAccess.Write),
+            using (var writer = new StreamWriter(File.Open(filename, FileMode.Create, FileAccess.Write),
                 Encoding.UTF8))
             {
                 writer.Write(jsonArray);


### PR DESCRIPTION
Makes the JsonLdWriter consistent with the other RDF writer implementations. Fixes #232