### PR TITLE
Fix math expression parsing

### DIFF
--- a/Libraries/dotNetRDF/Parsing/Tokens/SparqlTokeniser.cs
+++ b/Libraries/dotNetRDF/Parsing/Tokens/SparqlTokeniser.cs
@@ -1607,7 +1607,8 @@ namespace VDS.RDF.Parsing.Tokens
                         // Check this is at the start of the string or immediately after the 'e'
                         if (Length > 0 && !Value.ToLower().EndsWith("e"))
                         {
-                            throw Error("Unexpected Character (Code " + (int)next + ") -\nThe minus sign can only occur at the Start of a Numeric Literal and once immediately after the exponent specifier, if this was intended as a subtractive operator please insert space to disambiguate this");
+                            //throw Error("Unexpected Character (Code " + (int)next + ") -\nThe minus sign can only occur at the Start of a Numeric Literal and once immediately after the exponent specifier, if this was intended as a subtractive operator please insert space to disambiguate this");
+                            break;
                         }
                     }
                 }

--- a/Libraries/dotNetRDF/Query/SPARQLExpressionParser.cs
+++ b/Libraries/dotNetRDF/Query/SPARQLExpressionParser.cs
@@ -326,7 +326,7 @@ namespace VDS.RDF.Query
             // Get the First Term of this Expression
             ISparqlExpression firstTerm = TryParseUnaryExpression(tokens);
 
-            if (tokens.Count > 0)
+            while (tokens.Count > 0)
             {
                 IToken next = tokens.Peek();
                 switch (next.TokenType)
@@ -334,44 +334,23 @@ namespace VDS.RDF.Query
                     case Token.MULTIPLY:
                     {
                         tokens.Dequeue();
-                        var rhs = TryParseMultiplicativeExpression(tokens);
-                        if (rhs is DivisionExpression)
-                        {
-                            var args = rhs.Arguments.ToList();
-                            return new DivisionExpression(new MultiplicationExpression(firstTerm, args[0]), args[1]);
-                        }
-                        if (rhs is MultiplicationExpression)
-                        {
-                            var args = rhs.Arguments.ToList();
-                            return new MultiplicationExpression(new MultiplicationExpression(firstTerm, args[0]),
-                                args[1]);
-                        }
-                        return new MultiplicationExpression(firstTerm, rhs);
+                        ISparqlExpression rhs = TryParseUnaryExpression(tokens);
+                        firstTerm = new MultiplicationExpression(firstTerm, rhs);
+                        break;
                     }
                     case Token.DIVIDE:
                     {
                         tokens.Dequeue();
-                        var rhs = TryParseMultiplicativeExpression(tokens);
-                        if (rhs is DivisionExpression)
-                        {
-                            var args = rhs.Arguments.ToList();
-                            return new DivisionExpression(new DivisionExpression(firstTerm, args[0]), args[1]);
-                        }
-                        if (rhs is MultiplicationExpression)
-                        {
-                            var args = rhs.Arguments.ToList();
-                            return new MultiplicationExpression(new DivisionExpression(firstTerm, args[0]), args[1]);
-                        }
-                        return new DivisionExpression(firstTerm, rhs);
+                        ISparqlExpression rhs = TryParseUnaryExpression(tokens);
+                        firstTerm = new DivisionExpression(firstTerm, rhs);
+                        break;
                     }
                     default:
                         return firstTerm;
                 }
             }
-            else
-            {
-                return firstTerm;
-            }
+
+            return firstTerm;
         }
 
         private ISparqlExpression TryParseUnaryExpression(Queue<IToken> tokens)

--- a/Testing/unittest/Query/MathEvaluationTests.cs
+++ b/Testing/unittest/Query/MathEvaluationTests.cs
@@ -49,8 +49,14 @@ namespace VDS.RDF.Query
         public void TestDivisionBeforeSubtraction()
         {
             // 10-4/2 should be interpreted as 10 - (4/2) = 8, not (10 - 4)/2 = 3
-            // TODO: SparqlParser throws an error if the space around the - is missed out, suggesting that the use of the MINUS token is ambiguous
             TestQuery("SELECT ?f WHERE {BIND (10 - 4/2 as ?f)}", "8");
+        }
+
+        [Fact]
+        public void TestAdditionExpressionWithASignedNumberComponent()
+        {
+            // Same as the above but without whitespace means that -4 can be interpreted as a negative integer.
+            TestQuery("SELECT ?f WHERE {BIND (10-4/2 as ?f)}", "8");
         }
 
         [Fact]

--- a/Testing/unittest/Query/MathEvaluationTests.cs
+++ b/Testing/unittest/Query/MathEvaluationTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentAssertions;
+﻿using FluentAssertions;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query.Datasets;
 using Xunit;
@@ -63,6 +58,24 @@ namespace VDS.RDF.Query
         {
             // 10/5/2 should be interpreted as (10/5)/2 = 1, not 10/(5/2) = 4
             TestQuery("SELECT ?f WHERE {BIND (10/5/2 as ?f)}", "1");
+        }
+
+        [Fact]
+        public void TestBracketedExpression1()
+        {
+            TestQuery("SELECT ?f WHERE {BIND (10/(5/2) as ?f)}", "4");
+        }
+
+        [Fact]
+        public void TestMultiplicativeExpressionEvaluatedLeftToRight()
+        {
+            TestQuery("SELECT ?f WHERE {BIND (10/5*2 as ?f)}", "4");
+        }
+
+        [Fact]
+        public void TestBracketedExpression2()
+        {
+            TestQuery("SELECT ?f WHERE {BIND (10/(5*2) as ?f)}", "1");
         }
     }
 }


### PR DESCRIPTION
This PR addresses a regression that was introduced in the fix for #225 and caused bracketed expressions to be incorrectly parsed.
It also changes the tokenizer to not throw when encountering a MINUS token while parsing a number. The logic is now that if a MINUS token is encountered and it is not at the start of a number or immediately after an 'e' then end of the number token has been encountered and the MINUS is the start of a new number token. In an addition expression it is possible that a subtraction with no whitespace would be interepreted as a number followed by a negative number. The SPARQL 1.1 spec addressed this issue and updated the definition of the addition expression and the SPARQLExpressionParser now reflects that interpretation.

Fixes #385