### PR TITLE
Add IGraph.AllNodes property and its implementation

### DIFF
--- a/Libraries/dotNetRDF.Query.Spin/SpinWrappedGraph.cs
+++ b/Libraries/dotNetRDF.Query.Spin/SpinWrappedGraph.cs
@@ -154,28 +154,19 @@ namespace VDS.RDF.Query.Spin
         // TODO provide the triple selection methods
 
         /// <inheritdoc />
-        public bool IsEmpty
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public bool IsEmpty => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public INamespaceMapper NamespaceMap
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public INamespaceMapper NamespaceMap => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public IEnumerable<INode> Nodes
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public IEnumerable<INode> Nodes => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public BaseTripleCollection Triples
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public IEnumerable<INode> AllNodes => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public BaseTripleCollection Triples => throw new NotImplementedException();
 
 
         /// <inheritdoc />

--- a/Libraries/dotNetRDF/Core/BaseGraph.cs
+++ b/Libraries/dotNetRDF/Core/BaseGraph.cs
@@ -39,14 +39,8 @@ namespace VDS.RDF
     /// <summary>
     /// Abstract Base Implementation of the <see cref="IGraph">IGraph</see> interface.
     /// </summary>
-#if !NETCORE
     [Serializable,XmlRoot(ElementName="graph")]
-#endif
-    public abstract class BaseGraph 
-        : IGraph
-#if !NETCORE
-        ,ISerializable
-#endif
+    public abstract class BaseGraph : IGraph, ISerializable
     {
         #region Variables
 
@@ -124,24 +118,17 @@ namespace VDS.RDF
         /// <summary>
         /// Gets the set of Triples described in this Graph.
         /// </summary>
-        public virtual BaseTripleCollection Triples
-        {
-            get
-            {
-                return _triples;
-            }
-        }
+        public virtual BaseTripleCollection Triples => _triples;
 
-        /// <summary>
-        /// Gets the set of Nodes which make up this Graph.
-        /// </summary>
-        public virtual IEnumerable<INode> Nodes
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> Nodes => _triples.SubjectNodes.Union(_triples.ObjectNodes).Distinct();
+
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> AllNodes
         {
             get
             {
-                return (from t in _triples
-                        select t.Subject).Concat(from t in _triples
-                                                 select t.Object).Distinct();
+                return _triples.SelectMany(t => t.Nodes).Distinct();
             }
         }
 
@@ -149,13 +136,7 @@ namespace VDS.RDF
         /// Gets the Namespace Mapper for this Graph which contains all in use Namespace Prefixes and their URIs.
         /// </summary>
         /// <returns></returns>
-        public virtual INamespaceMapper NamespaceMap
-        {
-            get
-            {
-                return _nsmapper;
-            }
-        }
+        public virtual INamespaceMapper NamespaceMap => _nsmapper;
 
         /// <summary>
         /// Gets the current Base Uri for the Graph.
@@ -165,26 +146,14 @@ namespace VDS.RDF
         /// </remarks>
         public virtual Uri BaseUri
         {
-            get
-            {
-                return _baseuri;
-            }
-            set
-            {
-                _baseuri = value;
-            }
+            get => _baseuri;
+            set => _baseuri = value;
         }
 
         /// <summary>
         /// Gets whether a Graph is Empty ie. Contains No Triples or Nodes.
         /// </summary>
-        public virtual bool IsEmpty
-        {
-            get
-            {
-                return (_triples.Count == 0);
-            }
-        }
+        public virtual bool IsEmpty => (_triples.Count == 0);
 
         #endregion
 
@@ -993,8 +962,6 @@ namespace VDS.RDF
             DetachEventHandlers(_triples);
         }
 
-#if !NETCORE
-
         #region ISerializable Members
 
         /// <summary>
@@ -1122,7 +1089,5 @@ namespace VDS.RDF
         }
 
         #endregion
-
-#endif
     }
 }

--- a/Libraries/dotNetRDF/Core/GraphPersistenceWrapper.cs
+++ b/Libraries/dotNetRDF/Core/GraphPersistenceWrapper.cs
@@ -52,9 +52,7 @@ namespace VDS.RDF
     /// Note that the wrapper does not automatically dispose of the wrapped graph when the wrapper is Dispose, this is by design since disposing of the wrapped Graph can have unintended consequences.
     /// </para>
     /// </remarks>
-#if !NETCORE
     [Serializable,XmlRoot(ElementName="graph")]
-#endif
     public class GraphPersistenceWrapper 
         : IGraph, ITransactionalGraph
     {
@@ -89,8 +87,7 @@ namespace VDS.RDF
         /// <param name="g">Graph.</param>
         public GraphPersistenceWrapper(IGraph g)
         {
-            if (g == null) throw new ArgumentNullException("graph", "Wrapped Graph cannot be null");
-            _g = g;
+            _g = g ?? throw new ArgumentNullException(nameof(g), "Wrapped Graph cannot be null");
 
             // Create Event Handlers and attach to the Triple Collection
             _tripleAddedHandler = new TripleEventHandler(OnTripleAsserted);
@@ -112,7 +109,6 @@ namespace VDS.RDF
             _alwaysQueueActions = alwaysQueueActions;
         }
 
-#if !NETCORE
         private List<Triple> _temp;
 
         /// <summary>
@@ -136,8 +132,6 @@ namespace VDS.RDF
             }
         }
 
-#endif
-
         /// <summary>
         /// Destructor for the wrapper to ensure that <see cref="GraphPersistenceWrapper.Dispose()">Dispose()</see> is called and thus that persistence happens
         /// </summary>
@@ -153,59 +147,30 @@ namespace VDS.RDF
         /// </summary>
         public Uri BaseUri
         {
-            get
-            {
-                return _g.BaseUri;
-            }
-            set
-            {
-                _g.BaseUri = value;
-            }
+            get => _g.BaseUri;
+            set => _g.BaseUri = value;
         }
 
         /// <summary>
         /// Gets whether the Graph is empty.
         /// </summary>
-        public bool IsEmpty
-        {
-            get 
-            { 
-                return _g.IsEmpty; 
-            }
-        }
+        public bool IsEmpty => _g.IsEmpty;
 
         /// <summary>
         /// Gets the Namespace Map for the Graph.
         /// </summary>
-        public INamespaceMapper NamespaceMap
-        {
-            get
-            { 
-                return _g.NamespaceMap; 
-            }
-        }
+        public INamespaceMapper NamespaceMap => _g.NamespaceMap;
 
-        /// <summary>
-        /// Gets the Nodes of the Graph.
-        /// </summary>
-        public IEnumerable<INode> Nodes
-        {
-            get 
-            { 
-                return _g.Nodes; 
-            }
-        }
+        /// <inheritdoc/>
+        public IEnumerable<INode> Nodes => _g.Nodes;
+
+        /// <inheritdoc/>
+        public IEnumerable<INode> AllNodes => _g.AllNodes;
 
         /// <summary>
         /// Gets the Triple Collection for the Graph.
         /// </summary>
-        public BaseTripleCollection Triples
-        {
-            get 
-            {
-                return _g.Triples; 
-            }
-        }
+        public BaseTripleCollection Triples => _g.Triples;
 
         /// <summary>
         /// Asserts a Triple in the Graph.
@@ -1152,13 +1117,7 @@ namespace VDS.RDF
         /// If <strong>true</strong> then the <see cref="GraphPersistenceWrapper.PersistInsertedTriples">PersistInsertedTriples()</see> and <see cref="GraphPersistenceWrapper.PersistDeletedTriples">PersistDeletedTriples()</see> methods are used to persist changes when the <see cref="GraphPersistenceWrapper.Flush">Flush()</see> method is called.  If <strong>false</strong> then the <see cref="GraphPersistenceWrapper.PersistGraph">PersistGraph()</see> method will be invoked instead.
         /// </para>
         /// </remarks>
-        protected virtual bool SupportsTriplePersistence
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected virtual bool SupportsTriplePersistence => true;
 
         /// <summary>
         /// Persists inserted Triples to the underlying Storage.
@@ -1383,13 +1342,7 @@ namespace VDS.RDF
         /// <summary>
         /// Gets whether the in-use <see cref="IStorageProvider">IStorageProvider</see> supports triple level updates.
         /// </summary>
-        protected override bool SupportsTriplePersistence
-        {
-            get
-            {
-                return _manager.UpdateSupported;
-            }
-        }
+        protected override bool SupportsTriplePersistence => _manager.UpdateSupported;
 
         /// <summary>
         /// Persists the deleted Triples to the in-use <see cref="IStorageProvider">IStorageProvider</see>.
@@ -1473,13 +1426,7 @@ namespace VDS.RDF
         /// <summary>
         /// Returns that Triple persistence is not supported.
         /// </summary>
-        protected override bool SupportsTriplePersistence
-        {
-            get
-            {
-                return false;
-            }
-        }
+        protected override bool SupportsTriplePersistence => false;
 
         /// <summary>
         /// Persists the entire Graph to a File.

--- a/Libraries/dotNetRDF/Core/IGraph.cs
+++ b/Libraries/dotNetRDF/Core/IGraph.cs
@@ -71,12 +71,18 @@ namespace VDS.RDF
         }
 
         /// <summary>
-        /// Gets the Nodes of the Graph.
+        /// Gets the unique Subject and Object nodes of the Graph.
         /// </summary>
+        /// <remarks>This property returns only nodes that appear in the Subject or Object position in triples. To retrieve a list of all INode instances in a graph including those in Predicate position in a triple, use the <see cref="AllNodes"/> property.</remarks>
         IEnumerable<INode> Nodes 
         {
             get;
         }
+
+        /// <summary>
+        /// Gets the unique Subject, Predicate and Object nodes of the Graph.
+        /// </summary>
+        IEnumerable<INode> AllNodes { get; }
 
         /// <summary>
         /// Gets the Triple Collection for the Graph.

--- a/Libraries/dotNetRDF/Core/UnionGraph.cs
+++ b/Libraries/dotNetRDF/Core/UnionGraph.cs
@@ -61,15 +61,10 @@ namespace VDS.RDF
         /// <summary>
         /// Gets the Nodes of the Graph.
         /// </summary>
-        public override IEnumerable<INode> Nodes
-        {
-            get
-            {
-                return _default.Nodes.Concat(from g in _graphs
-                                                  from n in g.Nodes
-                                                  select n);
-            }
-        }
+        public override IEnumerable<INode> Nodes =>
+            _default.Nodes.Concat(from g in _graphs
+                from n in g.Nodes
+                select n);
 
         /// <summary>
         /// Asserts some Triples in the Graph.

--- a/Libraries/dotNetRDF/Core/WrapperGraph.cs
+++ b/Libraries/dotNetRDF/Core/WrapperGraph.cs
@@ -110,59 +110,31 @@ namespace VDS.RDF
         /// </summary>
         public virtual Uri BaseUri
         {
-            get
-            {
-                return _g.BaseUri;
-            }
-            set
-            {
-                _g.BaseUri = value;
-            }
+            get => _g.BaseUri;
+            set => _g.BaseUri = value;
         }
 
         /// <summary>
         /// Gets whether the Graph is empty.
         /// </summary>
-        public virtual bool IsEmpty
-        {
-            get 
-            { 
-                return _g.IsEmpty; 
-            }
-        }
+        public virtual bool IsEmpty => _g.IsEmpty;
 
         /// <summary>
         /// Gets the Namespace Map for the Graph.
         /// </summary>
-        public virtual INamespaceMapper NamespaceMap
-        {
-            get
-            { 
-                return _g.NamespaceMap; 
-            }
-        }
+        public virtual INamespaceMapper NamespaceMap => _g.NamespaceMap;
 
-        /// <summary>
-        /// Gets the Nodes of the Graph.
-        /// </summary>
-        public virtual IEnumerable<INode> Nodes
-        {
-            get 
-            { 
-                return _g.Nodes; 
-            }
-        }
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> Nodes => _g.Nodes;
+
+
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> AllNodes => _g.AllNodes;
 
         /// <summary>
         /// Gets the Triple Collection for the Graph.
         /// </summary>
-        public virtual BaseTripleCollection Triples
-        {
-            get 
-            {
-                return _g.Triples; 
-            }
-        }
+        public virtual BaseTripleCollection Triples => _g.Triples;
 
         /// <summary>
         /// Asserts a Triple in the Graph.

--- a/Testing/unittest/Core/AbstractGraphTests.cs
+++ b/Testing/unittest/Core/AbstractGraphTests.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using FluentAssertions;
 using Xunit;
 using VDS.RDF.Parsing;
 
@@ -65,7 +66,7 @@ namespace VDS.RDF
         public void GraphAssert01()
         {
             IGraph g = this.GetInstance();
-            g.NamespaceMap.AddNamespace(String.Empty, UriFactory.Create("http://example/"));
+            g.NamespaceMap.AddNamespace(string.Empty, UriFactory.Create("http://example/"));
 
             Triple t = new Triple(g.CreateUriNode(":s"), g.CreateUriNode(":p"), g.CreateBlankNode(":o"));
             g.Assert(t);
@@ -77,7 +78,7 @@ namespace VDS.RDF
         public void GraphRetract01()
         {
             IGraph g = this.GetInstance();
-            g.NamespaceMap.AddNamespace(String.Empty, UriFactory.Create("http://example/"));
+            g.NamespaceMap.AddNamespace(string.Empty, UriFactory.Create("http://example/"));
 
             Triple t = new Triple(g.CreateUriNode(":s"), g.CreateUriNode(":p"), g.CreateBlankNode(":o"));
             g.Assert(t);
@@ -102,6 +103,24 @@ namespace VDS.RDF
 
             g.Retract(g.GetTriplesWithPredicate(rdfType).ToList());
             Assert.False(g.GetTriplesWithPredicate(rdfType).Any());
+        }
+
+        [Fact]
+        public void NodesPropertyShouldNotReturnPredicateNodes()
+        {
+            var g = GetInstance();
+            g.NamespaceMap.AddNamespace(string.Empty, UriFactory.Create("http://example/"));
+            g.Assert(new Triple(g.CreateUriNode(":s"), g.CreateUriNode(":p"), g.CreateUriNode(":o")));
+            g.Nodes.Should().HaveCount(2).And.NotContain(g.CreateUriNode(":p"));
+        }
+
+        [Fact]
+        public void AllNodesPropertyShouldIncludePredicateNodes()
+        {
+            var g = GetInstance();
+            g.NamespaceMap.AddNamespace(string.Empty, UriFactory.Create("http://example/"));
+            g.Assert(new Triple(g.CreateUriNode(":s"), g.CreateUriNode(":p"), g.CreateUriNode(":o")));
+            g.AllNodes.Should().HaveCount(3).And.Contain(g.CreateUriNode(":p"));
         }
 
         [Fact]


### PR DESCRIPTION
Updated description of IGraph.Nodes property to make it clear that only subject and object nodes are returned and that the IGraph.AllNodes property should be used to also enumerate over predicate nodes.

Closes #207