### PR TITLE
Fix NumericNode constructors

### DIFF
--- a/Libraries/dotNetRDF/Nodes/DecimalNode.cs
+++ b/Libraries/dotNetRDF/Nodes/DecimalNode.cs
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Globalization;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Query.Expressions;
@@ -45,7 +46,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Decimal value.</param>
         /// <param name="lexicalValue">Lexical value.</param>
-        public DecimalNode(IGraph g, decimal value, String lexicalValue)
+        public DecimalNode(IGraph g, decimal value, string lexicalValue)
             : base(g, lexicalValue, UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeDecimal), SparqlNumericType.Decimal)
         {
             _value = value;
@@ -57,7 +58,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Decimal value.</param>
         public DecimalNode(IGraph g, decimal value)
-            : this(g, value, value.ToString()) { }
+            : this(g, value, value.ToString(CultureInfo.InvariantCulture)) { }
 
         /// <summary>
         /// Gets the integer value of the decimal.

--- a/Libraries/dotNetRDF/Nodes/DoubleNode.cs
+++ b/Libraries/dotNetRDF/Nodes/DoubleNode.cs
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Globalization;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Query.Expressions;
@@ -57,7 +58,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Double value.</param>
         public DoubleNode(IGraph g, double value)
-            : this(g, value, value.ToString()) { }
+            : this(g, value, value.ToString(CultureInfo.InvariantCulture)) { }
 
         /// <summary>
         /// Gets the integer value of the double.

--- a/Libraries/dotNetRDF/Nodes/FloatNode.cs
+++ b/Libraries/dotNetRDF/Nodes/FloatNode.cs
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Globalization;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Query.Expressions;
@@ -57,7 +58,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Float value.</param>
         public FloatNode(IGraph g, float value)
-            : this(g, value, value.ToString()) { }
+            : this(g, value, value.ToString(CultureInfo.InvariantCulture)) { }
 
         /// <summary>
         /// Gets the integer value of the float.

--- a/Libraries/dotNetRDF/Nodes/LongNode.cs
+++ b/Libraries/dotNetRDF/Nodes/LongNode.cs
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Globalization;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Query.Expressions;
@@ -45,7 +46,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Long value.</param>
         /// <param name="lexicalValue">Lexical Value.</param>
-        public LongNode(IGraph g, long value, String lexicalValue)
+        public LongNode(IGraph g, long value, string lexicalValue)
             : this(g, value, lexicalValue, UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeInteger)) { }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace VDS.RDF.Nodes
         /// <param name="value">Long value.</param>
         /// <param name="lexicalValue">Lexical Value.</param>
         /// <param name="datatype">Datatype URI.</param>
-        public LongNode(IGraph g, long value, String lexicalValue, Uri datatype)
+        public LongNode(IGraph g, long value, string lexicalValue, Uri datatype)
             : base(g, lexicalValue, datatype, SparqlNumericType.Integer)
         {
             _value = value;
@@ -67,7 +68,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Long value.</param>
         public LongNode(IGraph g, long value)
-            : this(g, value, value.ToString()) { }
+            : this(g, value, value.ToString(CultureInfo.InvariantCulture)) { }
 
         /// <summary>
         /// Gets the long value.
@@ -141,7 +142,7 @@ namespace VDS.RDF.Nodes
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Unsigned Long value.</param>
         /// <param name="lexicalValue">Lexical Value.</param>
-        public UnsignedLongNode(IGraph g, ulong value, String lexicalValue)
+        public UnsignedLongNode(IGraph g, ulong value, string lexicalValue)
             : this(g, value, lexicalValue, UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeUnsignedInt)) { }
 
         /// <summary>
@@ -151,19 +152,19 @@ namespace VDS.RDF.Nodes
         /// <param name="value">Unsigned Long value.</param>
         /// <param name="lexicalValue">Lexical Value.</param>
         /// <param name="datatype">Datatype URI.</param>
-        public UnsignedLongNode(IGraph g, ulong value, String lexicalValue, Uri datatype)
+        public UnsignedLongNode(IGraph g, ulong value, string lexicalValue, Uri datatype)
             : base(g, lexicalValue, datatype, SparqlNumericType.Integer)
         {
             _value = value;
         }
 
         /// <summary>
-        /// Creates a new usigned long valued node.
+        /// Creates a new unsigned long valued node.
         /// </summary>
         /// <param name="g">Graph the node belongs to.</param>
         /// <param name="value">Unsigned Long value.</param>
         public UnsignedLongNode(IGraph g, ulong value)
-            : this(g, value, value.ToString()) { }
+            : this(g, value, value.ToString(CultureInfo.InvariantCulture)) { }
 
         /// <summary>
         /// Gets the long value of the ulong.

--- a/Testing/unittest/BaseTest.cs
+++ b/Testing/unittest/BaseTest.cs
@@ -43,5 +43,10 @@ namespace VDS.RDF
                 new CultureInfo("ru-RU"), 
                 new CultureInfo("pt-BR")
             };
+
+        public static IEnumerable<object[]> GetTestCultures()
+        {
+            return TestedCultureInfos.Select(ci => new object[]{ci});
+        }
     }
 }

--- a/Testing/unittest/Core/ValuedNodeTests.cs
+++ b/Testing/unittest/Core/ValuedNodeTests.cs
@@ -107,6 +107,7 @@ namespace VDS.RDF
             foreach (var ci in TestedCultureInfos)
             {
                 TestTools.ExecuteWithChangedCulture(ci, () => RoundTripValuedNodeConversion(3.4m, n => n.AsDecimal()));
+                TestTools.ExecuteWithChangedCulture(ci, () => RoundTripValuedNodeConversion(1000000.0m, n => n.AsDecimal()));
             }
         }
 
@@ -116,6 +117,7 @@ namespace VDS.RDF
             foreach (var ci in TestedCultureInfos)
             {
                 TestTools.ExecuteWithChangedCulture(ci, () => RoundTripValuedNodeConversion(3.4d, n => n.AsDouble()));
+                TestTools.ExecuteWithChangedCulture(ci, ()=>RoundTripValuedNodeConversion(1000000.0d, n=>n.AsDouble()));
             }
         }
 
@@ -125,7 +127,42 @@ namespace VDS.RDF
             foreach (var ci in TestedCultureInfos)
             {
                 TestTools.ExecuteWithChangedCulture(ci, () => RoundTripValuedNodeConversion(3.4f, n => n.AsFloat()));
+                TestTools.ExecuteWithChangedCulture(ci, () => RoundTripValuedNodeConversion(1000.0e3f, n => n.AsFloat()));
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCultures))]
+        public void ShouldApplyInvariantFormattingToDecimalLiteralStringRegardlessOfCulture(CultureInfo ci)
+        {
+            TestTools.ExecuteWithChangedCulture(ci, () => AssertLiteralString("3.4", ()=>new DecimalNode(_graph, 3.4m)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCultures))]
+        public void ShouldApplyInvariantFormattingToDoubleLiteralStringRegardlessOfCulture(CultureInfo ci)
+        {
+            TestTools.ExecuteWithChangedCulture(ci, () => AssertLiteralString("3.4", () => new DoubleNode(_graph, 3.4d)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCultures))]
+        public void ShouldApplyInvariantFormattingToFloatLiteralStringRegardlessOfCulture(CultureInfo ci)
+        {
+            TestTools.ExecuteWithChangedCulture(ci, () => AssertLiteralString("3.4", () => new FloatNode(_graph, 3.4f)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCultures))]
+        public void ShouldApplyInvariantFormattingToLongLiteralStringRegardlessOfCulture(CultureInfo ci)
+        {
+            TestTools.ExecuteWithChangedCulture(ci, () => AssertLiteralString("3400000", () => new LongNode(_graph, 3400000L)));
+        }
+
+        private void AssertLiteralString(string expectLiteral, Func<IValuedNode> constructor)
+        {
+            var valuedNode = constructor();
+            Assert.Equal(expectLiteral, (valuedNode as ILiteralNode).Value);
         }
 
         private void RoundTripValuedNodeConversion<T>(dynamic value, Func<IValuedNode, T> convertBack)


### PR DESCRIPTION
Fixes the constructors of the classes derived from NumericNode so that the constructor that takes only a value type parameter generates a literal value using the invariant culture.
Addresses #306