### PR TITLE
Update async APIs

### DIFF
--- a/Libraries/dotNetRDF.Data.Virtuoso/VirtuosoManager.cs
+++ b/Libraries/dotNetRDF.Data.Virtuoso/VirtuosoManager.cs
@@ -1440,50 +1440,6 @@ namespace VDS.RDF.Storage
         }
 
         /// <summary>
-        /// Executes a Query SQL Command against the database and returns a DataTable.
-        /// </summary>
-        /// <param name="sqlCmd">SQL Command.</param>
-        /// <returns>DataTable of results.</returns>
-        private DataTable ExecuteQuery(string sqlCmd)
-        {
-            //Create the SQL Command
-            var cmd = new VirtuosoCommand(sqlCmd, _db);
-            cmd.CommandTimeout = _timeout > 0 ? _timeout : cmd.CommandTimeout;
-            if (_dbtrans != null)
-            {
-                //Add to the Transaction if required
-                cmd.Transaction = _dbtrans;
-            }
-
-            //Execute the Query
-            var adapter = new VirtuosoDataAdapter(cmd);
-            var results = new DataTable();
-            adapter.Fill(results);
-
-            return results;
-        }
-
-        /// <summary>
-        /// Executes a Query SQL Command against the database and returns the scalar result (first column of first row of the result).
-        /// </summary>
-        /// <param name="sqlCmd">SQL Command.</param>
-        /// <returns>First Column of First Row of the Results.</returns>
-        private object ExecuteScalar(string sqlCmd)
-        {
-            //Create the SQL Command
-            var cmd = new VirtuosoCommand(sqlCmd, _db);
-            cmd.CommandTimeout = _timeout > 0 ? _timeout : cmd.CommandTimeout;
-            if (_dbtrans != null)
-            {
-                //Add to the Transaction if required
-                cmd.Transaction = _dbtrans;
-            }
-
-            //Execute the Scalar
-            return cmd.ExecuteScalar();
-        }
-
-        /// <summary>
         /// Gets whether there is an active connection to the Virtuoso database.
         /// </summary>
         public bool HasOpenConnection

--- a/Libraries/dotNetRDF/Configuration/ProcessorFactories.cs
+++ b/Libraries/dotNetRDF/Configuration/ProcessorFactories.cs
@@ -161,9 +161,15 @@ namespace VDS.RDF.Configuration
                     INode endpointObj = ConfigurationLoader.GetConfigurationNode(g, objNode, g.CreateUriNode(UriFactory.Create(ConfigurationLoader.PropertyEndpoint)));
                     if (endpointObj == null) return false;
                     temp = ConfigurationLoader.LoadObject(g, endpointObj);
-                    if (temp is SparqlRemoteEndpoint)
+                    if (temp is SparqlRemoteEndpoint queryEndpoint)
                     {
-                        processor = new RemoteQueryProcessor((SparqlRemoteEndpoint)temp);
+#pragma warning disable 618
+                        processor = new RemoteQueryProcessor(queryEndpoint);
+#pragma warning restore 618
+                    }
+                    else if (temp is SparqlQueryClient queryClient)
+                    {
+                        processor = new RemoteQueryProcessor(queryClient);
                     }
                     else
                     {

--- a/Libraries/dotNetRDF/Query/FederatedSparqlQueryClient.cs
+++ b/Libraries/dotNetRDF/Query/FederatedSparqlQueryClient.cs
@@ -46,7 +46,7 @@ namespace VDS.RDF.Query
     /// it just naively merges the data.
     /// </para>
     /// </remarks>
-    public class FederatedSparqlQueryClient
+    public class FederatedSparqlQueryClient : ISparqlQueryClient
     {
         private readonly HttpClient _httpClient;
         private readonly List<SparqlQueryClient> _endpoints = new List<SparqlQueryClient>();
@@ -116,14 +116,20 @@ namespace VDS.RDF.Query
         /// </summary>
         /// <param name="sparqlQuery">The SPARQL query string.</param>
         /// <returns>An RDF graph containing the combined results received from all remote endpoints.</returns>
-        public async Task<IGraph> QueryWithResultGraphAsync(string sparqlQuery)
+        public Task<IGraph> QueryWithResultGraphAsync(string sparqlQuery)
+        {
+            return QueryWithResultGraphAsync(sparqlQuery, CancellationToken.None);
+        }
+
+        /// <inheritdoc />
+        public async Task<IGraph> QueryWithResultGraphAsync(string sparqlQuery, CancellationToken cancellationToken)
         {
             var g = new Graph();
 
             // If no endpoints return an empty graph
             if (_endpoints.Count == 0) return g;
 
-            await QueryWithResultGraphAsync(sparqlQuery, new GraphHandler(g), CancellationToken.None);
+            await QueryWithResultGraphAsync(sparqlQuery, new GraphHandler(g), cancellationToken);
             return g;
         }
 

--- a/Libraries/dotNetRDF/Query/GenericQueryProcessor.cs
+++ b/Libraries/dotNetRDF/Query/GenericQueryProcessor.cs
@@ -90,5 +90,17 @@ namespace VDS.RDF.Query
                 query.QueryExecutionTime = elapsed;
             }
         }
+
+        /// <inheritdoc />
+        public Task<object> ProcessQueryAsync(SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(query));
+        }
+
+        /// <inheritdoc />
+        public Task ProcessQueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(rdfHandler, resultsHandler, query));
+        }
     }
 }

--- a/Libraries/dotNetRDF/Query/ISparqlQueryAlgebraProcessor.cs
+++ b/Libraries/dotNetRDF/Query/ISparqlQueryAlgebraProcessor.cs
@@ -1,0 +1,252 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+using VDS.RDF.Query.Algebra;
+
+namespace VDS.RDF.Query
+{
+    /// <summary>
+    /// Interface for SPARQL Query Algebra Processors.
+    /// </summary>
+    /// <remarks>
+    /// A SPARQL Query Algebra Processor is a class which knows how to evaluate the.
+    /// </remarks>
+    /// <typeparam name="TResult">Type of intermediate results produced by processing an Algebra operator.</typeparam>
+    /// <typeparam name="TContext">Type of context object providing evaluation context.</typeparam>
+    public interface ISparqlQueryAlgebraProcessor<TResult, TContext>
+    {
+        /// <summary>
+        /// Processes SPARQL Algebra.
+        /// </summary>
+        /// <param name="algebra">Algebra.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessAlgebra(ISparqlAlgebra algebra, TContext context);
+
+        /// <summary>
+        /// Processes an Ask.
+        /// </summary>
+        /// <param name="ask">Ask.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessAsk(Ask ask, TContext context);
+
+        /// <summary>
+        /// Processes a BGP.
+        /// </summary>
+        /// <param name="bgp">BGP.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessBgp(IBgp bgp, TContext context);
+
+        /// <summary>
+        /// Processes a Bindings modifier.
+        /// </summary>
+        /// <param name="b">Bindings.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessBindings(Bindings b, TContext context);
+
+        /// <summary>
+        /// Processes a Distinct modifier.
+        /// </summary>
+        /// <param name="distinct">Distinct modifier.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessDistinct(Distinct distinct, TContext context);
+
+        /// <summary>
+        /// Processes an Exists Join.
+        /// </summary>
+        /// <param name="existsJoin">Exists Join.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessExistsJoin(IExistsJoin existsJoin, TContext context);
+
+        /// <summary>
+        /// Processes an Extend.
+        /// </summary>
+        /// <param name="extend">Extend.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessExtend(Extend extend, TContext context);
+
+        /// <summary>
+        /// Processes a Filter.
+        /// </summary>
+        /// <param name="filter">Filter.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessFilter(IFilter filter, TContext context);
+
+        /// <summary>
+        /// Processes a Graph.
+        /// </summary>
+        /// <param name="graph">Graph.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessGraph(Algebra.Graph graph, TContext context);
+
+        /// <summary>
+        /// Processes a Group By.
+        /// </summary>
+        /// <param name="groupBy">Group By.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessGroupBy(GroupBy groupBy, TContext context);
+
+        /// <summary>
+        /// Processes a Having.
+        /// </summary>
+        /// <param name="having">Having.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessHaving(Having having, TContext context);
+
+        /// <summary>
+        /// Processes a Join.
+        /// </summary>
+        /// <param name="join">Join.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessJoin(IJoin join, TContext context);
+
+        /// <summary>
+        /// Processes a LeftJoin.
+        /// </summary>
+        /// <param name="leftJoin">Left Join.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessLeftJoin(ILeftJoin leftJoin, TContext context);
+
+        /// <summary>
+        /// Processes a Minus.
+        /// </summary>
+        /// <param name="minus">Minus.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessMinus(IMinus minus, TContext context);
+
+        /// <summary>
+        /// Processes a Negated Property Set.
+        /// </summary>
+        /// <param name="negPropSet">Negated Property Set.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessNegatedPropertySet(NegatedPropertySet negPropSet, TContext context);
+
+        /// <summary>
+        /// Processes a Null Operator.
+        /// </summary>
+        /// <param name="nullOp">Null Operator.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessNullOperator(NullOperator nullOp, TContext context);
+
+        /// <summary>
+        /// Processes a One or More Path.
+        /// </summary>
+        /// <param name="path">Path.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessOneOrMorePath(OneOrMorePath path, TContext context);
+
+        /// <summary>
+        /// Processes an Order By.
+        /// </summary>
+        /// <param name="orderBy"></param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessOrderBy(OrderBy orderBy, TContext context);
+
+        /// <summary>
+        /// Processes a Property Path.
+        /// </summary>
+        /// <param name="path">Path.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessPropertyPath(PropertyPath path, TContext context);
+
+        /// <summary>
+        /// Processes a Reduced modifier.
+        /// </summary>
+        /// <param name="reduced">Reduced modifier.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessReduced(Reduced reduced, TContext context);
+
+        /// <summary>
+        /// Processes a Select.
+        /// </summary>
+        /// <param name="select">Select.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessSelect(Select select, TContext context);
+
+        /// <summary>
+        /// Processes a Select Distinct Graphs.
+        /// </summary>
+        /// <param name="selDistGraphs">Select Distinct Graphs.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessSelectDistinctGraphs(SelectDistinctGraphs selDistGraphs, TContext context);
+
+        /// <summary>
+        /// Processes a Service.
+        /// </summary>
+        /// <param name="service">Service.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessService(Service service, TContext context);
+
+        /// <summary>
+        /// Processes a Slice modifier.
+        /// </summary>
+        /// <param name="slice">Slice modifier.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessSlice(Slice slice, TContext context);
+        
+        /// <summary>
+        /// Processes a subquery.
+        /// </summary>
+        /// <param name="subquery">Subquery.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessSubQuery(SubQuery subquery, TContext context);
+
+        /// <summary>
+        /// Processes a Union.
+        /// </summary>
+        /// <param name="union">Union.</param>
+        /// <param name="context">Evaluation Context.</param>
+        TResult ProcessUnion(IUnion union, TContext context);
+
+        /// <summary>
+        /// Processes an Unknown Operator.
+        /// </summary>
+        /// <param name="algebra">Algebra.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessUnknownOperator(ISparqlAlgebra algebra, TContext context);
+
+        /// <summary>
+        /// Processes a Zero Length Path.
+        /// </summary>
+        /// <param name="path">Path.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessZeroLengthPath(ZeroLengthPath path, TContext context);
+
+        /// <summary>
+        /// Processes a Zero or More Path.
+        /// </summary>
+        /// <param name="path">Path.</param>
+        /// <param name="context">Evaluation Context.</param>
+        /// <returns></returns>
+        TResult ProcessZeroOrMorePath(ZeroOrMorePath path, TContext context);
+    }
+}

--- a/Libraries/dotNetRDF/Query/ISparqlQueryClient.cs
+++ b/Libraries/dotNetRDF/Query/ISparqlQueryClient.cs
@@ -1,0 +1,76 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2020 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VDS.RDF.Query
+{
+    /// <summary>
+    /// Interface to be implemented by classes that provide a client for accessing a remote SPARQL query service.
+    /// </summary>
+    public interface ISparqlQueryClient
+    {
+        /// <summary>
+        /// Execute a SPARQL query that is intended to return a SPARQL results set.
+        /// </summary>
+        /// <param name="sparqlQuery">The query to be executed.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The query results.</returns>
+        /// <remarks>This method should be  used when processing SPARQL SELECT or ASK queries.</remarks>
+        Task<SparqlResultSet> QueryWithResultSetAsync(string sparqlQuery, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Execute a SPARQL query that is intended to return a SPARQL results set.
+        /// </summary>
+        /// <param name="sparqlQuery">The query to be executed.</param>
+        /// <param name="resultsHandler">The handler to use when parsing the results returned by the server.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The query results.</returns>
+        /// <remarks>This method should be  used when processing SPARQL SELECT or ASK queries.</remarks>
+        Task QueryWithResultSetAsync(
+            string sparqlQuery, ISparqlResultsHandler resultsHandler, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Execute a SPARQL query that is intended to return an RDF Graph.
+        /// </summary>
+        /// <param name="sparqlQuery">The query to be executed.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>An RDF Graph.</returns>
+        /// <remarks>This method should be used when processing SPARQL CONSTRUCT or DESCRIBE queries.</remarks>
+        Task<IGraph> QueryWithResultGraphAsync(string sparqlQuery, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Execute a SPARQL query that is intended to return an RDF Graph.
+        /// </summary>
+        /// <param name="sparqlQuery">The query to be executed.</param>
+        /// <param name="handler">The handler to use when parsing the graph data returned by the server.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>An RDF Graph.</returns>
+        /// <remarks>This method should be used when processing SPARQL CONSTRUCT or DESCRIBE queries.</remarks>
+        Task QueryWithResultGraphAsync(string sparqlQuery, IRdfHandler handler,
+            CancellationToken cancellationToken);
+    }
+}

--- a/Libraries/dotNetRDF/Query/ISparqlQueryProcessor.cs
+++ b/Libraries/dotNetRDF/Query/ISparqlQueryProcessor.cs
@@ -25,7 +25,7 @@
 */
 
 using System;
-using VDS.RDF.Query.Algebra;
+using System.Threading.Tasks;
 
 namespace VDS.RDF.Query
 {
@@ -66,6 +66,7 @@ namespace VDS.RDF.Query
         /// <param name="rdfCallback">Callback for queries that return a Graph.</param>
         /// <param name="resultsCallback">Callback for queries that return a Result Set.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future version. Use the ProcessQueryAsync method instead.")]
         void ProcessQuery(SparqlQuery query, GraphCallback rdfCallback, SparqlResultsCallback resultsCallback, object state);
 
         /// <summary>
@@ -76,235 +77,22 @@ namespace VDS.RDF.Query
         /// <param name="query">SPARQL Query.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future version. Use the ProcessQueryAsync method instead.")]
         void ProcessQuery(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query, QueryCallback callback, object state);
 
+        /// <summary>
+        /// Process a SPARQL query asynchronously returning either a <see cref="SparqlResultSet"/> or a <see cref="IGraph"/> depending on the type of the query.
+        /// </summary>
+        /// <param name="query">SPARQL query.</param>
+        /// <returns>Either an &lt;see cref="IGraph"&gt;IGraph&lt;/see&gt; instance of a &lt;see cref="SparqlResultSet"&gt;SparqlResultSet&lt;/see&gt; depending on the type of the query.</returns>
+        Task<object> ProcessQueryAsync(SparqlQuery query);
+
+        /// <summary>
+        /// Process a SPARQL query asynchronously, passing the results to teh relevant handler.
+        /// </summary>
+        /// <param name="rdfHandler">RDF handler invoked for queries that return RDF graphs.</param>
+        /// <param name="resultsHandler">Results handler invoked for queries that return SPARQL results sets.</param>
+        /// <param name="query">SPARQL query.</param>
+        Task ProcessQueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query);
     }
-
-    /// <summary>
-    /// Interface for SPARQL Query Algebra Processors.
-    /// </summary>
-    /// <remarks>
-    /// A SPARQL Query Algebra Processor is a class which knows how to evaluate the.
-    /// </remarks>
-    /// <typeparam name="TResult">Type of intermediate results produced by processing an Algebra operator.</typeparam>
-    /// <typeparam name="TContext">Type of context object providing evaluation context.</typeparam>
-    public interface ISparqlQueryAlgebraProcessor<TResult, TContext>
-    {
-        /// <summary>
-        /// Processes SPARQL Algebra.
-        /// </summary>
-        /// <param name="algebra">Algebra.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessAlgebra(ISparqlAlgebra algebra, TContext context);
-
-        /// <summary>
-        /// Processes an Ask.
-        /// </summary>
-        /// <param name="ask">Ask.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessAsk(Ask ask, TContext context);
-
-        /// <summary>
-        /// Processes a BGP.
-        /// </summary>
-        /// <param name="bgp">BGP.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessBgp(IBgp bgp, TContext context);
-
-        /// <summary>
-        /// Processes a Bindings modifier.
-        /// </summary>
-        /// <param name="b">Bindings.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessBindings(Bindings b, TContext context);
-
-        /// <summary>
-        /// Processes a Distinct modifier.
-        /// </summary>
-        /// <param name="distinct">Distinct modifier.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessDistinct(Distinct distinct, TContext context);
-
-        /// <summary>
-        /// Processes an Exists Join.
-        /// </summary>
-        /// <param name="existsJoin">Exists Join.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessExistsJoin(IExistsJoin existsJoin, TContext context);
-
-        /// <summary>
-        /// Processes an Extend.
-        /// </summary>
-        /// <param name="extend">Extend.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessExtend(Extend extend, TContext context);
-
-        /// <summary>
-        /// Processes a Filter.
-        /// </summary>
-        /// <param name="filter">Filter.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessFilter(IFilter filter, TContext context);
-
-        /// <summary>
-        /// Processes a Graph.
-        /// </summary>
-        /// <param name="graph">Graph.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessGraph(Algebra.Graph graph, TContext context);
-
-        /// <summary>
-        /// Processes a Group By.
-        /// </summary>
-        /// <param name="groupBy">Group By.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessGroupBy(GroupBy groupBy, TContext context);
-
-        /// <summary>
-        /// Processes a Having.
-        /// </summary>
-        /// <param name="having">Having.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessHaving(Having having, TContext context);
-
-        /// <summary>
-        /// Processes a Join.
-        /// </summary>
-        /// <param name="join">Join.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessJoin(IJoin join, TContext context);
-
-        /// <summary>
-        /// Processes a LeftJoin.
-        /// </summary>
-        /// <param name="leftJoin">Left Join.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessLeftJoin(ILeftJoin leftJoin, TContext context);
-
-        /// <summary>
-        /// Processes a Minus.
-        /// </summary>
-        /// <param name="minus">Minus.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessMinus(IMinus minus, TContext context);
-
-        /// <summary>
-        /// Processes a Negated Property Set.
-        /// </summary>
-        /// <param name="negPropSet">Negated Property Set.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessNegatedPropertySet(NegatedPropertySet negPropSet, TContext context);
-
-        /// <summary>
-        /// Processes a Null Operator.
-        /// </summary>
-        /// <param name="nullOp">Null Operator.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessNullOperator(NullOperator nullOp, TContext context);
-
-        /// <summary>
-        /// Processes a One or More Path.
-        /// </summary>
-        /// <param name="path">Path.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessOneOrMorePath(OneOrMorePath path, TContext context);
-
-        /// <summary>
-        /// Processes an Order By.
-        /// </summary>
-        /// <param name="orderBy"></param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessOrderBy(OrderBy orderBy, TContext context);
-
-        /// <summary>
-        /// Processes a Property Path.
-        /// </summary>
-        /// <param name="path">Path.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessPropertyPath(PropertyPath path, TContext context);
-
-        /// <summary>
-        /// Processes a Reduced modifier.
-        /// </summary>
-        /// <param name="reduced">Reduced modifier.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessReduced(Reduced reduced, TContext context);
-
-        /// <summary>
-        /// Processes a Select.
-        /// </summary>
-        /// <param name="select">Select.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessSelect(Select select, TContext context);
-
-        /// <summary>
-        /// Processes a Select Distinct Graphs.
-        /// </summary>
-        /// <param name="selDistGraphs">Select Distinct Graphs.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessSelectDistinctGraphs(SelectDistinctGraphs selDistGraphs, TContext context);
-
-        /// <summary>
-        /// Processes a Service.
-        /// </summary>
-        /// <param name="service">Service.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessService(Service service, TContext context);
-
-        /// <summary>
-        /// Processes a Slice modifier.
-        /// </summary>
-        /// <param name="slice">Slice modifier.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessSlice(Slice slice, TContext context);
-        
-        /// <summary>
-        /// Processes a subquery.
-        /// </summary>
-        /// <param name="subquery">Subquery.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessSubQuery(SubQuery subquery, TContext context);
-
-        /// <summary>
-        /// Processes a Union.
-        /// </summary>
-        /// <param name="union">Union.</param>
-        /// <param name="context">Evaluation Context.</param>
-        TResult ProcessUnion(IUnion union, TContext context);
-
-        /// <summary>
-        /// Processes an Unknown Operator.
-        /// </summary>
-        /// <param name="algebra">Algebra.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessUnknownOperator(ISparqlAlgebra algebra, TContext context);
-
-        /// <summary>
-        /// Processes a Zero Length Path.
-        /// </summary>
-        /// <param name="path">Path.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessZeroLengthPath(ZeroLengthPath path, TContext context);
-
-        /// <summary>
-        /// Processes a Zero or More Path.
-        /// </summary>
-        /// <param name="path">Path.</param>
-        /// <param name="context">Evaluation Context.</param>
-        /// <returns></returns>
-        TResult ProcessZeroOrMorePath(ZeroOrMorePath path, TContext context);
-    }
-
-    // public interface ISparqlPatternProcessor<TResult, TContext> : ISparqlQueryAlgebraProcessor<TResult, TContext>
-    // {
-    //    void ProcessPattern(ITriplePattern
-    // }
 }

--- a/Libraries/dotNetRDF/Query/LeviathanQueryProcessor.cs
+++ b/Libraries/dotNetRDF/Query/LeviathanQueryProcessor.cs
@@ -320,6 +320,27 @@ namespace VDS.RDF.Query
         }
 
         /// <summary>
+        /// Process a SPARQL query asynchronously returning either a <see cref="SparqlResultSet"/> or a <see cref="IGraph"/> depending on the type of the query.
+        /// </summary>
+        /// <param name="query">SPARQL query.</param>
+        /// <returns>Either an &lt;see cref="IGraph"&gt;IGraph&lt;/see&gt; instance of a &lt;see cref="SparqlResultSet"&gt;SparqlResultSet&lt;/see&gt; depending on the type of the query.</returns>
+        public Task<object> ProcessQueryAsync(SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(query));
+        }
+
+        /// <summary>
+        /// Process a SPARQL query asynchronously, passing the results to teh relevant handler.
+        /// </summary>
+        /// <param name="rdfHandler">RDF handler invoked for queries that return RDF graphs.</param>
+        /// <param name="resultsHandler">Results handler invoked for queries that return SPARQL results sets.</param>
+        /// <param name="query">SPARQL query.</param>
+        public Task ProcessQueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(rdfHandler, resultsHandler, query));
+        }
+
+        /// <summary>
         /// Processes a SPARQL Query asynchronously passing the results to the relevant handler and invoking the callback when the query completes.
         /// </summary>
         /// <param name="rdfHandler">RDF Handler.</param>

--- a/Libraries/dotNetRDF/Query/PelletQueryProcessor.cs
+++ b/Libraries/dotNetRDF/Query/PelletQueryProcessor.cs
@@ -25,6 +25,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using VDS.RDF.Query.Inference.Pellet;
 using VDS.RDF.Query.Inference.Pellet.Services;
 
@@ -159,6 +160,20 @@ namespace VDS.RDF.Query
                 TimeSpan elapsed = (DateTime.Now - start);
                 query.QueryExecutionTime = (DateTime.Now - start);
             }
+        }
+
+        /// <inheritdoc />
+        public Task<object> ProcessQueryAsync(SparqlQuery query)
+        {
+            // TODO: Use async interface on PelletQueryService when it is supported instead.
+            return Task.Factory.StartNew(()=>ProcessQuery(query));
+        }
+
+        /// <inheritdoc />
+        public Task ProcessQueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query)
+        {
+            // TODO: Use async interface on PelletQueryService when it is supported instead.
+            return Task.Factory.StartNew(() => ProcessQuery(rdfHandler, resultsHandler, query));
         }
     }
 }

--- a/Libraries/dotNetRDF/Query/SimpleQueryProcessor.cs
+++ b/Libraries/dotNetRDF/Query/SimpleQueryProcessor.cs
@@ -25,7 +25,7 @@
 */
 
 using System;
-using VDS.RDF.Parsing.Handlers;
+using System.Threading.Tasks;
 using VDS.RDF.Writing.Formatting;
 
 namespace VDS.RDF.Query
@@ -89,5 +89,16 @@ namespace VDS.RDF.Query
             }
         }
 
+        /// <inheritdoc />
+        public Task<object> ProcessQueryAsync(SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(query));
+        }
+
+        /// <inheritdoc />
+        public Task ProcessQueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, SparqlQuery query)
+        {
+            return Task.Factory.StartNew(() => ProcessQuery(rdfHandler, resultsHandler, query));
+        }
     }
 }

--- a/Libraries/dotNetRDF/Query/SparqlQueryClient.cs
+++ b/Libraries/dotNetRDF/Query/SparqlQueryClient.cs
@@ -43,7 +43,7 @@ namespace VDS.RDF.Query
     /// <summary>
     /// A class for connecting to a remote SPARQL endpoint and making queries against it using the System.Net.Http library.
     /// </summary>
-    public class SparqlQueryClient
+    public class SparqlQueryClient : ISparqlQueryClient
     {
         private readonly HttpClient _httpClient;
         private const int LongQueryLength = 2048;

--- a/Libraries/dotNetRDF/Storage/IStorageProvider.cs
+++ b/Libraries/dotNetRDF/Storage/IStorageProvider.cs
@@ -26,6 +26,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
 using VDS.RDF.Storage.Management;
@@ -369,6 +371,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to load.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with LoadGraphAsync(IGraph, string, CancellationToken)")]
         void LoadGraph(IGraph g, Uri graphUri, AsyncStorageCallback callback, object state);
 
         /// <summary>
@@ -378,6 +381,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to load.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with LoadGraphAsync(IGraph, string, CancellationToken)")]
         void LoadGraph(IGraph g, string graphUri, AsyncStorageCallback callback, object state);
 
         /// <summary>
@@ -387,6 +391,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to load.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with LoadGraphAsync(IRdfHandler, string, CancellationToken)")]
         void LoadGraph(IRdfHandler handler, Uri graphUri, AsyncStorageCallback callback, object state);
 
         /// <summary>
@@ -396,7 +401,24 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to load.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with LoadGraphAsync(IRdfHandler, string, CancellationToken)")]
         void LoadGraph(IRdfHandler handler, string graphUri, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Loads a graph from the store asynchronously.
+        /// </summary>
+        /// <param name="g">The target graph to load into.</param>
+        /// <param name="graphUri">URI of the graph to load.</param>
+        /// <param name="cancellationToken"></param>
+        Task LoadGraphAsync(IGraph g, string graphUri, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Loads a graph from the store asynchronously.
+        /// </summary>
+        /// <param name="handler">The handler to receive the loaded triples.</param>
+        /// <param name="graphUri">URI of the graph to load.</param>
+        /// <param name="cancellationToken"></param>
+        Task LoadGraphAsync(IRdfHandler handler, string graphUri, CancellationToken cancellationToken);
 
         /// <summary>
         /// Saves a Graph to the Store asynchronously.
@@ -404,27 +426,48 @@ namespace VDS.RDF.Storage
         /// <param name="g">Graph to save.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with SaveGraphAsync(IGraph, CancellationToken)")]
         void SaveGraph(IGraph g, AsyncStorageCallback callback, object state);
 
         /// <summary>
-        /// Updates a Graph in the Store asychronously.
+        /// Saves a Graph to the Store asynchronously.
+        /// </summary>
+        /// <param name="g">Graph to save.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task SaveGraphAsync(IGraph g, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Updates a Graph in the Store asynchronously.
         /// </summary>
         /// <param name="graphUri">URI of the Graph to update.</param>
         /// <param name="additions">Triples to be added.</param>
         /// <param name="removals">Triples to be removed.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with UpdateGraphAsync(string, IEnumerable<Triple>, IEnumerable<Triple>, CancellationToken")]
         void UpdateGraph(Uri graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals, AsyncStorageCallback callback, object state);
 
         /// <summary>
-        /// Updates a Graph in the Store asychronously.
+        /// Updates a Graph in the Store asynchronously.
         /// </summary>
         /// <param name="graphUri">URI of the Graph to update.</param>
         /// <param name="additions">Triples to be added.</param>
         /// <param name="removals">Triples to be removed.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with UpdateGraphAsync(string, IEnumerable<Triple>, IEnumerable<Triple>, CancellationToken")]
         void UpdateGraph(string graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Updates a graph in the store asynchronously.
+        /// </summary>
+        /// <param name="graphName">Name of the graph to update.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        /// <param name="cancellationToken"></param>
+        Task UpdateGraphAsync(string graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Deletes a Graph from the Store.
@@ -440,14 +483,31 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to delete.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with DeleteGraphAsync(string, CancellationToken)")]
         void DeleteGraph(string graphUri, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Deletes a graph from the store asynchronously.
+        /// </summary>
+        /// <param name="graphName">Name of the graph to delete.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task DeleteGraphAsync(string graphName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Lists the Graphs in the Store asynchronously.
         /// </summary>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("Replaced with ListGraphsAsync(CancellationToken)")]
         void ListGraphs(AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Lists the names of the graphs in the store asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IEnumerable<string>> ListGraphsAsync(CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -466,6 +526,7 @@ namespace VDS.RDF.Storage
         /// <exception cref="RdfStorageException">Thrown if an error occurs performing the query.</exception>
         /// <exception cref="RdfParseException">Thrown if the query is invalid when validated by dotNetRDF prior to passing the query request to the store or if the request succeeds but the store returns malformed results.</exception>
         /// <exception cref="RdfParserSelectionException">Thrown if the store returns results in a format dotNetRDF does not understand.</exception>
+        [Obsolete("This method is obsolete and will be removed in a future version. Replaced by QueryAsync(string, CancellationToken)")]
         void Query(string sparqlQuery, AsyncStorageCallback callback, object state);
 
         /// <summary>
@@ -480,7 +541,25 @@ namespace VDS.RDF.Storage
         /// <exception cref="RdfStorageException">Thrown if an error occurs performing the query.</exception>
         /// <exception cref="RdfParseException">Thrown if the query is invalid when validated by dotNetRDF prior to passing the query request to the store or if the request succeeds but the store returns malformed results.</exception>
         /// <exception cref="RdfParserSelectionException">Thrown if the store returns results in a format dotNetRDF does not understand.</exception>
+        [Obsolete("Replaced by QueryAsync(IRdfHandler, ISparqlResultsHandler, string")]
         void Query(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, string sparqlQuery, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Queries the store asynchronously.
+        /// </summary>
+        /// <param name="sparqlQuery">SPARQL Query.</param>
+        /// <param name="cancellationToken"></param>
+        Task<object> QueryAsync(string sparqlQuery, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Queries the store asynchronously.
+        /// </summary>
+        /// <param name="rdfHandler">RDF Handler that will receive graph results from CONSTRUCT or DESCRIBE queries.</param>
+        /// <param name="resultsHandler">SPARQL Results set handler that will receive results from ASK or SELECT queries.</param>
+        /// <param name="sparqlQuery">The SPARQL query to execute.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task QueryAsync(IRdfHandler rdfHandler, ISparqlResultsHandler resultsHandler, string sparqlQuery, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -495,7 +574,16 @@ namespace VDS.RDF.Storage
         /// <param name="sparqlUpdates">SPARQL Update.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future version. Replaced by UpdateAsync(string, CancellationToken).")]
         void Update(string sparqlUpdates, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Updates the store asynchronously.
+        /// </summary>
+        /// <param name="sparqlUpdates"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task UpdateAsync(string sparqlUpdates, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/Libraries/dotNetRDF/Storage/Management/AllegroGraphServer.cs
+++ b/Libraries/dotNetRDF/Storage/Management/AllegroGraphServer.cs
@@ -42,8 +42,8 @@ namespace VDS.RDF.Storage.Management
     public class AllegroGraphServer
         : SesameServer
     {
-        private string _agraphBase;
-        private string _catalog;
+        private readonly string _agraphBase;
+        private readonly string _catalog;
          
         /// <summary>
         /// Creates a new Connection to an AllegroGraph store.
@@ -263,6 +263,7 @@ namespace VDS.RDF.Storage.Management
         /// </summary>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to callback.</param>
+        [Obsolete("Replaced with ListStoresAsync(CancellationToken).")]
         public override void ListStores(AsyncStorageCallback callback, object state)
         {
             try

--- a/Libraries/dotNetRDF/Storage/Management/IStorageServer.cs
+++ b/Libraries/dotNetRDF/Storage/Management/IStorageServer.cs
@@ -26,6 +26,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using VDS.RDF.Storage.Management.Provisioning;
 
 namespace VDS.RDF.Storage.Management
@@ -110,7 +112,15 @@ namespace VDS.RDF.Storage.Management
         /// </summary>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by ListStoresAsync.")]
         void ListStores(AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Lists the available stores asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IEnumerable<string>> ListStoresAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets a default template for creating a store with the given ID.
@@ -119,7 +129,16 @@ namespace VDS.RDF.Storage.Management
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by GetDefaultTemplateAsync.")]
         void GetDefaultTemplate(string id, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Gets a default template for creating a store with the given ID.
+        /// </summary>
+        /// <param name="id">The store ID.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IStoreTemplate> GetDefaultTemplateAsync(string id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets all available templates for creating a store with the given ID.
@@ -127,7 +146,16 @@ namespace VDS.RDF.Storage.Management
         /// <param name="id">ID.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by GetAvailableTemplatesAsync.")]
         void GetAvailableTemplates(string id, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Gets all available templates for creating a store with the given ID.
+        /// </summary>
+        /// <param name="id">The store ID.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IEnumerable<IStoreTemplate>> GetAvailableTemplatesAsync(string id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a store asynchronously.
@@ -138,7 +166,16 @@ namespace VDS.RDF.Storage.Management
         /// <remarks>
         /// Behaviour with regards to whether creating a store overwrites an existing store with the same ID is at the discretion of the implementation and <em>SHOULD</em> be documented in an implementations comments.
         /// </remarks>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by CreateStoreAsync.")]
         void CreateStore(IStoreTemplate template, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Creates a store asynchronously.
+        /// </summary>
+        /// <param name="template">Template for the store to be created.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<string> CreateStoreAsync(IStoreTemplate template, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deletes a store asynchronously.
@@ -146,7 +183,16 @@ namespace VDS.RDF.Storage.Management
         /// <param name="storeID">ID of the store to delete.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by DeleteStoreAsync.")]
         void DeleteStore(string storeID, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Deletes a store asynchronously.
+        /// </summary>
+        /// <param name="storeId">ID of the store to delete.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task DeleteStoreAsync(string storeId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets a store asynchronously.
@@ -154,6 +200,15 @@ namespace VDS.RDF.Storage.Management
         /// <param name="storeId">Store ID.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by GetStoreAsync.")]
         void GetStore(string storeId, AsyncStorageCallback callback, object state);
+
+        /// <summary>
+        /// Gets a store asynchronously.
+        /// </summary>
+        /// <param name="storeId">Store ID.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IAsyncStorageProvider> GetStoreAsync(string storeId, CancellationToken cancellationToken);
     }
 }

--- a/Testing/dotNetRDF.Connectors.Stardog.Tests/resources/UnitTestConfig.properties
+++ b/Testing/dotNetRDF.Connectors.Stardog.Tests/resources/UnitTestConfig.properties
@@ -50,7 +50,7 @@ Storage.Sesame.Repository=unit-test
 # A Stardog install to use for testing
 Storage.Stardog=true
 Storage.Stardog.Server=http://localhost:5820
-Storage.Stardog.DB=test
+Storage.Stardog.DB=test2
 Storage.Stardog.User=admin
 Storage.Stardog.Password=admin
 

--- a/Testing/dotNetRDF.Connectors.Tests/BaseAsyncTests.cs
+++ b/Testing/dotNetRDF.Connectors.Tests/BaseAsyncTests.cs
@@ -24,8 +24,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
@@ -35,11 +37,14 @@ namespace VDS.RDF.Storage
 
     public abstract class BaseAsyncTests
     {
-        private const String SaveGraphUri = "http://localhost/storage/async/SaveGraph";
-        private const String AddTripleUri = "http://localhost/storage/async/AddTriples";
-        private const String RemoveTriplesUri = "http://localhost/storage/async/RemoveTriples";
-        private const String DeleteGraphUri = "http://localhost/storage/async/DeleteGraph";
-        private const String QueryGraphUri = "http://localhost/storage/async/QueryGraph";
+        private const string SaveGraphUri = "http://localhost/storage/async/SaveGraph";
+        private const string SaveGraphUri2 = "http://localhost/storage/async/SaveGraph2";
+        private const string AddTripleUri = "http://localhost/storage/async/AddTriples";
+        private const string RemoveTriplesUri = "http://localhost/storage/async/RemoveTriples";
+        private const string DeleteGraphUri = "http://localhost/storage/async/DeleteGraph";
+        private const string QueryGraphUri = "http://localhost/storage/async/QueryGraph";
+        private const string ListGraphsUri = "http://localhost/storage/async/ListGraphs";
+
 
         protected int WaitDelay = 15000;
 
@@ -49,15 +54,18 @@ namespace VDS.RDF.Storage
         /// <returns></returns>
         protected abstract IAsyncStorageProvider GetAsyncProvider();
 
-        protected void Fail(IAsyncStorageProvider provider, String msg)
+        protected void Fail(IAsyncStorageProvider provider, string msg)
         {
             Assert.True(false, "[" + provider.GetType().Name + "] " + msg);
         }
 
-        protected void Fail(IAsyncStorageProvider provider, String msg, Exception e)
+        protected void Fail(IAsyncStorageProvider provider, string msg, Exception e)
         {
             throw new Exception("[" + provider.GetType().Name + "] " + msg, e);
         }
+
+        #region Callback-based async API tests
+#pragma warning disable CS0618 // Type or member is obsolete
 
         protected void TestAsyncSaveLoad(IGraph g)
         {
@@ -394,7 +402,7 @@ namespace VDS.RDF.Storage
                 {
                     foreach (Uri u in resArgs.GraphUris)
                     {
-                        Console.WriteLine((u != null ? u.ToString() : "Default Graph"));
+                        Console.WriteLine(u != null ? u.ToString() : "Default Graph");
                     }
                 }
                 else
@@ -420,7 +428,7 @@ namespace VDS.RDF.Storage
             {
                 var signal = new ManualResetEvent(false);
                 AsyncStorageCallbackArgs resArgs = null;
-                g.BaseUri = UriFactory.Create(SaveGraphUri);
+                g.BaseUri = UriFactory.Create(QueryGraphUri);
                 provider.SaveGraph(g, (_, args, state) =>
                 {
                     resArgs = args;
@@ -518,5 +526,218 @@ namespace VDS.RDF.Storage
             g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
             TestAsyncQuery(g);
         }
+
+#pragma warning restore CS0618 // Type or member is obsolete
+        #endregion
+
+        #region Task-based async API tests
+
+        protected async Task TestSaveLoadAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            try
+            {
+                g.BaseUri = UriFactory.Create(SaveGraphUri2);
+                await provider.SaveGraphAsync(g, CancellationToken.None);
+                var h = new Graph();
+                await provider.LoadGraphAsync(h, SaveGraphUri2, CancellationToken.None);
+                GraphDiffReport diff = g.Difference(h);
+                Assert.True(diff.AreEqual, "[" + provider.GetType().Name + "] Graphs were not equal");
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        protected async Task TestDeleteGraphAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            if (!provider.DeleteSupported)
+            {
+                throw new SkipException("[" + provider.GetType().Name +
+                                        "] IO Behaviour required for this test is not supported, skipping test for this provider");
+            }
+
+            try
+            {
+                g.BaseUri = UriFactory.Create(DeleteGraphUri);
+                await provider.SaveGraphAsync(g, CancellationToken.None);
+
+                await provider.DeleteGraphAsync(DeleteGraphUri, CancellationToken.None);
+
+                var h = new Graph();
+                await provider.LoadGraphAsync(h, DeleteGraphUri, CancellationToken.None);
+                Assert.True(h.IsEmpty, "[" + provider.GetType().Name + "] Expected an empty Graph");
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        protected async Task TestDeleteTriplesAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            if (!provider.UpdateSupported || (provider.IOBehaviour & IOBehaviour.CanUpdateDeleteTriples) == 0)
+            {
+                throw new SkipException("[" + provider.GetType().Name +
+                                        "] IO Behaviour required for this test is not supported, skipping test for this provider");
+            }
+
+            try
+            {
+                g.BaseUri = UriFactory.Create(RemoveTriplesUri);
+                await provider.SaveGraphAsync(g, CancellationToken.None);
+                var ts = g.GetTriplesWithPredicate(UriFactory.Create(RdfSpecsHelper.RdfType)).ToList();
+                await provider.UpdateGraphAsync(RemoveTriplesUri, null, ts, CancellationToken.None);
+                var h = new Graph();
+                await provider.LoadGraphAsync(h, RemoveTriplesUri, CancellationToken.None);
+
+                foreach (Triple t in ts)
+                {
+                    Assert.False(h.ContainsTriple(t),
+                        "[" + provider.GetType().Name + "] Removed Triple " + t + " is still present");
+                }
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        protected async Task TestAddTriplesAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            if (!provider.UpdateSupported || (provider.IOBehaviour & IOBehaviour.CanUpdateAddTriples) == 0)
+            {
+                throw new SkipException(
+                    $"[{provider.GetType().Name}] IO Behaviour required for this test is not supported, skipping test for this provider");
+            }
+
+            try
+            {
+                var emptyGraph = new Graph { BaseUri = UriFactory.Create(AddTripleUri) };
+                await provider.SaveGraphAsync(emptyGraph, CancellationToken.None);
+                var ts = g.GetTriplesWithPredicate(UriFactory.Create(RdfSpecsHelper.RdfType)).Select(t =>
+                        new Triple(t.Subject, t.Predicate,
+                            g.CreateUriNode(UriFactory.Create("http://example.org/Test"))))
+                    .ToList();
+                await provider.UpdateGraphAsync(AddTripleUri, ts, null, CancellationToken.None);
+
+                var h = new Graph();
+                await provider.LoadGraphAsync(h, AddTripleUri, CancellationToken.None);
+                foreach (Triple t in ts)
+                {
+                    Assert.True(h.ContainsTriple(t),
+                        $"[{provider.GetType().Name}] Added Triple {t} is not present");
+                }
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        protected async Task TestListGraphsAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            if (!provider.ListGraphsSupported)
+            {
+                throw new SkipException("[" + provider.GetType().Name +
+                                        "] IO Behaviour required for this test is not supported, skipping test for this provider");
+            }
+
+            try
+            {
+                g.BaseUri = UriFactory.Create(ListGraphsUri);
+                await provider.SaveGraphAsync(g, CancellationToken.None);
+                IEnumerable<string> graphs = await provider.ListGraphsAsync(CancellationToken.None);
+                Assert.Contains(ListGraphsUri, graphs);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        protected async Task TestQueryAsync(IGraph g)
+        {
+            IAsyncStorageProvider provider = GetAsyncProvider();
+            if (!(provider is IAsyncQueryableStorage))
+            {
+                throw new SkipException("[" + provider.GetType().Name +
+                                        "] IO Behaviour required for this test is not supported, skipping test for this provider");
+            }
+
+            try
+            {
+                g.BaseUri = UriFactory.Create(QueryGraphUri);
+                await provider.SaveGraphAsync(g, CancellationToken.None);
+                var results = await ((IAsyncQueryableStorage)provider).QueryAsync(
+                    "SELECT * WHERE { GRAPH <" + QueryGraphUri + "> { ?s a ?type } }", CancellationToken.None);
+                Assert.NotNull(results);
+                SparqlResultSet resultSet = Assert.IsAssignableFrom<SparqlResultSet>(results);
+                foreach (SparqlResult r in resultSet)
+                {
+                    Assert.True(g.GetTriplesWithSubjectObject(r["s"], r["type"]).Any(),
+                        "Unexpected Type triple " + r["s"].ToString() + " a " + r["type"].ToString() +
+                        " was returned");
+                }
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [SkippableFact]
+        public async Task StorageSaveLoadAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestSaveLoadAsync(g);
+        }
+
+        [SkippableFact]
+        public async Task StorageDeleteGraphAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestDeleteGraphAsync(g);
+        }
+
+        [SkippableFact]
+        public async Task StorageDeleteTriplesAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestDeleteTriplesAsync(g);
+        }
+
+        [SkippableFact]
+        public async Task StorageAddTriplesAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestAddTriplesAsync(g);
+        }
+
+        [SkippableFact]
+        public async Task StorageListGraphsAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestListGraphsAsync(g);
+        }
+
+        [SkippableFact]
+        public async Task StorageQueryAsync()
+        {
+            var g = new Graph();
+            g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
+            await TestQueryAsync(g);
+        }
+        #endregion 
     }
 }

--- a/Testing/dotNetRDF.Connectors.Tests/PersistentTripleStoreTests.cs
+++ b/Testing/dotNetRDF.Connectors.Tests/PersistentTripleStoreTests.cs
@@ -804,27 +804,6 @@ namespace VDS.RDF.Storage
 
         #region SPARQL Update Tests
 
-        private void TestUpdateUnsynced(IStorageProvider manager)
-        {
-            EnsureTestDataset(manager);
-
-            Skip.IfNot(TestConfigManager.GetSettingAsBoolean(TestConfigManager.UseRemoteParsing),
-                "Test Config marks Remote Parsing as unavailable, test cannot be run");
-
-            var store = new PersistentTripleStore(manager);
-            try
-            {
-                store.Remove(new Uri(TestGraphUri1));
-
-                store.ExecuteUpdate("LOAD <http://dbpedia.org/resource/Ilkeston>");
-            }
-            finally
-            {
-                store.Discard();
-                store.Dispose();
-            }
-        }
-
         private void TestUpdate(IStorageProvider manager)
         {
             EnsureTestDataset(manager);
@@ -857,13 +836,6 @@ namespace VDS.RDF.Storage
             {
                 store.Dispose();
             }
-        }
-
-        [SkippableFact]
-        public void StoragePersistentTripleStoreMemUpdateUnsynced()
-        {
-            IStorageProvider manager = GetStorageProvider();
-            Assert.Throws<SparqlUpdateException>(() => TestUpdateUnsynced(manager));
         }
 
         #endregion

--- a/Testing/test_images/README.md
+++ b/Testing/test_images/README.md
@@ -6,7 +6,7 @@ only for testing purposes and are in no way good examples of using these stores 
 ## Images Provided
 
 ### Fuseki
-    docker run --rm -p 3030:3030 --name fuseki fuseki/latest --mem /ds
+    docker run --rm -p 3030:3030 --name fuseki fuseki:latest --mem /ds
     
 Exposes a store at http://localhost:3030/ds/data
 

--- a/Testing/unittest/Query/SparqlProcessorsWithHandlersTests.cs
+++ b/Testing/unittest/Query/SparqlProcessorsWithHandlersTests.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using Xunit;
 using VDS.RDF.Parsing;
 using VDS.RDF.Parsing.Handlers;
@@ -233,7 +234,7 @@ namespace VDS.RDF.Query
             if (_remote == null)
             {
                 Skip.IfNot(TestConfigManager.GetSettingAsBoolean(TestConfigManager.UseIIS), "Test Config marks IIS as unavailable, cannot run test");
-                _remote = new RemoteQueryProcessor(new SparqlRemoteEndpoint(new Uri(TestConfigManager.GetSetting(TestConfigManager.LocalQueryUri))));
+                _remote = new RemoteQueryProcessor(new SparqlQueryClient(new HttpClient(),  new Uri(TestConfigManager.GetSetting(TestConfigManager.LocalQueryUri))));
             }
         }
 

--- a/Testing/unittest/Storage/Async/SparqlGraphStoreAsync.cs
+++ b/Testing/unittest/Storage/Async/SparqlGraphStoreAsync.cs
@@ -23,13 +23,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Xunit;
-using VDS.RDF.Storage;
-
 namespace VDS.RDF.Storage.Async
 {
 


### PR DESCRIPTION
Updated APIs for storage servers and storage connectors as well as the ISparqlQueryProcessor interface. Storage implementations have all been updated to use async HttpClient calls under the covers. The query processor async interface has been implemented by running the query as a task on a separate thread - this could be revisited later if there is more extensive work done on the query engine.