### PR TITLE
Fixes for handling UTF-8 encoded JSON-LD and IRIs

### DIFF
--- a/Libraries/dotNetRDF/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRDF/JsonLd/Processors/JsonLdUtils.cs
@@ -274,7 +274,13 @@ namespace VDS.RDF.JsonLd.Processors
         /// <returns>True if <paramref name="value"/> can be parsed as an absolute IRI, false otherwise.</returns>
         public static bool IsAbsoluteIri(string value)
         {
-            return Uri.TryCreate(value, UriKind.Absolute, out var _) && Uri.EscapeUriString(value).Equals(value);
+            return Uri.TryCreate(value, UriKind.Absolute, out var u)
+                   && (
+                       // Trying to determine if the TryCreate constructor performed some unwanted escaping
+                       // IsWellFormedOriginalString() works most of the time but fails for some of the JSON-LD tests - in particular where the path contains [ or ]
+                       u.IsWellFormedOriginalString() || 
+                       // This check sees if escaping the original string changes it - this unfortunately fails for IRIs because .NET 
+                       Uri.EscapeUriString(value).Equals(value));
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed DefaultDocumentLoader to decode the body using the charset specified in the Content-Type header instead of relying on WebClient.DownloadString (which doesn't do this!)
- Changed implementation of JsonLdUtils.IsAbsoluteIri to include IRIs with certain non-ASCII characters that are being erroneously escaped by Uri.EscapeUriString

Fixes #376