### PR TITLE
Do not use Uri.ToString

### DIFF
--- a/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
+++ b/Libraries/dotNetRDF/Writing/Formatting/BaseFormatter.cs
@@ -128,7 +128,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <returns></returns>
         public virtual String FormatUri(Uri u)
         {
-            return FormatUri(u.ToString());
+            return FormatUri(u.IsAbsoluteUri ? u.AbsoluteUri : u.OriginalString);
         }
 
         /// <summary>


### PR DESCRIPTION
`Uri.ToString` does not preserve the exact URI format it was created in, with respect to IRI characters. `urn:%C3%A1` would be formatted as `urn:á` which corresponds to URI-to-IRI conversion rules, but is nonetheless a distinct IRI as far as RDF is concerned.

In the vast majority of cases, `AbsoluteUri` is the only applicable property to use to get a 100% valid URI. `OriginalString` is unsafe to use in this case because the `Uri` constructor accepts a variety of strings, some of which do correspond to an absolute URI but aren't in the proper format (like `C:\` getting converted to `file:///C:/`).

For future compatibility, `OriginalString` is the only usable property when the URI is not absolute. However, this does not perform any of the useful sanitization like checking invalid characters (which may appear there), but that is true of `ToString()` as well.