### PR TITLE
Add default result messages for constraints

### DIFF
--- a/Libraries/dotNetRDF/Shacl/Constraints/And.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/And.cs
@@ -38,7 +38,9 @@ namespace VDS.RDF.Shacl.Constraints
             : base(shape, node)
         {
         }
- 
+
+        protected override string DefaultMessage => "Value must conform to all of the specified shapes.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Ask.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Ask.cs
@@ -43,6 +43,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "SPARQL ASK must return true for all value nodes.";
+
         protected override string Query
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Class.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Class.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value node must be an instance of type {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Closed.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Closed.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value node must not have properties other than those defined by this shape.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Datatype.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Datatype.cs
@@ -45,6 +45,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be a literal with a datatype of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Disjoint.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Disjoint.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be disjoint with the values of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Equals.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Equals.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Values nodes must be the same as the values of the property {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/HasValue.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/HasValue.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/In.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/In.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be one of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/LanguageIn.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/LanguageIn.cs
@@ -41,6 +41,9 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage =>
+            $"Value must be a literal with a language tag that is one of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/LessThan.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/LessThan.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be less than the value of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/LessThanOrEquals.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/LessThanOrEquals.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be less than or equal to the value of {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MaxCount.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MaxCount.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"There must be no more than {NumericValue} values.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MaxExclusive.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MaxExclusive.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be less than {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MaxInclusive.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MaxInclusive.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be less than or equal to {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MaxLength.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MaxLength.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value length must be less than {NumericValue}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MinCount.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MinCount.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"There should be at least {NumericValue} value(s).";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MinExclusive.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MinExclusive.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be greater than {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MinInclusive.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MinInclusive.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be greater than or equal to {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/MinLength.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/MinLength.cs
@@ -36,6 +36,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value length must be greater than or equal to {NumericValue}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Node.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Node.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value must conform to the specified node shape.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/NodeKind.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/NodeKind.cs
@@ -40,6 +40,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => $"Value must be a node of the SHACL node kind {this}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Not.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Not.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value must not conform to the prohibited node shape.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Or.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Or.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value must conform to at least one of the specified node shapes.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Pattern.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Pattern.cs
@@ -40,6 +40,9 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage =>
+            $"Value must match the expected regular expression \"{this}\" with flags \"{Flags}\".";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/QualifiedMaxCount.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/QualifiedMaxCount.cs
@@ -39,6 +39,9 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage =>
+            $"Number of value nodes matching the shape {Shape} must not exceed {NumericValue}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/QualifiedMinCount.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/QualifiedMinCount.cs
@@ -39,6 +39,9 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage =>
+            $"Number of value nodes matching the shape {Shape} must be at least {NumericValue}.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Select.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Select.cs
@@ -50,6 +50,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "SPARQL SELECT query must not return any result bindings.";
+
         protected override string Query
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/UniqueLang.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/UniqueLang.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value nodes must not use the same language tag.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Libraries/dotNetRDF/Shacl/Constraints/Xone.cs
+++ b/Libraries/dotNetRDF/Shacl/Constraints/Xone.cs
@@ -39,6 +39,8 @@ namespace VDS.RDF.Shacl.Constraints
         {
         }
 
+        protected override string DefaultMessage => "Value must conform to exactly one of the specified target shapes.";
+
         internal override INode ConstraintComponent
         {
             get

--- a/Testing/unittest/Shacl/Examples.cs
+++ b/Testing/unittest/Shacl/Examples.cs
@@ -64,6 +64,7 @@ namespace VDS.RDF.Shacl
     sh:conforms false ;
     sh:result [
         a sh:ValidationResult ;
+        sh:resultMessage ""Value node must be an instance of type urn:C."" ;
         sh:sourceConstraintComponent sh:ClassConstraintComponent ;
         sh:resultSeverity sh:Violation ;
         sh:sourceShape [] ;


### PR DESCRIPTION
This PR updates the SHACL constraint classes with a default message for each one.