### PR TITLE
Update Dependencies

### DIFF
--- a/Libraries/dotNetRDF.Data.DataTables/dotNetRDF.Data.DataTables.csproj
+++ b/Libraries/dotNetRDF.Data.DataTables/dotNetRDF.Data.DataTables.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Package which allow integrating dotNetRDF with System.Data.DataTable</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF.Data.DataTables</AssemblyTitle>
     <VersionPrefix>$(Version)</VersionPrefix>
     <Authors>RobVesse;tpluscode;kal_ahmed;ronmichael;dotnetrdf</Authors>

--- a/Libraries/dotNetRDF.Data.Virtuoso/dotNetRDF.Data.Virtuoso.csproj
+++ b/Libraries/dotNetRDF.Data.Virtuoso/dotNetRDF.Data.Virtuoso.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>dotNetRDF.Data.Virtuoso provides support for using OpenLink Virtuoso as a backend triplestore with dotNetRDF</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF.Data.Virtuoso</AssemblyTitle>
     <VersionPrefix>$(Version)</VersionPrefix>
     <Authors>RobVesse;tpluscode;kal_ahmed;ronmichael;dotnetrdf</Authors>

--- a/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
+++ b/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>dotNetRDF.Query.FullText provides Full Text SPARQL support as a plugin for the dotNetRDF Leviathan SPARQL Engine using Lucene.Net</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF.Query.FullText</AssemblyTitle>
     <VersionPrefix>$(Version)</VersionPrefix>
     <Authors>RobVesse;tpluscode;kal_ahmed;ronmichael;dotnetrdf</Authors>

--- a/Libraries/dotNetRDF.Query.Spin/dotNetRDF.Query.Spin.csproj
+++ b/Libraries/dotNetRDF.Query.Spin/dotNetRDF.Query.Spin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A library which provides a full SPIN implementation using dotNetRDF's Leviathan SPARQL engine</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF SPIN</AssemblyTitle>
     <VersionPrefix>$(Version)</VersionPrefix>
     <Authors>tpluscode;dotnetrdf</Authors>

--- a/Libraries/dotNetRDF.Web/dotNetRDF.Web.csproj
+++ b/Libraries/dotNetRDF.Web/dotNetRDF.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides a framework for building RDF-powered web applications and web APIs.</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF.Web</AssemblyTitle>
     <VersionPrefix>1.0.13-pre6</VersionPrefix>
     <TargetFrameworks>net40</TargetFrameworks>

--- a/Libraries/dotNetRDF/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRDF/Parsing/JsonLdParser.cs
@@ -240,8 +240,10 @@ namespace VDS.RDF.Parsing
                     var roundedValue = Math.Round(doubleValue);
                     if (doubleValue.Equals(roundedValue) && doubleValue < 1000000000000000000000.0 && datatype == null)
                     {
-                        // Integer values up to 10^21 should be rendered as a fixed-point integer
+                        // Integer values up to 10^21 should be rendered as an integer rather than a float
                         literalValue = roundedValue.ToString("F0");
+                        // The JSON-LD test suite requires no leading minus sign when the value is 0
+                        if (literalValue.Equals("-0")) literalValue = "0";
                         datatype = XsdNs + "integer";
                     }
                     else

--- a/Libraries/dotNetRDF/dotNetRDF.csproj
+++ b/Libraries/dotNetRDF/dotNetRDF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>dotNetRDF is a RDF, SPARQL and Semantic Web API for .Net.  It provides simple but powerfully extensible APIs for this and integrates with a variety of popular triple stores.</Description>
-    <Copyright>Copyright © dotNetRDF Project 2009-2019</Copyright>
+    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
     <AssemblyTitle>dotNetRDF</AssemblyTitle>
     <VersionPrefix>$(Version)</VersionPrefix>
     <Authors>RobVesse;tpluscode;kal_ahmed;ronmichael;dotnetrdf</Authors>
@@ -60,7 +60,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.28" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.31" />
     <PackageReference Include="VDS.Common" Version="1.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
@@ -70,13 +70,13 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="AngleSharp" Version="0.14.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.6.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
+++ b/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -17,12 +17,12 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="WireMock.Net" Version="1.3.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="WireMock.Net" Version="1.4.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Testing/unittest/Dynamic/DynamicExtensionTests.cs
+++ b/Testing/unittest/Dynamic/DynamicExtensionTests.cs
@@ -339,8 +339,8 @@ u:s u:p u:o .
         ""9999-12-31T23:59:59.999999""^^xsd:dateTime ,
         ""9999-12-31T23:59:59.999999+00:00""^^xsd:dateTime ,
         ""79228162514264337593543950335""^^xsd:decimal ,
-        ""1.79769313486232E+308""^^xsd:double ,
-        ""3.402823E+38""^^xsd:float ,
+        ""1.797E+308""^^xsd:double ,
+        ""3.402E+38""^^xsd:float ,
         ""9223372036854775807""^^xsd:integer ,
         ""2147483647""^^xsd:integer ,
         """" ,
@@ -354,15 +354,15 @@ u:s u:p u:o .
             {
                 p = new object[]
                 {
-                    new NodeFactory().CreateBlankNode(),
+                    new NodeFactory().CreateBlankNode("o"),
                     UriFactory.Create("urn:o"),
                     true,
                     byte.MaxValue,
                     DateTime.MaxValue,
                     DateTimeOffset.MaxValue,
                     decimal.MaxValue,
-                    double.MaxValue,
-                    float.MaxValue,
+                    1.797e308,
+                    3.402e38f,
                     long.MaxValue,
                     int.MaxValue,
                     string.Empty,
@@ -371,7 +371,8 @@ u:s u:p u:o .
                 }
             };
 
-            Assert.Equal<IGraph>(expected, d);
+            TestTools.CompareGraphs(expected, d, true);
+            //Assert.Equal<IGraph>(expected, d);
         }
 
         [Fact]

--- a/Testing/unittest/unittest.csproj
+++ b/Testing/unittest/unittest.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>dotNetRDF.Test</AssemblyTitle>
-    <VersionPrefix>1.0.13-pre6</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>dotNetRDF.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Build/dotNetRDF.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -37,11 +35,11 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -61,17 +59,17 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <ProjectReference Include="..\..\Libraries\dotNetRDF.Data.DataTables\dotNetRDF.Data.DataTables.csproj" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NO_VIRTUOSO</DefineConstants>
   </PropertyGroup>
 
@@ -86,7 +84,7 @@
     <Compile Include="**\*.cs" Exclude="obj\**\*cs;**\*.NetCore.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <Compile Include="**\*.cs" Exclude="obj\**\*cs;**\*.NetCore.cs;Storage\VirtuosoTest.cs;Query\FullText\*.cs;Web\*.cs" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 branches:
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build_script:
   - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { msbuild Build\shfb\dotnetrdf.shfbproj /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release /p:HelpFileVersion=$env:GitVersion_NuGetVersion }
 
 test_script:
-  - ps: dotnet test -c Release --filter "Category!=explicit" --framework netcoreapp2.2 Testing\unittest\unittest.csproj
+  - ps: dotnet test -c Release --filter "Category!=explicit" --framework netcoreapp3.1 Testing\unittest\unittest.csproj
   - ps: dotnet test -c Release --filter "Category!=explicit" --framework net472 Testing\unittest\unittest.csproj
   - ps: dotnet test -c Release --filter "Category=fulltext" --framework net472
 
@@ -42,6 +42,8 @@ deploy:
   - provider: NuGet
     api_key:
       secure: 9zViqGPPKYiYVnk9iH14649Oj6tXTwsNxtZ73AcsESYm795D918U0D3UlH9zjxcT
+    on:
+      appveyor_repo_tag: true
     artifact: /((?!Spin).)*.nupkg/
 
 artifacts:


### PR DESCRIPTION
Bumps dotNetRDF dependencies to the latest release version.
Moves the test projects from netcoreapp2.2 to netcoreapp3.1 - this introduced a couple of minor issues with the tests that needed fixing.
Move the Appveyor build to the VS2019 image (required for .NET Core 3.1)