### PR TITLE
Fix for collection blank nodes edge case

### DIFF
--- a/Libraries/dotNetRDF/Writing/WriterUtilities.cs
+++ b/Libraries/dotNetRDF/Writing/WriterUtilities.cs
@@ -511,8 +511,6 @@ namespace VDS.RDF.Writing
                     }
 
                     List<Triple> ts = context.Graph.GetTriples(b).ToList();
-                    ts.RemoveAll(t => t.Predicate.Equals(first));
-                    ts.RemoveAll(t => t.Predicate.Equals(rest));
 
                     if (ts.Count <= 1)
                     {
@@ -522,6 +520,8 @@ namespace VDS.RDF.Writing
                     }
                     else
                     {
+                        ts.RemoveAll(t => t.Predicate.Equals(first));
+                        ts.RemoveAll(t => t.Predicate.Equals(rest));
                         if (context.Graph.GetTriplesWithObject(b).Count() == 1)
                         {
                             ts.RemoveAll(t => t.Object.Equals(b));

--- a/Testing/unittest/Writing/CompressionTests.cs
+++ b/Testing/unittest/Writing/CompressionTests.cs
@@ -45,11 +45,11 @@ namespace VDS.RDF.Writing
 
         readonly List<KeyValuePair<IRdfWriter, IRdfReader>> _compressers = new List<KeyValuePair<IRdfWriter, IRdfReader>>()
         {
-            //new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(), new TurtleParser()),
+            new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(), new TurtleParser()),
             new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(TurtleSyntax.W3C), new TurtleParser(TurtleSyntax.W3C)),
-            //new KeyValuePair<IRdfWriter, IRdfReader>(new Notation3Writer(), new Notation3Parser()),
-            //new KeyValuePair<IRdfWriter, IRdfReader>(new RdfXmlWriter(), new RdfXmlParser()),
-            //new KeyValuePair<IRdfWriter, IRdfReader>(new PrettyRdfXmlWriter(), new RdfXmlParser())
+            new KeyValuePair<IRdfWriter, IRdfReader>(new Notation3Writer(), new Notation3Parser()),
+            new KeyValuePair<IRdfWriter, IRdfReader>(new RdfXmlWriter(), new RdfXmlParser()),
+            new KeyValuePair<IRdfWriter, IRdfReader>(new PrettyRdfXmlWriter(), new RdfXmlParser())
         };
 
         protected void CheckCompressionRoundTrip(IGraph g)

--- a/Testing/unittest/Writing/CompressionTests.cs
+++ b/Testing/unittest/Writing/CompressionTests.cs
@@ -30,18 +30,26 @@ using System.Text;
 using Xunit;
 using VDS.RDF.Parsing;
 using VDS.RDF.Writing;
+using Xunit.Abstractions;
 
 namespace VDS.RDF.Writing
 {
     public abstract class CompressionTests
     {
+        protected ITestOutputHelper _output;
+
+        protected CompressionTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         readonly List<KeyValuePair<IRdfWriter, IRdfReader>> _compressers = new List<KeyValuePair<IRdfWriter, IRdfReader>>()
         {
-            new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(), new TurtleParser()),
+            //new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(), new TurtleParser()),
             new KeyValuePair<IRdfWriter, IRdfReader>(new CompressingTurtleWriter(TurtleSyntax.W3C), new TurtleParser(TurtleSyntax.W3C)),
-            new KeyValuePair<IRdfWriter, IRdfReader>(new Notation3Writer(), new Notation3Parser()),
-            new KeyValuePair<IRdfWriter, IRdfReader>(new RdfXmlWriter(), new RdfXmlParser()),
-            new KeyValuePair<IRdfWriter, IRdfReader>(new PrettyRdfXmlWriter(), new RdfXmlParser())
+            //new KeyValuePair<IRdfWriter, IRdfReader>(new Notation3Writer(), new Notation3Parser()),
+            //new KeyValuePair<IRdfWriter, IRdfReader>(new RdfXmlWriter(), new RdfXmlParser()),
+            //new KeyValuePair<IRdfWriter, IRdfReader>(new PrettyRdfXmlWriter(), new RdfXmlParser())
         };
 
         protected void CheckCompressionRoundTrip(IGraph g)
@@ -61,9 +69,9 @@ namespace VDS.RDF.Writing
                 System.IO.StringWriter strWriter = new System.IO.StringWriter();
                 writer.Save(g, strWriter);
 
-                Console.WriteLine("Compressed Output using " + kvp.Key.GetType().Name);
-                Console.WriteLine(strWriter.ToString());
-                Console.WriteLine();
+                _output.WriteLine("Compressed Output using " + kvp.Key.GetType().Name);
+                _output.WriteLine(strWriter.ToString());
+                _output.WriteLine("");
 
                 Graph h = new Graph();
                 StringParser.Parse(h, strWriter.ToString(), kvp.Value);

--- a/Testing/unittest/Writing/WriterTests.cs
+++ b/Testing/unittest/Writing/WriterTests.cs
@@ -30,6 +30,8 @@ using System.Text;
 using Xunit;
 using VDS.RDF.Parsing;
 using VDS.RDF.Writing.Formatting;
+using Xunit.Abstractions;
+
 #pragma warning disable 618
 
 namespace VDS.RDF.Writing
@@ -37,7 +39,7 @@ namespace VDS.RDF.Writing
     public class WriterTests
         : CompressionTests
     {
-        // private String prefix = "@prefix : <http://example.org>.\n";
+        public WriterTests(ITestOutputHelper output): base(output) { }
         
         [Fact]
         public void WritingBlankNodeOutput()


### PR DESCRIPTION
The fix provided here ensures that triples with RDF list predicates (rdf:first, rdf:rest) are counted when determining if the blank nodes is a "single-use blank node". This avoids marking a blank node in a list as an explicitly empty property collection which was in turn resulting in the attached rdf:type property of the blank node being incorrectly assigned to a separate blank node.