### PR TITLE
Ensure that RAND() returns a consistent value for any given binding set.

### DIFF
--- a/Libraries/dotNetRDF/Query/Expressions/Functions/Sparql/Numeric/RandFunction.cs
+++ b/Libraries/dotNetRDF/Query/Expressions/Functions/Sparql/Numeric/RandFunction.cs
@@ -38,6 +38,7 @@ namespace VDS.RDF.Query.Expressions.Functions.Sparql.Numeric
         : ISparqlExpression
     {
         private static Random _rnd = new Random();
+        private Dictionary<int, IValuedNode> _bindings = new Dictionary<int, IValuedNode>();
 
         /// <summary>
         /// Creates a new SPARQL RAND() Function.
@@ -53,7 +54,11 @@ namespace VDS.RDF.Query.Expressions.Functions.Sparql.Numeric
         /// <returns></returns>
         public IValuedNode Evaluate(SparqlEvaluationContext context, int bindingID)
         {
-            return new DoubleNode(null, _rnd.NextDouble());
+            // Ensure we return a consistent value when evaluating a set we have already seen
+            if (_bindings.TryGetValue(bindingID, out IValuedNode result)) return result;
+            result = new DoubleNode(null, _rnd.NextDouble());
+            _bindings[bindingID] = result;
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
The existing implementation of the RAND function would return a different value for the same binding each time it was invoked. This led to occassional errors in sorting a result set ordered by RAND() when the evaluation returns a different sort order for two sets on each invocation.
This fix alters the implementation of the RAND function to cache the value that is bound for each set and always return the bound value on future invocations for the same set.