### PR TITLE
Reinstate parser test suites

### DIFF
--- a/Libraries/dotNetRDF/Parsing/RdfAParserBase.cs
+++ b/Libraries/dotNetRDF/Parsing/RdfAParserBase.cs
@@ -822,7 +822,7 @@ namespace VDS.RDF.Parsing
                     {
                         // It's an XML Literal - this is now RDFa 1.0 Only
                         // This is an incompatability with RDFa 1.1
-                        foreach (var child in GetChildren(currElement).OfType<TElement>())
+                        foreach (var child in GetChildren(currElement).OfType<TElement>().Where(c=>!IsTextNode(c)))
                         {
                             ProcessXmlLiteral(evalContext, child, noDefaultNamespace);
                         }
@@ -862,7 +862,7 @@ namespace VDS.RDF.Parsing
                     else if (!datatype || (datatype && GetAttribute(currElement, "datatype").Equals(string.Empty)))
                     {
                         // Value is an XML Literal
-                        foreach (var child in GetChildren(currElement).OfType<TElement>())
+                        foreach (var child in GetChildren(currElement).OfType<TElement>().Where(c=>!IsTextNode(c)))
                         {
                             ProcessXmlLiteral(evalContext, child, noDefaultNamespace);
                         }
@@ -1484,7 +1484,7 @@ namespace VDS.RDF.Parsing
             }
 
             // Recurse on any child nodes
-            foreach (var child in GetChildren(n).OfType<TElement>())
+            foreach (var child in GetChildren(n).OfType<TElement>().Where(c=>!IsTextNode(c)))
             {
                 ProcessXmlLiteral(evalContext, child, noDefaultNamespace);
             }

--- a/Libraries/dotNetRDF/Parsing/TriXParser.NetCore.cs
+++ b/Libraries/dotNetRDF/Parsing/TriXParser.NetCore.cs
@@ -1,0 +1,82 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.IO;
+using System.Xml;
+
+namespace VDS.RDF.Parsing
+{
+    public partial class TriXParser
+    {
+        private static XmlReaderSettings GetSettings()
+        {
+            return new XmlReaderSettings
+            {
+                ConformanceLevel = ConformanceLevel.Document,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                IgnoreWhitespace = true,
+            };
+        }
+
+        /// <inheritdoc />
+        public void Load(IRdfHandler handler, TextReader input)
+        {
+            if (handler == null)
+            {
+                throw new RdfParseException("Cannot parse an RDF Dataset using a null handler");
+            }
+
+            if (input == null)
+            {
+                throw new RdfParseException("Cannot parse an RDF Dataset from a null input");
+            }
+
+
+            try
+            {
+                // Get the reader and start parsing
+                var reader = XmlReader.Create(input, GetSettings());
+                RaiseWarning(
+                    "The TriX Parser is operating without XSL support, if your TriX file requires XSL then it will not be parsed successfully");
+                TryParseGraphset(reader, handler);
+
+                input.Close();
+            }
+            catch (XmlException xmlEx)
+            {
+                // Wrap in a RDF Parse Exception
+                throw new RdfParseException(
+                    "Unable to Parse this TriX since the XmlReader encountered an error, see the inner exception for details",
+                    xmlEx);
+            }
+            finally
+            {
+                input.Close();
+            }
+        }
+    }
+}

--- a/Libraries/dotNetRDF/Parsing/TriXParser.NetFull.cs
+++ b/Libraries/dotNetRDF/Parsing/TriXParser.NetFull.cs
@@ -1,0 +1,99 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2017 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Xsl;
+using VDS.RDF.Parsing.Handlers;
+using VDS.RDF.Storage;
+using VDS.RDF.Writing;
+
+namespace VDS.RDF.Parsing
+{
+    public partial class TriXParser
+    {
+        private static XmlReaderSettings GetSettings()
+        {
+            return new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Parse,
+                ConformanceLevel = ConformanceLevel.Document,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = false,
+                IgnoreWhitespace = true,
+            };
+        }
+
+        /// <inheritdoc />
+        public void Load(IRdfHandler handler, TextReader input)
+        {
+            if (handler == null)
+            {
+                throw new RdfParseException("Cannot parse an RDF Dataset using a null handler");
+            }
+
+            if (input == null)
+            {
+                throw new RdfParseException("Cannot parse an RDF Dataset from a null input");
+            }
+
+            // Load source XML
+            using (var xmlReader = XmlReader.Create(input, GetSettings()))
+            {
+                var source = XDocument.Load(xmlReader);
+                foreach (var pi in source.Nodes().OfType<XProcessingInstruction>().Where(pi=>pi.Target.Equals("xml-stylesheet")))
+                {
+                    source = ApplyTransform(source, pi);
+                }
+                using(var transformedXmlReader = source.CreateReader())
+                {
+                    TryParseGraphset(transformedXmlReader, handler);
+                }
+            }
+        }
+
+        private XDocument ApplyTransform(XDocument input, XProcessingInstruction pi)
+        {
+            var match = Regex.Match(pi.Data, @"href\s*=\s*""([^""]*)""");
+            if (match == null) throw new RdfParseException("Expected href value in xml-stylesheet PI");
+            var xslRef = match.Groups[1].Value;
+            var xslt = new XslCompiledTransform();
+            var xmlStringBuilder = new StringBuilder();
+            xslt.Load(XmlReader.Create(new StreamReader(xslRef), GetSettings()));
+            var output = new XDocument();
+            using (var writer = output.CreateWriter())
+            {
+                xslt.Transform(input.CreateReader(), writer);
+            }
+            return output;
+        }
+    }
+}

--- a/Testing/unittest/Parsing/Suites/BaseDatasetParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseDatasetParserSuite.cs
@@ -56,7 +56,7 @@ namespace VDS.RDF.Parsing.Suites
             else
             {
                 Console.WriteLine("Parsed Dataset did not match Expected Dataset (Test Failed)");
-                FailedTest(testName);
+                FailedTest(testName, "Parsed Dataset did not match Expected Dataset");
             }
         }
 

--- a/Testing/unittest/Parsing/Suites/BaseDatasetParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseDatasetParserSuite.cs
@@ -51,19 +51,16 @@ namespace VDS.RDF.Parsing.Suites
             if (AreEqual(expected, actual))
             {
                 Console.WriteLine("Parsed Dataset matches Expected Dataset (Test Passed)");
-                this.Passed++;
+                PassedTest(testName);
             }
             else
             {
                 Console.WriteLine("Parsed Dataset did not match Expected Dataset (Test Failed)");
-                this.Failed++;
+                FailedTest(testName);
             }
         }
 
-        protected override string FileExtension
-        {
-            get { return ".nt"; }
-        }
+        protected override string FileExtension => ".nt";
 
         private static bool AreEqual(TripleStore expected, TripleStore actual)
         {

--- a/Testing/unittest/Parsing/Suites/BaseRdfParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseRdfParserSuite.cs
@@ -56,13 +56,13 @@ namespace VDS.RDF.Parsing.Suites
             if (diff.AreEqual)
             {
                 Console.WriteLine("Parsed Graph matches Expected Graph (Test Passed)");
-                this.Passed++;
+                PassedTest(testName);
             }
             else
             {
                 Console.WriteLine("Parsed Graph did not match Expected Graph (Test Failed)");
                 Console.Error.WriteLine("Test " + testName + " - Parsed Graph did not match Expected Graph");
-                this.Failed++;
+                FailedTest(testName);
                 TestTools.ShowDifferences(diff, "Expected (" + this.ResultsParser.ToString() + ")", "Actual (" + this.Parser.ToString() + ")");
             }
         }

--- a/Testing/unittest/Parsing/Suites/BaseRdfParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseRdfParserSuite.cs
@@ -62,7 +62,7 @@ namespace VDS.RDF.Parsing.Suites
             {
                 Console.WriteLine("Parsed Graph did not match Expected Graph (Test Failed)");
                 Console.Error.WriteLine("Test " + testName + " - Parsed Graph did not match Expected Graph");
-                FailedTest(testName);
+                FailedTest(testName, "Parsed Graph did not match Expected Graph");
                 TestTools.ShowDifferences(diff, "Expected (" + this.ResultsParser.ToString() + ")", "Actual (" + this.Parser.ToString() + ")");
             }
         }

--- a/Testing/unittest/Parsing/Suites/BaseResultsParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseResultsParserSuite.cs
@@ -58,7 +58,7 @@ namespace VDS.RDF.Parsing.Suites
             else
             {
                 Console.WriteLine("Parsed Results did not match Expected Graph (Test Failed)");
-                FailedTest(testName);
+                FailedTest(testName, "Parsed Results did not match Expected Graph ");
                 Console.WriteLine("Expected:");
                 TestTools.ShowResults(expected);
                 Console.WriteLine();

--- a/Testing/unittest/Parsing/Suites/BaseResultsParserSuite.cs
+++ b/Testing/unittest/Parsing/Suites/BaseResultsParserSuite.cs
@@ -24,7 +24,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System;
-using Xunit;
 using VDS.RDF.Query;
 
 namespace VDS.RDF.Parsing.Suites
@@ -35,31 +34,31 @@ namespace VDS.RDF.Parsing.Suites
         protected BaseResultsParserSuite(ISparqlResultsReader testParser, ISparqlResultsReader resultsParser, String baseDir)
             : base(testParser, resultsParser, baseDir)
         {
-            this.Parser.Warning += TestTools.WarningPrinter;
-            this.ResultsParser.Warning += TestTools.WarningPrinter;
+            Parser.Warning += TestTools.WarningPrinter;
+            ResultsParser.Warning += TestTools.WarningPrinter;
         }
 
         protected override SparqlResultSet TryParseTestInput(string file)
         {
             SparqlResultSet actual = new SparqlResultSet();
-            this.Parser.Load(actual, file);
+            Parser.Load(actual, file);
             return actual;
         }
 
         protected override void TryValidateResults(string testName, string resultFile, SparqlResultSet actual)
         {
             SparqlResultSet expected = new SparqlResultSet();
-            this.ResultsParser.Load(expected, resultFile);
+            ResultsParser.Load(expected, resultFile);
 
             if (expected.Equals(actual))
             {
                 Console.WriteLine("Parsed Results matches Expected Results (Test Passed)");
-                this.Passed++;
+                PassedTest(testName);
             }
             else
             {
                 Console.WriteLine("Parsed Results did not match Expected Graph (Test Failed)");
-                this.Failed++;
+                FailedTest(testName);
                 Console.WriteLine("Expected:");
                 TestTools.ShowResults(expected);
                 Console.WriteLine();
@@ -68,9 +67,6 @@ namespace VDS.RDF.Parsing.Suites
             }
         }
 
-        protected override string FileExtension
-        {
-            get { return ".srx"; }
-        }
+        protected override string FileExtension => ".srx";
     }
 }

--- a/Testing/unittest/Parsing/Suites/N3.cs
+++ b/Testing/unittest/Parsing/Suites/N3.cs
@@ -23,16 +23,10 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
-using Xunit;
-using VDS.RDF.Parsing;
-using VDS.RDF.Query;
-using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -41,26 +35,29 @@ namespace VDS.RDF.Parsing.Suites
     public class N3
         : BaseRdfParserSuite
     {
-        public N3()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public N3(ITestOutputHelper testOutputHelper)
             : base(new Notation3Parser(), new NTriplesParser(), "n3\\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteN3()
         {
             //Run manifests
-            this.RunDirectory(f => Path.GetExtension(f).Equals(".n3") && !f.Contains("bad"), true);
-            this.RunDirectory(f => Path.GetExtension(f).Equals(".n3") && f.Contains("bad"), false);
+            RunDirectory(f => Path.GetExtension(f).Equals(".n3") && !f.Contains("bad"), true);
+            RunDirectory(f => Path.GetExtension(f).Equals(".n3") && f.Contains("bad"), false);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/NQuads.cs
+++ b/Testing/unittest/Parsing/Suites/NQuads.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using VDS.RDF.XunitExtensions;
+﻿using VDS.RDF.XunitExtensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -11,14 +8,17 @@ namespace VDS.RDF.Parsing.Suites
     public class NQuads
         : BaseDatasetParserSuite
     {
-        public NQuads()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NQuads(ITestOutputHelper testOutputHelper)
             : base(new NQuadsParser(), new NQuadsParser(), @"nquads11\")
         {
-            this.CheckResults = false;
-            this.Parser.Warning += TestTools.WarningPrinter;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
+            Parser.Warning += TestTools.WarningPrinter;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuitesNQuads11()
         {
             //Nodes for positive and negative tests
@@ -28,15 +28,15 @@ namespace VDS.RDF.Parsing.Suites
             INode negSyntaxTest = g.CreateUriNode("rdft:TestNQuadsNegativeSyntax");
 
             //Run manifests
-            this.RunManifest(@"..\\resources\nquads11\manifest.ttl", posSyntaxTest, negSyntaxTest);
+            RunManifest(@"..\\resources\nquads11\manifest.ttl", posSyntaxTest, negSyntaxTest);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/NQuads.cs
+++ b/Testing/unittest/Parsing/Suites/NQuads.cs
@@ -28,7 +28,7 @@ namespace VDS.RDF.Parsing.Suites
             INode negSyntaxTest = g.CreateUriNode("rdft:TestNQuadsNegativeSyntax");
 
             //Run manifests
-            RunManifest(@"..\\resources\nquads11\manifest.ttl", posSyntaxTest, negSyntaxTest);
+            RunManifest(@"resources\nquads11\manifest.ttl", posSyntaxTest, negSyntaxTest);
 
             if (Count == 0) Assert.True(false, "No tests found");
 

--- a/Testing/unittest/Parsing/Suites/NTriples.cs
+++ b/Testing/unittest/Parsing/Suites/NTriples.cs
@@ -27,6 +27,7 @@ using System;
 using System.IO;
 using VDS.RDF.XunitExtensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -34,32 +35,35 @@ namespace VDS.RDF.Parsing.Suites
     public class NTriples
         : BaseRdfParserSuite
     {
-        public NTriples()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NTriples(ITestOutputHelper testOutputHelper)
             : base(new NTriplesParser(NTriplesSyntax.Original), new NTriplesParser(NTriplesSyntax.Original), @"ntriples\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteNTriples()
         {
             //Run manifests
-            this.RunDirectory(f => Path.GetExtension(f).Equals(".nt"), true);
+            RunDirectory(f => Path.GetExtension(f).Equals(".nt"), true);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double) this.Passed/(double) this.Count)*100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed/(double) Count)*100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
 
         [Fact]
         public void ParsingNTriplesUnicodeEscapes1()
         {
             Graph g = new Graph();
-            g.LoadFromFile(@"resources\turtle11\localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nt", this.Parser);
+            g.LoadFromFile(@"resources\turtle11\localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nt", Parser);
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);
         }
@@ -71,7 +75,7 @@ namespace VDS.RDF.Parsing.Suites
 <http://s> <http://p> _:node.id.";
 
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => g.LoadFromString(data, this.Parser));
+            Assert.Throws<RdfParseException>(() => g.LoadFromString(data, Parser));
         }
 
         [Fact]
@@ -80,7 +84,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\'quote"" .";
 
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => g.LoadFromString(data, this.Parser));
+            Assert.Throws<RdfParseException>(() => g.LoadFromString(data, Parser));
         }
 
         [Fact]
@@ -89,7 +93,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\""quote"" .";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
 
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);
@@ -103,8 +107,8 @@ namespace VDS.RDF.Parsing.Suites
         public NTriples11()
             : base(new NTriplesParser(), new NTriplesParser(), @"ntriples11\")
         {
-            this.CheckResults = false;
-            this.Parser.Warning += TestTools.WarningPrinter;
+            CheckResults = false;
+            Parser.Warning += TestTools.WarningPrinter;
         }
 
         [SkippableFact]
@@ -117,15 +121,15 @@ namespace VDS.RDF.Parsing.Suites
             INode negSyntaxTest = g.CreateUriNode("rdft:TestNTriplesNegativeSyntax");
 
             //Run manifests
-            this.RunManifest(@"resources\ntriples11\manifest.ttl", posSyntaxTest, negSyntaxTest);
+            RunManifest(@"resources\ntriples11\manifest.ttl", posSyntaxTest, negSyntaxTest);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double) this.Passed/(double) this.Count)*100) + "% Passed");
+            Console.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            Console.WriteLine(((Passed/(double) Count)*100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
 
         [Fact]
@@ -135,7 +139,7 @@ namespace VDS.RDF.Parsing.Suites
 <http://s> <http://p> _:node.id.";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
             Assert.False(g.IsEmpty);
             Assert.Equal(2, g.Triples.Count);
         }
@@ -146,7 +150,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\'quote"" .";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
 
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);
@@ -158,7 +162,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\""quote"" .";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
 
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);

--- a/Testing/unittest/Parsing/Suites/RdfXml.cs
+++ b/Testing/unittest/Parsing/Suites/RdfXml.cs
@@ -37,6 +37,12 @@ namespace VDS.RDF.Parsing.Suites
         : BaseRdfParserSuite
     {
         private readonly ITestOutputHelper _testOutputHelper;
+        private static readonly string[] SkipTests =
+        {
+            "amp-in-url\\test001.rdf", // Uses entities in DTD - not supported in .NET Core RDF/XML parser
+            "rdf-containers-syntax-vs-schema\\test005.rdf", // Obsoleted test file with no root element
+            "xmlbase\\test012.rdf", // Obsoleted test file with no root element
+        };
 
         public RdfXmlDomParser(ITestOutputHelper testOutputHelper)
             : base(new RdfXmlParser(RdfXmlParserMode.DOM), new NTriplesParser(), "rdfxml\\")
@@ -49,16 +55,26 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingSuiteRdfXmlDom()
         {
             //Run manifests
-            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
-            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error") && !SkipTests.Any(f.EndsWith), true);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error") && !SkipTests.Any(f.EndsWith), false);
 
-            if (Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0)
+            {
+                Assert.True(false, "No tests found");
+            }
 
             _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
             _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (Failed > 0) Assert.True(false, Failed + " Tests failed: " + string.Join(", ", FailedTests));
-            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate: " + string.Join(", ", IndeterminateTests));
+            if (Failed > 0)
+            {
+                Assert.True(false, Failed + " Tests failed: \n\t" + string.Join("\n\t", FailedTests));
+            }
+
+            if (Indeterminate > 0)
+            {
+                throw new SkipTestException(Indeterminate + " Tests are indeterminate: " + string.Join(", ", IndeterminateTests));
+            }
         }
 
         [Fact]
@@ -75,6 +91,13 @@ namespace VDS.RDF.Parsing.Suites
     {
         private readonly ITestOutputHelper _testOutputHelper;
 
+        private static readonly string[] SkipTests =
+        {
+            "amp-in-url\\test001.rdf", // Uses entities in DTD - not supported in .NET Core RDF/XML parser
+            "rdf-containers-syntax-vs-schema\\test005.rdf", // Obsoleted test file with no root element
+            "xmlbase\\test012.rdf", // Obsoleted test file with no root element
+        };
+
         public RdfXmlStreamingParser(ITestOutputHelper testOutputHelper)
             : base(new RdfXmlParser(RdfXmlParserMode.Streaming), new NTriplesParser(), "rdfxml\\")
         {
@@ -86,8 +109,8 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingSuiteRdfXmlStreaming()
         {
             //Run manifests
-            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
-            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error") && !SkipTests.Any(f.EndsWith), true);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error") && !SkipTests.Any(f.EndsWith), false);
             if (Count == 0) Assert.True(false, "No tests found");
 
             _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");

--- a/Testing/unittest/Parsing/Suites/RdfXml.cs
+++ b/Testing/unittest/Parsing/Suites/RdfXml.cs
@@ -23,16 +23,10 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
-using Xunit;
-using VDS.RDF.Parsing;
-using VDS.RDF.Query;
-using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -40,67 +34,73 @@ namespace VDS.RDF.Parsing.Suites
     public class RdfXmlDomParser
         : BaseRdfParserSuite
     {
-        public RdfXmlDomParser()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public RdfXmlDomParser(ITestOutputHelper testOutputHelper)
             : base(new RdfXmlParser(RdfXmlParserMode.DOM), new NTriplesParser(), "rdfxml\\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteRdfXmlDOM()
         {
             //Run manifests
-            this.RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
-            this.RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
 
         [Fact]
         public void ParsingRdfXmlIDsDOM()
         {
             IGraph g = new Graph();
-            g.BaseUri = BaseRdfParserSuite.BaseUri;
-            this.Parser.Load(g, "resources\\rdfxml\\xmlbase\\test014.rdf");
+            g.BaseUri = BaseUri;
+            Parser.Load(g, "resources\\rdfxml\\xmlbase\\test014.rdf");
         }
     }
 
     public class RdfXmlStreamingParser
         : BaseRdfParserSuite
     {
-        public RdfXmlStreamingParser()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public RdfXmlStreamingParser(ITestOutputHelper testOutputHelper)
             : base(new RdfXmlParser(RdfXmlParserMode.Streaming), new NTriplesParser(), "rdfxml\\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteRdfXmlStreaming()
         {
             //Run manifests
-            this.RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
-            this.RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
+            RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && f.Contains("error"), false);
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
 
         [Fact]
         public void ParsingRdfXmlIDsStreaming()
         {
             IGraph g = new Graph();
-            g.BaseUri = BaseRdfParserSuite.BaseUri;
-            this.Parser.Load(g, "resources\\rdfxml\\xmlbase\\test014.rdf");
+            g.BaseUri = BaseUri;
+            Parser.Load(g, "resources\\rdfxml\\xmlbase\\test014.rdf");
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/RdfXml.cs
+++ b/Testing/unittest/Parsing/Suites/RdfXml.cs
@@ -23,7 +23,9 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using System;
 using System.IO;
+using System.Linq;
 using VDS.RDF.XunitExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -44,7 +46,7 @@ namespace VDS.RDF.Parsing.Suites
         }
 
         [Fact]
-        public void ParsingSuiteRdfXmlDOM()
+        public void ParsingSuiteRdfXmlDom()
         {
             //Run manifests
             RunAllDirectories(f => Path.GetExtension(f).Equals(".rdf") && !f.Contains("error"), true);
@@ -55,12 +57,12 @@ namespace VDS.RDF.Parsing.Suites
             _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
             _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
-            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed: " + string.Join(", ", FailedTests));
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate: " + string.Join(", ", IndeterminateTests));
         }
 
         [Fact]
-        public void ParsingRdfXmlIDsDOM()
+        public void ParsingRdfXmlIDsDom()
         {
             IGraph g = new Graph();
             g.BaseUri = BaseUri;
@@ -91,8 +93,8 @@ namespace VDS.RDF.Parsing.Suites
             _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
             _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
-            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed: " + string.Join(", ", FailedTests));
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate" + string.Join(", ", PassedTests));
         }
 
         [Fact]

--- a/Testing/unittest/Parsing/Suites/SparqlResultsXml.cs
+++ b/Testing/unittest/Parsing/Suites/SparqlResultsXml.cs
@@ -25,10 +25,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
 using System.IO;
-using System.Linq;
-using Xunit;
 using VDS.RDF.Query;
 using VDS.RDF.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -37,26 +37,29 @@ namespace VDS.RDF.Parsing.Suites
     public class SparqlResultsXml
         : BaseResultsParserSuite
     {
-        public SparqlResultsXml()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public SparqlResultsXml(ITestOutputHelper testOutputHelper)
             : base(new SparqlXmlParser(), new SparqlXmlParser(), "srx\\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteSparqlResultsXml()
         {
             //Run manifests
-            this.RunDirectory(f => Path.GetExtension(f).Equals(".srx") && !f.Contains("bad"), true);
-            this.RunDirectory(f => Path.GetExtension(f).Equals(".srx") && f.Contains("bad"), false);
+            RunDirectory(f => Path.GetExtension(f).Equals(".srx") && !f.Contains("bad"), true);
+            RunDirectory(f => Path.GetExtension(f).Equals(".srx") && f.Contains("bad"), false);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
 
         [Fact]
@@ -64,7 +67,7 @@ namespace VDS.RDF.Parsing.Suites
         {
             // Test case based off of CORE-410
             SparqlResultSet results = new SparqlResultSet();
-            this.ResultsParser.Load(results, @"resources\sparql\core-410.srx");
+            ResultsParser.Load(results, @"resources\sparql\core-410.srx");
 
             TestTools.ShowResults(results);
 
@@ -97,7 +100,7 @@ namespace VDS.RDF.Parsing.Suites
             // Test case based off of CORE-410
             SparqlResultSet results = new SparqlResultSet();
 
-            Assert.Throws<RdfParseException>(() => this.ResultsParser.Load(results, @"resources\sparql\bad-core-410.srx"));
+            Assert.Throws<RdfParseException>(() => ResultsParser.Load(results, @"resources\sparql\bad-core-410.srx"));
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/TriG.cs
+++ b/Testing/unittest/Parsing/Suites/TriG.cs
@@ -33,6 +33,7 @@ using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -41,13 +42,16 @@ namespace VDS.RDF.Parsing.Suites
     public class TriG
         : BaseDatasetParserSuite
     {
-        public TriG()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public TriG(ITestOutputHelper testOutputHelper)
             : base(new TriGParser(), new NQuadsParser(), "trig\\")
         {
+            _testOutputHelper = testOutputHelper;
             this.CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteTriG()
         {
             //Run manifests
@@ -56,8 +60,8 @@ namespace VDS.RDF.Parsing.Suites
 
             if (this.Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
+            _testOutputHelper.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
 
             if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
             if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");

--- a/Testing/unittest/Parsing/Suites/TriX.cs
+++ b/Testing/unittest/Parsing/Suites/TriX.cs
@@ -23,40 +23,36 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Text;
-using Xunit;
-using VDS.RDF.Parsing;
-using VDS.RDF.Query;
-using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
     public partial class TriX
         : BaseDatasetParserSuite
     {
-        public TriX()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public TriX(ITestOutputHelper testOutputHelper)
             : base(new TriXParser(), new NQuadsParser(), "trix\\")
         {
-            this.CheckResults = false;
+            _testOutputHelper = testOutputHelper;
+            CheckResults = false;
         }
 
-        [SkippableFact]
+        [Fact]
         public void ParsingSuiteTriX()
         {
             RunManifests();
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/TriX.cs
+++ b/Testing/unittest/Parsing/Suites/TriX.cs
@@ -51,7 +51,11 @@ namespace VDS.RDF.Parsing.Suites
             _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
             _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Failed > 0)
+            {
+                foreach(var failure in FailedTests) { _testOutputHelper.WriteLine(failure.ToString());}
+                Assert.True(false, Failed + " Tests failed");
+            }
             if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
     }

--- a/Testing/unittest/Parsing/Suites/Turtle11.cs
+++ b/Testing/unittest/Parsing/Suites/Turtle11.cs
@@ -41,11 +41,11 @@ namespace VDS.RDF.Parsing.Suites
             : base(new TurtleParser(TurtleSyntax.W3C), new NTriplesParser(), "turtle11-unofficial\\") { }
 
         [SkippableFact]
-        public void ParsingSuiteTurtleW3CUnofficalTests()
+        public void ParsingSuiteTurtleW3CUnofficialTests()
         {
             //Run manifests
-            RunManifest("..\\resources/turtle11-unofficial/manifest.ttl", true);
-            RunManifest("..\\resources/turtle11-unofficial/manifest-bad.ttl", false);
+            RunManifest("resources/turtle11-unofficial/manifest.ttl", true);
+            RunManifest("resources/turtle11-unofficial/manifest-bad.ttl", false);
 
             if (Count == 0) Assert.True(false, "No tests found");
 
@@ -86,7 +86,7 @@ namespace VDS.RDF.Parsing.Suites
                 INode negEvalTest = g.CreateUriNode("rdft:TestTurtleNegativeEval");
 
                 //Run manifests
-                RunManifest("..\\resources/turtle11/manifest.ttl", new[] { posSyntaxTest }, new[] { negSyntaxTest, negEvalTest });
+                RunManifest("resources/turtle11/manifest.ttl", new[] { posSyntaxTest }, new[] { negSyntaxTest, negEvalTest });
 
                 if (Count == 0) Assert.True(false, "No tests found");
 

--- a/Testing/unittest/Parsing/Suites/Turtle11.cs
+++ b/Testing/unittest/Parsing/Suites/Turtle11.cs
@@ -26,9 +26,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 using System;
 using System.IO;
 using System.Linq;
-using Xunit;
 using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -43,16 +44,16 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingSuiteTurtleW3CUnofficalTests()
         {
             //Run manifests
-            this.RunManifest("..\\resources/turtle11-unofficial/manifest.ttl", true);
-            this.RunManifest("..\\resources/turtle11-unofficial/manifest-bad.ttl", false);
+            RunManifest("..\\resources/turtle11-unofficial/manifest.ttl", true);
+            RunManifest("..\\resources/turtle11-unofficial/manifest-bad.ttl", false);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            Console.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            Console.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0) Assert.True(false, Failed + " Tests failed");
+            if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate");
         }
     }
 
@@ -61,10 +62,15 @@ namespace VDS.RDF.Parsing.Suites
     public class Turtle11
         : BaseRdfParserSuite
     {
-        public Turtle11()
-            : base(new TurtleParser(TurtleSyntax.W3C), new NTriplesParser(), "turtle11\\") { }
+        private readonly ITestOutputHelper _testOutputHelper;
 
-        [SkippableFact]
+        public Turtle11(ITestOutputHelper testOutputHelper)
+            : base(new TurtleParser(TurtleSyntax.W3C), new NTriplesParser(), "turtle11\\")
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
         public void ParsingSuiteTurtleW3C()
         {
             try
@@ -80,25 +86,25 @@ namespace VDS.RDF.Parsing.Suites
                 INode negEvalTest = g.CreateUriNode("rdft:TestTurtleNegativeEval");
 
                 //Run manifests
-                this.RunManifest("..\\resources/turtle11/manifest.ttl", new INode[] { posSyntaxTest }, new INode[] { negSyntaxTest, negEvalTest });
+                RunManifest("..\\resources/turtle11/manifest.ttl", new[] { posSyntaxTest }, new[] { negSyntaxTest, negEvalTest });
 
-                if (this.Count == 0) Assert.True(false, "No tests found");
+                if (Count == 0) Assert.True(false, "No tests found");
 
-                Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed - " + this.Indeterminate + " Indeterminate");
-                Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+                _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed - " + Indeterminate + " Indeterminate");
+                _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-                if (this.Failed > 0)
+                if (Failed > 0)
                 {
-                    if (this.Indeterminate == 0)
+                    if (Indeterminate == 0)
                     {
-                        Assert.True(false, this.Failed + " Tests failed and " + this.Passed + " Tests Passed");
+                        Assert.True(false, Failed + " Tests failed and " + Passed + " Tests Passed");
                     }
                     else
                     {
-                        Assert.True(false, this.Failed + " Test failed, " + this.Indeterminate + " Tests are indeterminate and " + this.Passed + " Tests Passed");
+                        Assert.True(false, Failed + " Test failed, " + Indeterminate + " Tests are indeterminate and " + Passed + " Tests Passed");
                     }
                 }
-                if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate and " + this.Passed + " Tests Passed");
+                if (Indeterminate > 0) throw new SkipTestException(Indeterminate + " Tests are indeterminate and " + Passed + " Tests Passed");
             }
             finally
             {
@@ -252,7 +258,7 @@ namespace VDS.RDF.Parsing.Suites
             //Dot required
             String graph = "@base <http://example.org/> .";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -263,7 +269,7 @@ namespace VDS.RDF.Parsing.Suites
             //Missing dot
             String graph = "@base <http://example.org/>";
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -275,7 +281,7 @@ namespace VDS.RDF.Parsing.Suites
             String graph = "@BASE <http://example.org/> .";
             Graph g = new Graph();
 
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
@@ -284,7 +290,7 @@ namespace VDS.RDF.Parsing.Suites
             //Forbidden dot
             String graph = "BASE <http://example.org/> .";
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() =>  this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() =>  Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -295,7 +301,7 @@ namespace VDS.RDF.Parsing.Suites
             //No dot required
             String graph = "BASE <http://example.org/>";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -306,7 +312,7 @@ namespace VDS.RDF.Parsing.Suites
             //No dot required and case insensitive
             String graph = "BaSe <http://example.org/>";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -317,7 +323,7 @@ namespace VDS.RDF.Parsing.Suites
             //Dot required
             String graph = "@prefix ex: <http://example.org/> .";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
@@ -328,7 +334,7 @@ namespace VDS.RDF.Parsing.Suites
             //Missing dot
             String graph = "@prefix ex: <http://example.org/>";
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
@@ -340,7 +346,7 @@ namespace VDS.RDF.Parsing.Suites
             String graph = "@PREFIX ex: <http://example.org/> .";
             Graph g = new Graph();
 
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
@@ -349,7 +355,7 @@ namespace VDS.RDF.Parsing.Suites
             //Forbidden dot
             String graph = "PREFIX ex: <http://example.org/> .";
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
@@ -360,7 +366,7 @@ namespace VDS.RDF.Parsing.Suites
             //No dot required and case insensitive
             String graph = "PrEfIx ex: <http://example.org/>";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
@@ -371,7 +377,7 @@ namespace VDS.RDF.Parsing.Suites
             // No white space between prefix and URI
             const String graph = "@prefix pre:<http://example.org> .";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("pre"));
         }
@@ -381,7 +387,7 @@ namespace VDS.RDF.Parsing.Suites
         {
             const String graph = "@prefix pre: <http://example.org> .";
             Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("pre"));
         }
@@ -392,7 +398,7 @@ namespace VDS.RDF.Parsing.Suites
             // Multiple : are not supported
             const String graph = "@prefix pre:pre: <http://example.org> .";
             Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
@@ -422,7 +428,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\'quote"" .";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
 
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);
@@ -434,7 +440,7 @@ namespace VDS.RDF.Parsing.Suites
             const String data = @"<http://s> <http://p> ""literal\""quote"" .";
 
             Graph g = new Graph();
-            g.LoadFromString(data, this.Parser);
+            g.LoadFromString(data, Parser);
 
             Assert.False(g.IsEmpty);
             Assert.Equal(1, g.Triples.Count);

--- a/Testing/unittest/Parsing/Suites/TurtleMemberSubmission.cs
+++ b/Testing/unittest/Parsing/Suites/TurtleMemberSubmission.cs
@@ -24,15 +24,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
-using Xunit;
-using VDS.RDF.Parsing;
-using VDS.RDF.Query;
-using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
@@ -44,7 +38,9 @@ namespace VDS.RDF.Parsing.Suites
         private readonly ITestOutputHelper _testOutputHelper;
 
         public TurtleMemberSubmission(ITestOutputHelper testOutputHelper)
-            : base(new TurtleParser(TurtleSyntax.Original), new NTriplesParser(), "turtle\\")
+            : base(new TurtleParser(TurtleSyntax.Original), 
+                new NTriplesParser(NTriplesSyntax.Original), //KA: test-29 will be indeterminate if using NTriples 1.1 syntax due to \t escape in the expected output result file
+                "turtle\\")
         {
             _testOutputHelper = testOutputHelper;
         }
@@ -53,25 +49,31 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingSuiteTurtleOriginal()
         {
             //Run manifests
-            this.RunManifest("resources/turtle/manifest.ttl", true);
-            this.RunManifest("resources/turtle/manifest-bad.ttl", false);
+            RunManifest("resources/turtle/manifest.ttl", true);
+            RunManifest("resources/turtle/manifest-bad.ttl", false);
 
-            if (this.Count == 0) Assert.True(false, "No tests found");
+            if (Count == 0) Assert.True(false, "No tests found");
 
-            _testOutputHelper.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            _testOutputHelper.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(Count + " Tests - " + Passed + " Passed - " + Failed + " Failed");
+            _testOutputHelper.WriteLine(((Passed / (double)Count) * 100) + "% Passed");
 
-            if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
-            if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");
+            if (Failed > 0)
+            {
+                Assert.True(false, Failed + " Tests failed: " + string.Join(", ", FailedTests));
+            }
+            if (Indeterminate > 0)
+            {
+                throw new SkipTestException(Indeterminate + " Tests are indeterminate: " + string.Join(", ", IndeterminateTests));
+            }
         }
 
         [Fact]
         public void ParsingTurtleOriginalBaseTurtleStyle1()
         {
             //Dot required
-            String graph = "@base <http://example.org/> .";
-            Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            var graph = "@base <http://example.org/> .";
+            var g = new Graph();
+            Parser.Load(g, new StringReader(graph));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -80,9 +82,9 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingTurtleOriginalBaseTurtleStyle2()
         {
             //Missing dot
-            String graph = "@base <http://example.org/>";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "@base <http://example.org/>";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.BaseUri);
         }
@@ -91,27 +93,27 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingTurtleOriginalBaseSparqlStyle1()
         {
             //Forbidden in Original Turtle
-            String graph = "BASE <http://example.org/> .";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "BASE <http://example.org/> .";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
         public void ParsingTurtleOriginalBaseSparqlStyle2()
         {
             //Forbidden in Original Turtle
-            String graph = "BASE <http://example.org/>";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "BASE <http://example.org/>";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
         public void ParsingTurtleOriginalPrefixTurtleStyle1()
         {
             //Dot required
-            String graph = "@prefix ex: <http://example.org/> .";
-            Graph g = new Graph();
-            this.Parser.Load(g, new StringReader(graph));
+            var graph = "@prefix ex: <http://example.org/> .";
+            var g = new Graph();
+            Parser.Load(g, new StringReader(graph));
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
 
@@ -119,9 +121,9 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingTurtleOriginalPrefixTurtleStyle2()
         {
             //Missing dot
-            String graph = "@prefix ex: <http://example.org/>";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "@prefix ex: <http://example.org/>";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
 
             Assert.Equal(new Uri("http://example.org"), g.NamespaceMap.GetNamespaceUri("ex"));
         }
@@ -130,18 +132,18 @@ namespace VDS.RDF.Parsing.Suites
         public void ParsingTurtleOriginalPrefixSparqlStyle1()
         {
             //Forbidden in Original Turtle
-            String graph = "PREFIX ex: <http://example.org/> .";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "PREFIX ex: <http://example.org/> .";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
         public void ParsingTurtleOriginalPrefixSparqlStyle2()
         {
             //Forbidden in Original Turtle
-            String graph = "PREFIX ex: <http://example.org/>";
-            Graph g = new Graph();
-            Assert.Throws<RdfParseException>(() => this.Parser.Load(g, new StringReader(graph)));
+            var graph = "PREFIX ex: <http://example.org/>";
+            var g = new Graph();
+            Assert.Throws<RdfParseException>(() => Parser.Load(g, new StringReader(graph)));
         }
 
         [Fact]
@@ -153,7 +155,7 @@ namespace VDS.RDF.Parsing.Suites
         [Fact]
         public void ParsingTurtleOriginalPrefixedNames2()
         {
-            this.Parser.Load(new Graph(), @"resources\turtle\test-14.ttl");
+            Parser.Load(new Graph(), @"resources\turtle\test-14.ttl");
         }
     }
 }

--- a/Testing/unittest/Parsing/Suites/TurtleMemberSubmission.cs
+++ b/Testing/unittest/Parsing/Suites/TurtleMemberSubmission.cs
@@ -33,6 +33,7 @@ using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Writing.Formatting;
 using VDS.RDF.XunitExtensions;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Parsing.Suites
 {
@@ -40,10 +41,15 @@ namespace VDS.RDF.Parsing.Suites
     public class TurtleMemberSubmission
         : BaseRdfParserSuite
     {
-        public TurtleMemberSubmission()
-            : base(new TurtleParser(TurtleSyntax.Original), new NTriplesParser(), "turtle\\") { }
+        private readonly ITestOutputHelper _testOutputHelper;
 
-        [SkippableFact]
+        public TurtleMemberSubmission(ITestOutputHelper testOutputHelper)
+            : base(new TurtleParser(TurtleSyntax.Original), new NTriplesParser(), "turtle\\")
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
         public void ParsingSuiteTurtleOriginal()
         {
             //Run manifests
@@ -52,8 +58,8 @@ namespace VDS.RDF.Parsing.Suites
 
             if (this.Count == 0) Assert.True(false, "No tests found");
 
-            Console.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
-            Console.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
+            _testOutputHelper.WriteLine(this.Count + " Tests - " + this.Passed + " Passed - " + this.Failed + " Failed");
+            _testOutputHelper.WriteLine((((double)this.Passed / (double)this.Count) * 100) + "% Passed");
 
             if (this.Failed > 0) Assert.True(false, this.Failed + " Tests failed");
             if (this.Indeterminate > 0) throw new SkipTestException(this.Indeterminate + " Tests are indeterminate");


### PR DESCRIPTION
Reinstated most of the RDF parser test suites and fixed the errors reported by those tests.
Implemented basic support for applying XSLT when parsing TriX on platforms that support the .NET XslCompiledTransform class.