### PR TITLE
fix: n-triples formatter double encoded escaped characters

### DIFF
--- a/Libraries/dotNetRDF/Core/URINode.cs
+++ b/Libraries/dotNetRDF/Core/URINode.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -41,7 +42,8 @@ namespace VDS.RDF
 #if !NETCORE
     [Serializable,XmlRoot(ElementName="uri")]
 #endif
-    public abstract class BaseUriNode 
+    [DebuggerDisplay("{" + nameof(_uri) + "}")]
+    public abstract class BaseUriNode
         : BaseNode, IUriNode, IEquatable<BaseUriNode>, IComparable<BaseUriNode>, IValuedNode
     {
         private Uri _uri;
@@ -529,13 +531,13 @@ namespace VDS.RDF
                 return String.Empty;
             }
         }
-        
+
         /// <summary>
         /// Gets the numeric type of the expression.
         /// </summary>
         public SparqlNumericType NumericType
         {
-            get 
+            get
             {
                 return SparqlNumericType.NaN;
             }

--- a/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
@@ -118,9 +118,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <returns></returns>
         public virtual String FormatUri(String u)
         {
-            // String uri = Uri.EscapeUriString(u);
-            u = u.Replace(">", "\\>");
-            return u;
+            return Rfc3987Formatter.EscapeUriString(u);
         }
 
         /// <summary>

--- a/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -130,7 +130,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <returns></returns>
         public virtual String FormatUri(Uri u)
         {
-            return FormatUri(u.AbsoluteUri);
+            return FormatUri(u.ToString());
         }
 
         /// <summary>

--- a/Libraries/dotNetRDF/Writing/Formatting/NTriplesFormatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/NTriplesFormatter.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -44,8 +44,8 @@ namespace VDS.RDF.Writing.Formatting
         /// Set of characters which must be escaped in Literals.
         /// </summary>
         private readonly List<string[]> _litEscapes = new List<string[]>
-        { 
-            new [] { @"\", @"\\" }, 
+        {
+            new [] { @"\", @"\\" },
             new [] { "\"", "\\\"" },
             new [] { "\n", @"\n" },
             new [] { "\r", @"\r" },
@@ -122,7 +122,7 @@ namespace VDS.RDF.Writing.Formatting
             return output.ToString();
         }
 
-        
+
         /// <summary>
         /// Formats a Literal Node.
         /// </summary>
@@ -237,7 +237,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <inheritdoc />
         public override string FormatUri(string u)
         {
-            return FormatChar(base.FormatUri(u).ToCharArray());
+            return FormatChar(u.ToCharArray());
         }
     }
 

--- a/Libraries/dotNetRDF/Writing/Formatting/Rfc3987Formatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/Rfc3987Formatter.cs
@@ -2,21 +2,21 @@
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
-// 
+//
 // Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is furnished
 // to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
@@ -33,55 +33,95 @@ namespace VDS.RDF.Writing.Formatting
         public static string EscapeUriString(string uriString)
         {
             var builder = new StringBuilder();
-            foreach (var c in uriString)
+            using (var enumerator = uriString.GetEnumerator())
             {
-                if (c >= 0x30 && c <= 0x39)
+                while (enumerator.MoveNext())
                 {
-                    // DIGIT
-                    builder.Append(c);
-                }
-                else if (c >= 0x041 && c <= 0x5a)
-                {
-                    // ALPHA
-                    builder.Append(c);
-                }
-                else if (c >= 0x61 && c <= 0x7a)
-                {
-                    // alpha
-                    builder.Append(c);
-                }
-                else if (c == '-' || c == '.' || c == '_' || c == '~')
-                {
-                    // unreserved
-                    builder.Append(c);
-                }
-                else if (c == ':' || c == '/' || c == '?' || c == '#' || c == '[' || c == ']' || c == '@' ||
-                         c == '!' || c == '$' || c == '&' || c == '\'' || c == '(' || c == ')' || c == '*' ||
-                         c == '+' || c == ',' || c == ';' || c == '=')
-                {
-                    // reserved
-                    builder.Append(c);
-                }
-                else if (c >= 0xA0 && c <= 0xD7FF || c >= 0xF900 && c <= 0xFDCF || c >= 0xFDF0 && c <= 0xFFEF ||
-                         c >= 0x10000 && c <= 0x1FFFD || c >= 0x20000 && c <= 0x2FFFD || c >= 0x30000 && c <= 0x3FFFD
-                         || c >= 0x40000 && c <= 0x4FFFD || c >= 0x50000 && c <= 0x5FFFD || c >= 0x60000 && c <= 0x6FFFD
-                         || c >= 0x70000 && c <= 0x7FFFD || c >= 0x80000 && c <= 0x8FFFD || c >= 0x90000 && c <= 0x9FFFD
-                         || c >= 0xA0000 && c <= 0xAFFFD || c >= 0xB0000 && c <= 0xBFFFD || c >= 0xC0000 && c <= 0xCFFFD
-                         || c >= 0xD0000 && c <= 0xDFFFD || c >= 0xE1000 && c <= 0xEFFFD)
-                {
-                    builder.Append(c);
-                }
-                else if (c >= 0xE000 && c <= 0xF8FF || c >= 0xF0000 && c <= 0xFFFFD && c >= 0x100000 && c <= 0x10FFFD)
-                {
-                    builder.Append(c);
-                }
-                else
-                {
-                    builder.Append(EscapeChar(c));
+                    var c = enumerator.Current;
+                    if (c == '%')
+                    {
+                        // Possibly already escaped
+                        char? escaped1 = null;
+                        char? escaped2 = null;
+                        if (enumerator.MoveNext())
+                        {
+                            escaped1 = enumerator.Current;
+                        }
+                        else
+                        {
+                            builder.AppendEscaped(c);
+                            continue;
+                        }
+
+                        if (enumerator.MoveNext())
+                        {
+                            escaped2 = enumerator.Current;
+                        }
+                        else
+                        {
+                            builder.AppendEscaped(c);
+                            builder.AppendEscaped(escaped1.Value);
+                            continue;
+                        }
+
+                        builder.AppendFormat("%{0}{1}", escaped1, escaped2);
+                    }
+                    else
+                    {
+                        builder.AppendEscaped(c);
+                    }
                 }
             }
 
             return builder.ToString();
+        }
+
+        private static void AppendEscaped(this StringBuilder builder, char c)
+        {
+            if (c >= 0x30 && c <= 0x39)
+            {
+                 // DIGIT
+                 builder.Append(c);
+            }
+            else if (c >= 0x041 && c <= 0x5a)
+            {
+                // ALPHA
+                builder.Append(c);
+            }
+            else if (c >= 0x61 && c <= 0x7a)
+            {
+                // alpha
+                builder.Append(c);
+            }
+            else if (c == '-' || c == '.' || c == '_' || c == '~')
+            {
+                // unreserved
+                builder.Append(c);
+            }
+            else if (c == ':' || c == '/' || c == '?' || c == '#' || c == '[' || c == ']' || c == '@' ||
+              c == '!' || c == '$' || c == '&' || c == '\'' || c == '(' || c == ')' || c == '*' ||
+              c == '+' || c == ',' || c == ';' || c == '=')
+            {
+                // reserved
+                builder.Append(c);
+            }
+            else if (c >= 0xA0 && c <= 0xD7FF || c >= 0xF900 && c <= 0xFDCF || c >= 0xFDF0 && c <= 0xFFEF ||
+              c >= 0x10000 && c <= 0x1FFFD || c >= 0x20000 && c <= 0x2FFFD || c >= 0x30000 && c <= 0x3FFFD
+              || c >= 0x40000 && c <= 0x4FFFD || c >= 0x50000 && c <= 0x5FFFD || c >= 0x60000 && c <= 0x6FFFD
+              || c >= 0x70000 && c <= 0x7FFFD || c >= 0x80000 && c <= 0x8FFFD || c >= 0x90000 && c <= 0x9FFFD
+              || c >= 0xA0000 && c <= 0xAFFFD || c >= 0xB0000 && c <= 0xBFFFD || c >= 0xC0000 && c <= 0xCFFFD
+              || c >= 0xD0000 && c <= 0xDFFFD || c >= 0xE1000 && c <= 0xEFFFD)
+            {
+                builder.Append(c);
+            }
+            else if (c >= 0xE000 && c <= 0xF8FF || c >= 0xF0000 && c <= 0xFFFFD && c >= 0x100000 && c <= 0x10FFFD)
+            {
+                builder.Append(c);
+            }
+            else
+            {
+                builder.Append(EscapeChar(c));
+            }
         }
 
         private static string EscapeChar(char c)

--- a/Testing/unittest/Writing/NTriplesFormatterTests.cs
+++ b/Testing/unittest/Writing/NTriplesFormatterTests.cs
@@ -40,6 +40,14 @@ namespace VDS.RDF.Writing
             formatOutput.Should().Be("http://example.org/渋谷駅");
         }
 
+        [Fact]
+        public void EscapeSequenceInOriginalStringMustNotBeDoubleEscaped()
+        {
+            var formatter = new NTriplesFormatter(NTriplesSyntax.Rdf11);
+            var formatOutput = formatter.FormatUri(new Uri("http://example.org/September%2C 2020"));
+            formatOutput.Should().Be("http://example.org/September%2C%202020");
+        }
+
         [Fact(Skip="Fails because the .NET URI constructor always unescapes %66 to f")]
         public void PercentCharactersArePreservedInUriFormatting()
         {

--- a/Testing/unittest/Writing/NTriplesFormatterTests.cs
+++ b/Testing/unittest/Writing/NTriplesFormatterTests.cs
@@ -48,6 +48,16 @@ namespace VDS.RDF.Writing
             formatOutput.Should().Be("http://example.org/September%2C%202020");
         }
 
+        [Theory]
+        [InlineData("http://example.org/September%2", "http://example.org/September%252")]
+        [InlineData("http://example.org/September%", "http://example.org/September%25")]
+        public void IncompleteEscapeSequenceGetsEscaped(string input, string expected)
+        {
+            var formatter = new NTriplesFormatter(NTriplesSyntax.Rdf11);
+            var formatOutput = formatter.FormatUri(new Uri(input));
+            formatOutput.Should().Be(expected);
+        }
+
         [Fact(Skip="Fails because the .NET URI constructor always unescapes %66 to f")]
         public void PercentCharactersArePreservedInUriFormatting()
         {
@@ -56,6 +66,5 @@ namespace VDS.RDF.Writing
             var formatOutput = formatter.FormatUri(u);
             formatOutput.Should().Be("http://a.example/%66oo-bar");
         }
-
     }
 }


### PR DESCRIPTION
This should address the double-escaping problem and should also fix a problem that Turtle formatter escaped Unicode characters

Unfortunately there are insufficient tests or maybe I missed them because I run Rider on Mac. Let's see what CI says.