### PR TITLE
IsReady implementation for StardogConnector

### DIFF
--- a/Libraries/dotNetRDF/Storage/StardogConnector.cs
+++ b/Libraries/dotNetRDF/Storage/StardogConnector.cs
@@ -116,6 +116,8 @@ namespace VDS.RDF.Storage
         private string _activeTrans;
         private readonly TriGWriter _writer = new TriGWriter();
 
+        private bool? _isReady = null;
+
         /// <summary>
         /// The underlying server connection.
         /// </summary>
@@ -268,7 +270,17 @@ namespace VDS.RDF.Storage
         /// <summary>
         /// Returns that the Connection is ready.
         /// </summary>
-        public override bool IsReady => true;
+        public override bool IsReady
+        {
+            get
+            {
+                if (!_isReady.HasValue)
+                {
+                    _isReady = Server.ListStores().Contains(_kb);
+                }
+                return _isReady.Value;
+            }
+        }
 
         /// <summary>
         /// Returns that the Connection is not read-only.
@@ -2448,6 +2460,7 @@ namespace VDS.RDF.Storage
         public override void Dispose()
         {
             // No Dispose actions
+            _isReady = false;
         }
 
         /// <summary>

--- a/Testing/unittest/Storage/StardogTests.cs
+++ b/Testing/unittest/Storage/StardogTests.cs
@@ -659,6 +659,28 @@ namespace VDS.RDF.Storage
             stardog.Dispose();
         }
 
+        [SkippableFact]
+        public void StorageStardogIsReadyValidDb()
+        {
+            StardogConnector stardog = StardogTests.GetConnection();
+            Assert.True(stardog.IsReady);
+
+            stardog.Dispose();
+        }
+
+        [SkippableFact]
+        public void StorageStardogIsReadyInvalidDb()
+        {
+            Skip.IfNot(TestConfigManager.GetSettingAsBoolean(TestConfigManager.UseStardog), "Test Config marks Stardog as unavailable, test cannot be run");
+            StardogConnector stardog =  new StardogConnector(TestConfigManager.GetSetting(TestConfigManager.StardogServer),
+                "i_dont_exist",
+                TestConfigManager.GetSetting(TestConfigManager.StardogUser),
+                TestConfigManager.GetSetting(TestConfigManager.StardogPassword));
+            Assert.False(stardog.IsReady);
+
+            stardog.Dispose();
+        }
+
         public void Dispose()
         {
             Options.HttpDebugging = false;


### PR DESCRIPTION
Fixes issue #278 

The IsReady property of the StardogConnector will now check if the specified database is actually included in the list of stores returned by a call to the Server's `ListStores` method