### PR TITLE
Add public extension APIs to QueryBuilder

### DIFF
--- a/Libraries/dotNetRDF/Query/Builder/GraphPatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/GraphPatternBuilder.cs
@@ -35,6 +35,9 @@ using VDS.RDF.Query.Patterns;
 
 namespace VDS.RDF.Query.Builder
 {
+    /// <summary>
+    /// Class for building graph patterns.
+    /// </summary>
     public sealed class GraphPatternBuilder : IGraphPatternBuilder, IDescribeGraphPatternBuilder
     {
         private readonly IList<InlineDataBuilder> _inlineDataBuilders = new List<InlineDataBuilder>();

--- a/Libraries/dotNetRDF/Query/Builder/IAggregateBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IAggregateBuilder.cs
@@ -35,7 +35,7 @@ namespace VDS.RDF.Query.Builder
     public interface IAggregateBuilder : IDistinctAggregateBuilder
     {
         /// <summary>
-        /// Gets a builder which builds a DISTICT aggregate.
+        /// Gets a builder which builds a DISTINCT aggregate.
         /// </summary>
         IDistinctAggregateBuilder Distinct { get; }
 

--- a/Libraries/dotNetRDF/Query/Builder/IPatternItemFactory.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IPatternItemFactory.cs
@@ -1,0 +1,99 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2021 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System;
+using VDS.RDF.Query.Patterns;
+
+namespace VDS.RDF.Query.Builder
+{
+    /// <summary>
+    /// Interface for creating <see cref="PatternItem"/> instances.
+    /// </summary>
+    public interface IPatternItemFactory
+    {
+        /// <summary>
+        /// Create a variable pattern item.
+        /// </summary>
+        /// <param name="variableName">The name of the variable.</param>
+        /// <returns></returns>
+        PatternItem CreateVariablePattern(string variableName);
+
+        /// <summary>
+        /// Create a URI node pattern.
+        /// </summary>
+        /// <param name="qName">The CURIE representation of the URI.</param>
+        /// <param name="namespaceMapper">The mapper to use when resolving the prefix part of the CURIE.</param>
+        /// <returns></returns>
+        PatternItem CreateNodeMatchPattern(string qName, INamespaceMapper namespaceMapper);
+
+        /// <summary>
+        /// Create a URI node pattern.
+        /// </summary>
+        /// <param name="uri">The URI for the pattern item.</param>
+        /// <returns></returns>
+        PatternItem CreateNodeMatchPattern(Uri uri);
+
+        /// <summary>
+        /// Create a pattern item that matches the specified node.
+        /// </summary>
+        /// <param name="node">The node to match.</param>
+        /// <returns></returns>
+        PatternItem CreateNodeMatchPattern(INode node);
+
+        /// <summary>
+        /// Create a pattern item that matches a specific blank node.
+        /// </summary>
+        /// <param name="blankNodeIdentifier">The blank node identifier to match.</param>
+        /// <returns></returns>
+        PatternItem CreateBlankNodeMatchPattern(string blankNodeIdentifier);
+
+        /// <summary>
+        /// Create a pattern item that matches a literal value.
+        /// </summary>
+        /// <param name="literal">The value to match as a literal.</param>
+        /// <returns></returns>
+        /// <remarks>If <paramref name="literal"/> is a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> then the literal pattern will use the appropriate XML Schema-compatible string representation as the literal value. For all other types, the value returned by the ToString method will be used as the literal value.</remarks>
+        PatternItem CreateLiteralNodeMatchPattern(object literal);
+
+        /// <summary>
+        /// Create a pattern item that matches a literal value with its associated datatype.
+        /// </summary>
+        /// <param name="literal">The literal value to match.</param>
+        /// <param name="datatype">The literal datatype URI to match.</param>
+        /// <returns></returns>
+        /// <remarks>If <paramref name="literal"/> is a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> then the literal pattern will use the appropriate XML Schema-compatible string representation as the literal value. For all other types, the value returned by the ToString method will be used as the literal value.</remarks>
+        PatternItem CreateLiteralNodeMatchPattern(object literal, Uri datatype);
+
+        /// <summary>
+        /// Create a pattern item that matches a literal value with an associated language tag.
+        /// </summary>
+        /// <param name="literal">The literal value to match.</param>
+        /// <param name="langSpec">The language tag to match.</param>
+        /// <returns></returns>
+        /// <remarks>If <paramref name="literal"/> is a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> then the literal pattern will use the appropriate XML Schema-compatible string representation as the literal value. For all other types, the value returned by the ToString method will be used as the literal value.</remarks>
+        PatternItem CreateLiteralNodeMatchPattern(object literal, string langSpec);
+    }
+}

--- a/Libraries/dotNetRDF/Query/Builder/IPatternItemFactory.cs
+++ b/Libraries/dotNetRDF/Query/Builder/IPatternItemFactory.cs
@@ -95,5 +95,15 @@ namespace VDS.RDF.Query.Builder
         /// <returns></returns>
         /// <remarks>If <paramref name="literal"/> is a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> then the literal pattern will use the appropriate XML Schema-compatible string representation as the literal value. For all other types, the value returned by the ToString method will be used as the literal value.</remarks>
         PatternItem CreateLiteralNodeMatchPattern(object literal, string langSpec);
+
+        /// <summary>
+        /// Create a pattern item that matches a node of a specific type.
+        /// </summary>
+        /// <param name="nodeType">The type of node to match. Must be one of <see cref="IBlankNode"/>, <see cref="ILiteralNode"/>, <see cref="IUriNode"/> or <see cref="IVariableNode"/>.</param>
+        /// <param name="patternString">The string value of the pattern item.</param>
+        /// <param name="namespaceMapper">The namespace mapper to use when resolving any prefixes in <paramref name="patternString"/>.</param>
+        /// <returns></returns>
+        /// <remarks>It is recommended to use one of the CreateXxxNodeMatchPattern methods in preference to this method.</remarks>
+        PatternItem CreatePatternItem(Type nodeType, string patternString, INamespaceMapper namespaceMapper);
     }
 }

--- a/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilderInternal.cs
+++ b/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilderInternal.cs
@@ -31,12 +31,17 @@ namespace VDS.RDF.Query.Builder
     /// <summary>
     /// Additional methods and properties that can be used by extensions of the <see cref="ITriplePatternBuilder"/> interface.
     /// </summary>
-    public interface ITriplePatternBuilderInternal
+    public interface ITriplePatternBuilderInternal : ITriplePatternBuilder
     {
         /// <summary>
         /// Gets the pattern item factory used by the builder.
         /// </summary>
         IPatternItemFactory PatternItemFactory { get; }
+
+        /// <summary>
+        /// Gets the prefix manager, which allows adding prefixes to the query or graph pattern.
+        /// </summary>
+        INamespaceMapper Prefixes { get; }
 
         /// <summary>
         /// Add TriplePattern to the builder.

--- a/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilderInternal.cs
+++ b/Libraries/dotNetRDF/Query/Builder/ITriplePatternBuilderInternal.cs
@@ -1,0 +1,47 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2021 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using VDS.RDF.Query.Patterns;
+
+namespace VDS.RDF.Query.Builder
+{
+    /// <summary>
+    /// Additional methods and properties that can be used by extensions of the <see cref="ITriplePatternBuilder"/> interface.
+    /// </summary>
+    public interface ITriplePatternBuilderInternal
+    {
+        /// <summary>
+        /// Gets the pattern item factory used by the builder.
+        /// </summary>
+        IPatternItemFactory PatternItemFactory { get; }
+
+        /// <summary>
+        /// Add TriplePattern to the builder.
+        /// </summary>
+        /// <param name="triplePattern"></param>
+        void AddPattern(TriplePattern triplePattern);
+    }
+}

--- a/Libraries/dotNetRDF/Query/Builder/PatternItemFactory.cs
+++ b/Libraries/dotNetRDF/Query/Builder/PatternItemFactory.cs
@@ -33,32 +33,32 @@ namespace VDS.RDF.Query.Builder
     /// <summary>
     /// Class responsible for creating <see cref="PatternItem"/>s.
     /// </summary>
-    internal class PatternItemFactory
+    internal class PatternItemFactory : IPatternItemFactory
     {
         private readonly NodeFactory _nodeFactory = new NodeFactory();
 
-        internal PatternItem CreateVariablePattern(string variableName)
+        public PatternItem CreateVariablePattern(string variableName)
         {
             return new VariablePattern(variableName);
         }
 
-        internal PatternItem CreateNodeMatchPattern(string qName, INamespaceMapper namespaceMapper)
+        public PatternItem CreateNodeMatchPattern(string qName, INamespaceMapper namespaceMapper)
         {
             var qNameResolved = Tools.ResolveQName(qName, namespaceMapper, null);
             return CreateNodeMatchPattern(new Uri(qNameResolved));
         }
 
-        internal PatternItem CreateNodeMatchPattern(Uri uri)
+        public PatternItem CreateNodeMatchPattern(Uri uri)
         {
             return CreateNodeMatchPattern(_nodeFactory.CreateUriNode(uri));
         }
 
-        internal PatternItem CreateNodeMatchPattern(INode node)
+        public PatternItem CreateNodeMatchPattern(INode node)
         {
             return new NodeMatchPattern(node);
         }
 
-        private PatternItem CreateBlankNodeMatchPattern(string blankNodeIdentifier)
+        public PatternItem CreateBlankNodeMatchPattern(string blankNodeIdentifier)
         {
             return new BlankNodePattern(blankNodeIdentifier);
         }
@@ -85,21 +85,21 @@ namespace VDS.RDF.Query.Builder
             throw new ArgumentException(string.Format("Invalid node type {0}", nodeType));
         }
 
-        internal PatternItem CreateLiteralNodeMatchPattern(object literal)
+        public PatternItem CreateLiteralNodeMatchPattern(object literal)
         {
             var literalString = GetLiteralString(literal);
 
             return new NodeMatchPattern(_nodeFactory.CreateLiteralNode(literalString));
         }
 
-        internal PatternItem CreateLiteralNodeMatchPattern(object literal, Uri datatype)
+        public PatternItem CreateLiteralNodeMatchPattern(object literal, Uri datatype)
         {
             var literalString = GetLiteralString(literal);
 
             return new NodeMatchPattern(_nodeFactory.CreateLiteralNode(literalString, datatype));
         }
 
-        internal PatternItem CreateLiteralNodeMatchPattern(object literal, string langSpec)
+        public PatternItem CreateLiteralNodeMatchPattern(object literal, string langSpec)
         {
             var literalString = GetLiteralString(literal);
 

--- a/Libraries/dotNetRDF/Query/Builder/PatternItemFactory.cs
+++ b/Libraries/dotNetRDF/Query/Builder/PatternItemFactory.cs
@@ -63,7 +63,7 @@ namespace VDS.RDF.Query.Builder
             return new BlankNodePattern(blankNodeIdentifier);
         }
 
-        internal PatternItem CreatePatternItem(Type nodeType, string patternString, INamespaceMapper namespaceMapper)
+        public PatternItem CreatePatternItem(Type nodeType, string patternString, INamespaceMapper namespaceMapper)
         {
             if (nodeType == typeof(IUriNode))
             {

--- a/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
@@ -32,7 +32,7 @@ using VDS.RDF.Query.Patterns;
 namespace VDS.RDF.Query.Builder
 {
     /// <inheritdoc />
-    public class TriplePatternBuilder : ITriplePatternBuilder
+    public class TriplePatternBuilder : ITriplePatternBuilder, ITriplePatternBuilderInternal
     {
         private readonly IList<ITriplePattern> _patterns = new List<ITriplePattern>();
         private readonly PatternItemFactory _patternItemFactory;
@@ -95,12 +95,12 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Gets the pattern item factory.
         /// </summary>
-        internal PatternItemFactory PatternItemFactory
+        public IPatternItemFactory PatternItemFactory
         {
             get { return _patternItemFactory; }
         }
 
-        internal void AddPattern(TriplePattern triplePattern)
+        public void AddPattern(TriplePattern triplePattern)
         {
             _patterns.Add(triplePattern);
         }

--- a/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
+++ b/Libraries/dotNetRDF/Query/Builder/TriplePatternBuilder.cs
@@ -31,12 +31,26 @@ using VDS.RDF.Query.Patterns;
 
 namespace VDS.RDF.Query.Builder
 {
-    /// <inheritdoc />
-    public class TriplePatternBuilder : ITriplePatternBuilder, ITriplePatternBuilderInternal
+    /// <summary>
+    /// Provides methods for building triple patterns.
+    /// </summary>
+    public class TriplePatternBuilder : ITriplePatternBuilderInternal
     {
         private readonly IList<ITriplePattern> _patterns = new List<ITriplePattern>();
         private readonly PatternItemFactory _patternItemFactory;
-        private readonly INamespaceMapper _prefixes;
+
+        /// <summary>
+        /// Gets the triple patterns.
+        /// </summary>
+        public ITriplePattern[] Patterns => _patterns.ToArray();
+
+        /// <summary>
+        /// Gets the pattern item factory.
+        /// </summary>
+        public IPatternItemFactory PatternItemFactory => _patternItemFactory;
+
+        /// <inheritdoc/>
+        public INamespaceMapper Prefixes { get; }
 
         /// <summary>
         /// 
@@ -44,7 +58,7 @@ namespace VDS.RDF.Query.Builder
         /// <param name="prefixes"></param>
         public TriplePatternBuilder(INamespaceMapper prefixes)
         {
-            _prefixes = prefixes;
+            Prefixes = prefixes;
             _patternItemFactory = new PatternItemFactory();
         }
 
@@ -63,7 +77,7 @@ namespace VDS.RDF.Query.Builder
         /// <inheritdoc/>
         public TriplePatternPredicatePart Subject<TNode>(string subject) where TNode : INode
         {
-            return Subject(PatternItemFactory.CreatePatternItem(typeof(TNode), subject, _prefixes));
+            return Subject(_patternItemFactory.CreatePatternItem(typeof(TNode), subject, Prefixes));
         }
 
         /// <inheritdoc/>
@@ -81,25 +95,10 @@ namespace VDS.RDF.Query.Builder
         /// <inheritdoc/>
         public TriplePatternPredicatePart Subject(PatternItem subject)
         {
-            return new TriplePatternPredicatePart(this, subject, _prefixes);
+            return new TriplePatternPredicatePart(this, subject, Prefixes);
         }
 
-        /// <summary>
-        /// Gets the triple patterns.
-        /// </summary>
-        public ITriplePattern[] Patterns
-        {
-            get { return _patterns.ToArray(); }
-        }
-
-        /// <summary>
-        /// Gets the pattern item factory.
-        /// </summary>
-        public IPatternItemFactory PatternItemFactory
-        {
-            get { return _patternItemFactory; }
-        }
-
+        /// <inheritdoc />
         public void AddPattern(TriplePattern triplePattern)
         {
             _patterns.Add(triplePattern);


### PR DESCRIPTION
This PR adds an extension API for TriplePatternBuilder that enables developers to extend the QueryBuilder's fluent API without leaking the details of the extension points into that API. This is done by adding a interface ITriplePatternBuilderInternal which is not exposed via the QueryBuilder's fluent API, but is implemented by the default TriplePatternBuilder class so an extension method implementation receiving an ITriplePatternBuilder as a receiver parameter can cast that parameter to an ITriplePatternBuilderInternal in order to access the extension APIs.

Closes #377