### PR TITLE
Make IriExpression constructor public

### DIFF
--- a/Libraries/dotNetRDF/Query/Builder/Expressions/IriExpression.cs
+++ b/Libraries/dotNetRDF/Query/Builder/Expressions/IriExpression.cs
@@ -35,7 +35,11 @@ namespace VDS.RDF.Query.Builder.Expressions
     /// </summary>
     public class IriExpression : RdfTermExpression
     {
-        internal IriExpression(Uri iri) 
+        /// <summary>
+        /// Wraps the <paramref name="iri"/> as a constant IRI expression.
+        /// </summary>
+        /// <param name="iri"></param>
+        public IriExpression(Uri iri) 
             : base(new ConstantTerm(new UriNode(null, iri)))
         {
         }


### PR DESCRIPTION
This makes it more convenient to create IRI constants in fluent SPARQL queries.