### PR TITLE
Add unit tests to PR #333

### DIFF
--- a/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
@@ -98,39 +98,8 @@ namespace VDS.RDF.JsonLd
         {
             foreach (var linkHeaderValue in linkHeaderValues)
             {
-                var fields = linkHeaderValue.Split(';').Select(x => x.Trim());
-                var linkValue = fields.First().TrimStart('<').TrimEnd('>');
-                var relTypes = new List<string>();
-                var mediaTypes = new List<string>();
-                foreach (var field in fields)
-                {
-                    var split = field.Split(new char[] { '=' }, 2);
-                    if (split.Length == 2)
-                    {
-                        var key = split[0].Trim();
-                        var value = split[1].Trim();
-                        if (key.Equals("rel"))
-                        {
-                            value = value.Trim('"');
-                            relTypes.AddRange(value.Split(' '));
-                        }
-                        else if (key.Equals("type"))
-                        {
-                            value = value.Trim('"');
-                            mediaTypes.Add(value);
-                        }
-                    }
-                }
-
-                yield return new WebLink { LinkValue = linkValue, RelationTypes = relTypes, MediaTypes = mediaTypes };
+                if (WebLink.TryParse(linkHeaderValue, out var link)) yield return link;
             }
-        }
-
-        internal class WebLink
-        {
-            public string LinkValue { get; set; }
-            public List<string> RelationTypes { get; set; }
-            public List<string> MediaTypes { get; set; }
         }
 
         private class RedirectingWebClient : WebClient

--- a/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
@@ -60,7 +60,7 @@ namespace VDS.RDF.JsonLd
             {
                 var contextLinks = ParseLinkHeaders(client.ResponseHeaders.GetValues("Link"));
                 var alternateLink = contextLinks.FirstOrDefault(link =>
-                    link.RelationTypes.Contains("alternate") && link.MediaTypes.Contains("application/ld+json", new MediaTypeComparer()));
+                    link.RelationTypes.Contains("alternate") && link.MediaTypes.Contains("application/ld+json"));
                 if (alternateLink != null)
                 {
                     return LoadJson(new Uri(remoteRef, alternateLink.LinkValue), loaderOptions);
@@ -116,6 +116,7 @@ namespace VDS.RDF.JsonLd
                         }
                         else if (key.Equals("type"))
                         {
+                            value = value.Trim('"');
                             mediaTypes.Add(value);
                         }
                     }
@@ -141,19 +142,6 @@ namespace VDS.RDF.JsonLd
                 var webResponse = base.GetWebResponse(request);
                 ResponseUri = webResponse?.ResponseUri;
                 return webResponse;
-            }
-        }
-
-        internal class MediaTypeComparer : IEqualityComparer<string>
-        {
-            public bool Equals(string x, string y)
-            {
-                return x.IndexOf(y) > -1;
-            }
-
-            public int GetHashCode(string obj)
-            {
-                return obj.GetHashCode();
             }
         }
     }

--- a/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
@@ -60,7 +60,7 @@ namespace VDS.RDF.JsonLd
             {
                 var contextLinks = ParseLinkHeaders(client.ResponseHeaders.GetValues("Link"));
                 var alternateLink = contextLinks.FirstOrDefault(link =>
-                    link.RelationTypes.Contains("alternate") && link.MediaTypes.Contains("application/ld+json"));
+                    link.RelationTypes.Contains("alternate") && link.MediaTypes.Contains("application/ld+json", new MediaTypeComparer()));
                 if (alternateLink != null)
                 {
                     return LoadJson(new Uri(remoteRef, alternateLink.LinkValue), loaderOptions);
@@ -141,6 +141,19 @@ namespace VDS.RDF.JsonLd
                 var webResponse = base.GetWebResponse(request);
                 ResponseUri = webResponse?.ResponseUri;
                 return webResponse;
+            }
+        }
+
+        internal class MediaTypeComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string x, string y)
+            {
+                return x.IndexOf(y) > -1;
+            }
+
+            public int GetHashCode(string obj)
+            {
+                return obj.GetHashCode();
             }
         }
     }

--- a/Libraries/dotNetRDF/JsonLd/WebLink.cs
+++ b/Libraries/dotNetRDF/JsonLd/WebLink.cs
@@ -1,0 +1,68 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace VDS.RDF.JsonLd
+{
+    internal class WebLink
+    {
+        public string LinkValue { get; set; }
+        public List<string> RelationTypes { get; set; }
+        public List<string> MediaTypes { get; set; }
+
+        public static bool TryParse(string linkHeaderValue, out WebLink result)
+        {
+            var fields = linkHeaderValue.Split(';').Select(x => x.Trim()).ToList();
+            var linkValue = fields.First().TrimStart('<').TrimEnd('>');
+            var relTypes = new List<string>();
+            var mediaTypes = new List<string>();
+            foreach (var field in fields)
+            {
+                var split = field.Split(new char[] { '=' }, 2);
+                if (split.Length == 2)
+                {
+                    var key = split[0].Trim();
+                    var value = split[1].Trim();
+                    if (key.Equals("rel"))
+                    {
+                        value = value.Trim('"');
+                        relTypes.AddRange(value.Split(' '));
+                    }
+                    else if (key.Equals("type"))
+                    {
+                        value = value.Trim('"');
+                        mediaTypes.Add(value);
+                    }
+                }
+            }
+
+            result = new WebLink { LinkValue = linkValue, RelationTypes = relTypes, MediaTypes = mediaTypes };
+            return true;
+        }
+    }
+}

--- a/Testing/unittest/JsonLd/WebLinkTests.cs
+++ b/Testing/unittest/JsonLd/WebLinkTests.cs
@@ -1,0 +1,58 @@
+﻿using Xunit;
+
+namespace VDS.RDF.JsonLd
+{
+    public class WebLinkTests
+    {
+        [Fact]
+        public void ParseSimpleLinkHeader()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>", out var link);
+            Assert.True(isValid);
+            Assert.Equal("http://example.org/foo.json", link.LinkValue);
+        }
+
+        [Fact]
+        public void ItCanParseTheRelField()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>;rel=rel1", out var link);
+            Assert.True(isValid);
+            Assert.Equal(new [] {"rel1"}, link.RelationTypes);
+        }
+
+        [Fact]
+        public void ItCanParseMultipleValuesFromTheRelField()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>;rel=\"rel1 rel2\"", out var link);
+            Assert.True(isValid);
+            Assert.Equal(new[] { "rel1", "rel2" }, link.RelationTypes);
+        }
+
+        [Fact]
+        public void ItCanParseTheTypeField()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>;type=application/ld+json", out var link);
+            Assert.True(isValid);
+            Assert.Equal(new[] { "application/ld+json" }, link.MediaTypes);
+        }
+
+        [Fact]
+        public void ItCanParseAQuotedMediaType()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>;type=\"application/ld+json\"", out var link);
+            Assert.True(isValid);
+            Assert.Equal(new[] { "application/ld+json" }, link.MediaTypes);
+        }
+
+        [Fact]
+        public void ItCanParseMultipleFields()
+        {
+            var isValid = WebLink.TryParse("<http://example.org/foo.json>;type=\"application/ld+json\";rel=alternate",
+                out var link);
+            Assert.True(isValid);
+            Assert.Equal(new[] { "application/ld+json" }, link.MediaTypes);
+            Assert.Equal(new string[] {"alternate"}, link.RelationTypes);
+            Assert.Equal("http://example.org/foo.json", link.LinkValue);
+        }
+    }
+}


### PR DESCRIPTION
Refactor the WebLink class and link header parsing to make it more testable and add some unit tests, including one covering the case addressed in #333