### PR TITLE
Set HasBase in JsonLdContext only if Uri is not null

### DIFF
--- a/Libraries/dotNetRDF/JsonLd/JsonLdContext.cs
+++ b/Libraries/dotNetRDF/JsonLd/JsonLdContext.cs
@@ -71,7 +71,7 @@ namespace VDS.RDF.JsonLd
         /// <remarks>The value may be a relative or an absolute IRI or null.</remarks>
         public Uri Base { 
             get => _base;
-            set { _base = value; HasBase = true; }
+            set { _base = value; HasBase = value != null; }
         }
 
         /// <summary>

--- a/Libraries/dotNetRDF/JsonLd/JsonLdContext.cs
+++ b/Libraries/dotNetRDF/JsonLd/JsonLdContext.cs
@@ -71,13 +71,8 @@ namespace VDS.RDF.JsonLd
         /// <remarks>The value may be a relative or an absolute IRI or null.</remarks>
         public Uri Base { 
             get => _base;
-            set { _base = value; HasBase = value != null; }
+            set { _base = value; }
         }
-
-        /// <summary>
-        /// Returns true if the Base property of this context has been explicitly set.
-        /// </summary>
-        public bool HasBase { get; private set; }
 
         /// <summary>
         /// Get the base IRI that this context was originally created with.
@@ -140,7 +135,6 @@ namespace VDS.RDF.JsonLd
         public void RemoveBase()
         {
             Base = null;
-            HasBase = false;
         }
 
         /// <summary>
@@ -152,7 +146,6 @@ namespace VDS.RDF.JsonLd
             var clone = new JsonLdContext(OriginalBase)
             {
                 Base = Base,
-                HasBase = HasBase,
                 Language = Language,
                 BaseDirection = BaseDirection,
                 Version = Version,

--- a/Libraries/dotNetRDF/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRDF/JsonLd/Processors/CompactProcessor.cs
@@ -1002,7 +1002,7 @@ namespace VDS.RDF.JsonLd.Processors
             }
 
             // 10 - If vocab is false, transform var to a relative IRI reference using the base IRI from active context, if it exists.
-            if (!vocab && activeContext.HasBase)
+            if (!vocab && activeContext.Base != null)
             {
                 if (iri.StartsWith("_:"))
                 {

--- a/Libraries/dotNetRDF/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRDF/JsonLd/Processors/ContextProcessor.cs
@@ -1024,7 +1024,7 @@ namespace VDS.RDF.JsonLd.Processors
 
             // 8 Otherwise, if document relative is true, set value to the result of resolving value against the base IRI. 
             // TODO: Only the basic algorithm in section 5.2 of [RFC3986] is used; neither Syntax-Based Normalization nor Scheme-Based Normalization are performed. Characters additionally allowed in IRI references are treated in the same way that unreserved characters are treated in URI references, per section 6.5 of [RFC3987].
-            if (documentRelative && activeContext.HasBase)
+            if (documentRelative && activeContext.Base != null)
             {
                 var iri = new Uri(activeContext.Base, value);
                 return iri.ToString();


### PR DESCRIPTION
I discovered this bug trying to run the compaction algorithm against the below input with context `{}`. The exception I got was a null reference at [this line](https://github.com/dotnetrdf/dotnetrdf/blob/fb3f801130a23735bca60408c37a7da32af169c7/Libraries/dotNetRDF/JsonLd/Processors/CompactProcessor.cs#L1013) where `activeContext.Base` is null. It seems that `if` condition above it for `activeContext.HasBase` should have returned false.
I'm not sure how a unit test can be written for this, and if one is warranted.

JSON to reproduce this. [Permalink to JsonLd Playground](https://json-ld.org/playground/#startTab=tab-compacted&json-ld=%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fcitizenship%2Fv1%22%5D%2C%22id%22%3A%22https%3A%2F%2Fissuer.oidp.uscis.gov%2Fcredentials%2F83627465%22%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22PermanentResidentCard%22%5D%2C%22issuer%22%3A%22did%3Aexample%3A489398593%22%2C%22identifier%22%3A%2283627465%22%2C%22name%22%3A%22Permanent%20Resident%20Card%22%2C%22description%22%3A%22Government%20of%20Example%20Permanent%20Resident%20Card.%22%2C%22issuanceDate%22%3A%222019-12-03T12%3A19%3A52Z%22%2C%22expirationDate%22%3A%222029-12-03T12%3A19%3A52Z%22%2C%22credentialSubject%22%3A%7B%22id%22%3A%22did%3Aexample%3Ab34ca6cd37bbf23%22%2C%22type%22%3A%5B%22PermanentResident%22%2C%22Person%22%5D%2C%22givenName%22%3A%22JOHN%22%2C%22familyName%22%3A%22SMITH%22%2C%22gender%22%3A%22Male%22%2C%22image%22%3A%22data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgokJggg%3D%3D%22%2C%22residentSince%22%3A%222015-01-01%22%2C%22lprCategory%22%3A%22C09%22%2C%22lprNumber%22%3A%22999-999-999%22%2C%22commuterClassification%22%3A%22C1%22%2C%22birthCountry%22%3A%22Bahamas%22%2C%22birthDate%22%3A%221958-07-17%22%7D%7D&context=%7B%7D)
```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/citizenship/v1"
  ],
  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
  "type": [ "VerifiableCredential", "PermanentResidentCard" ],
  "issuer": "did:example:489398593",
  "identifier": "83627465",
  "name": "Permanent Resident Card",
  "description": "Government of Example Permanent Resident Card.",
  "issuanceDate": "2019-12-03T12:19:52Z",
  "expirationDate": "2029-12-03T12:19:52Z",
  "credentialSubject": {
    "id": "did:example:b34ca6cd37bbf23",
    "type": [ "PermanentResident", "Person" ],
    "givenName": "JOHN",
    "familyName": "SMITH",
    "gender": "Male",
    "image": "data:image/png;base64,iVBORw0KGgokJggg==",
    "residentSince": "2015-01-01",
    "lprCategory": "C09",
    "lprNumber": "999-999-999",
    "commuterClassification": "C1",
    "birthCountry": "Bahamas",
    "birthDate": "1958-07-17"
  }
}

```