### PR TITLE
Release 2.7.2

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,12 @@
 ﻿Change Log
 ==========
 
+2.7.2
+-----
+
+This is a minor update to bump dependencies, in particular it updates the Newtonsoft.Json dependency from 12.x to 13.x. It also
+includes minor updates for HtmlAgilityPack (1.11.31->1.11.34) and AngleSharp (0.14.0->0.16.0)
+
 2.7.1
 -----
 FIX: Fixed the UriLoaderCache to correctly handle cache file freshness checks when a cache file is deleted and then recreated within a short period of time.  Thanks to @co2chicken for the report. (#396)

--- a/Libraries/dotNetRDF/dotNetRDF.csproj
+++ b/Libraries/dotNetRDF/dotNetRDF.csproj
@@ -59,8 +59,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.31" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
     <PackageReference Include="VDS.Common" Version="1.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="AngleSharp" Version="0.14.0" />
+    <PackageReference Include="AngleSharp" Version="0.16.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />

--- a/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
+++ b/Testing/dotNetRDF.MockServerTests/dotNetRDF.MockServerTests.csproj
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="WireMock.Net" Version="1.4.6" />
+    <PackageReference Include="WireMock.Net" Version="1.4.18" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Testing/unittest/unittest.csproj
+++ b/Testing/unittest/unittest.csproj
@@ -35,7 +35,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />


### PR DESCRIPTION
- Bump Newtonsoft.Json from 12.0.3 to 13.0.1
- Bump AngleSharp and HtmlAgilitiyPack to their latest minor releases
- Bump WireMock and Microsoft.Test test dependencies

Closes #401