### PR TITLE
JsonLd Framing algorithm: assign base type to context to correct framing

### DIFF
--- a/Libraries/dotNetRDF/JsonLd/JsonLdProcessor.cs
+++ b/Libraries/dotNetRDF/JsonLd/JsonLdProcessor.cs
@@ -294,7 +294,7 @@ namespace VDS.RDF.JsonLd
                 ? Expand(remoteFrame, remoteFrameUri, loaderOptions, frameExpansionOptions)
                 : Expand(frame, frameExpansionOptions);
 
-            var context = new JObject();
+            JToken context = new JObject();
             var haveContext = false;
             if (remoteFrame != null && remoteFrame.Document is JObject remoteFrameObject &&
                 remoteFrameObject.ContainsKey("@context"))
@@ -304,7 +304,7 @@ namespace VDS.RDF.JsonLd
             }
             else if (frame is JObject fo && fo.ContainsKey("@context"))
             {
-                context = fo["@context"] as JObject;
+                context = fo["@context"];
                 haveContext = true;
             }
 


### PR DESCRIPTION
Minor bug fix to the framing algorithm. When `@context` in the frame is set to a URL, it will assign to null when cast `as JObject`. This produces incorrect result.

Steps to reproduce
```
            var document = JObject.Parse(@"{
              '@context': 'https://w3id.org/security/v2',
              'id': 'did:example:489398593#test',
              'type': 'Ed25519Signature2018',
              'controller': 'did:example:489398593',
              'publicKeyBase58': 'oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu'
            }");

            var result = JsonLdProcessor.Frame(
                document,
                new JObject
                {
                    { "@context", "https://w3id.org/security/v2" },
                    { "@embed", "@always" },
                    { "id", "did:example:489398593#test" }
                },
                new JsonLdProcessorOptions
                {
                    CompactToRelative = false,
                    ExpandContext = "https://w3id.org/security/v2"
                });
```

Expected: ([JsonLd Playground permalink](https://json-ld.org/playground/#startTab=tab-framed&json-ld=%7B%22%40context%22%3A%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fv2%22%2C%22id%22%3A%22did%3Aexample%3A489398593%23test%22%2C%22type%22%3A%22Ed25519Signature2018%22%2C%22controller%22%3A%22did%3Aexample%3A489398593%22%2C%22publicKeyBase58%22%3A%22oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu%22%7D&frame=%7B%22%40context%22%3A%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fv2%22%2C%22%40embed%22%3A%22%40always%22%2C%22id%22%3A%22did%3Aexample%3A489398593%23test%22%7D&context=%7B%7D))
```json
{
  "id": "did:example:489398593#test",
  "type": "Ed25519Signature2018",
  "controller": "did:example:489398593",
  "publicKeyBase58": "oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu",
  "@context": "https://w3id.org/security/v2"
}
```

Actual:
```json
{
  "@id": "did:example:489398593#test",
  "@type": "https://w3id.org/security#Ed25519Signature2018",
  "https://w3id.org/security#controller": {
    "@id": "did:example:489398593"
  },
  "https://w3id.org/security#publicKeyBase58": "oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu",
  "@context": null
}
```