### PR TITLE
Support overriding the default XML Reader settings for XML parsers

### DIFF
--- a/Libraries/dotNetRDF/Parsing/Contexts/RdfXmlParserContext.cs
+++ b/Libraries/dotNetRDF/Parsing/Contexts/RdfXmlParserContext.cs
@@ -130,10 +130,11 @@ namespace VDS.RDF.Parsing.Contexts
         /// <param name="handler">RDF Handler.</param>
         /// <param name="input">Input.</param>
         /// <param name="uriFactory">URI Factory to use.</param>
-        public RdfXmlParserContext(IRdfHandler handler, TextReader input, IUriFactory uriFactory= null)
+        /// <param name="xmlReaderSettings">The settngs to pass through to the underlying XML parser.</param>
+        public RdfXmlParserContext(IRdfHandler handler, TextReader input, IUriFactory uriFactory= null, XmlReaderSettings xmlReaderSettings = null)
             : base(handler, false, uriFactory ?? RDF.UriFactory.Root)
         {
-            _queue = new StreamingEventQueue<IRdfXmlEvent>(new StreamingEventGenerator(input, handler.GetBaseUri().ToSafeString()));
+            _queue = new StreamingEventQueue<IRdfXmlEvent>(new StreamingEventGenerator(input, handler.GetBaseUri().ToSafeString(), xmlReaderSettings));
         }
 
         /// <summary>

--- a/Libraries/dotNetRDF/Parsing/Events/RdfXml/StreamingEventGenerator.cs
+++ b/Libraries/dotNetRDF/Parsing/Events/RdfXml/StreamingEventGenerator.cs
@@ -27,7 +27,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Xml;
 
 namespace VDS.RDF.Parsing.Events.RdfXml
@@ -57,31 +56,13 @@ namespace VDS.RDF.Parsing.Events.RdfXml
         /// Creates a new Streaming Event Generator.
         /// </summary>
         /// <param name="stream">Stream.</param>
-        public StreamingEventGenerator(Stream stream)
-        {
-            _reader = XmlReader.Create(stream, GetSettings());
-            _hasLineInfo = (_reader is IXmlLineInfo);
-        }
-
-        /// <summary>
-        /// Creates a new Streaming Event Generator.
-        /// </summary>
-        /// <param name="stream">Stream.</param>
         /// <param name="baseUri">Base URI.</param>
-        public StreamingEventGenerator(Stream stream, string baseUri)
-            : this(stream)
+        /// <param name="xmlReaderSettings">The settings to pass through to the underlying XMLReader instance.</param>
+        public StreamingEventGenerator(Stream stream, string baseUri = null, XmlReaderSettings xmlReaderSettings = null)
         {
-            _currentBaseUri = baseUri;
-        }
-
-        /// <summary>
-        /// Creates a new Streaming Event Generator.
-        /// </summary>
-        /// <param name="reader">Text Reader.</param>
-        public StreamingEventGenerator(TextReader reader)
-        {
-            _reader = XmlReader.Create(reader, GetSettings());
+            _reader = XmlReader.Create(stream, xmlReaderSettings ?? GetSettings());
             _hasLineInfo = (_reader is IXmlLineInfo);
+            _currentBaseUri = baseUri ?? String.Empty;
         }
 
         /// <summary>
@@ -89,20 +70,12 @@ namespace VDS.RDF.Parsing.Events.RdfXml
         /// </summary>
         /// <param name="reader">Text Reader.</param>
         /// <param name="baseUri">Base URI.</param>
-        public StreamingEventGenerator(TextReader reader, string baseUri)
-            : this(reader)
+        /// <param name="xmlReaderSettings">The settings to pass through to the underlying XMLReader instance.</param>
+        public StreamingEventGenerator(TextReader reader, string baseUri = null,XmlReaderSettings xmlReaderSettings = null)
         {
-            _currentBaseUri = baseUri;
-        }
-
-        /// <summary>
-        /// Creates a new Streaming Event Generator.
-        /// </summary>
-        /// <param name="file">Filename.</param>
-        public StreamingEventGenerator(string file)
-        {
-            _reader = XmlReader.Create(new FileStream(file, FileMode.Open), GetSettings());
+            _reader = XmlReader.Create(reader, xmlReaderSettings ?? GetSettings());
             _hasLineInfo = (_reader is IXmlLineInfo);
+            _currentBaseUri = baseUri ?? string.Empty;
         }
 
         /// <summary>
@@ -110,28 +83,28 @@ namespace VDS.RDF.Parsing.Events.RdfXml
         /// </summary>
         /// <param name="file">Filename.</param>
         /// <param name="baseUri">Base URI.</param>
-        public StreamingEventGenerator(string file, string baseUri)
-            : this(file)
+        /// <param name="xmlReaderSettings">Settings to pass through to the underlying XML parser.</param>
+        public StreamingEventGenerator(string file, string baseUri = null, XmlReaderSettings xmlReaderSettings = null)
         {
-            _currentBaseUri = baseUri;
+            _reader = XmlReader.Create(new FileStream(file, FileMode.Open), xmlReaderSettings ?? GetSettings());
+            _hasLineInfo = (_reader is IXmlLineInfo);
+            _currentBaseUri = baseUri ?? string.Empty;
         }
 
         /// <summary>
-        /// Initialises the XML Reader settings.
+        /// Returns the default XML Reader settings.
         /// </summary>
         /// <returns></returns>
         private XmlReaderSettings GetSettings()
         {
-            var settings = new XmlReaderSettings();
-#if NETCORE 
-            settings.DtdProcessing = DtdProcessing.Ignore;
-#elif NET40 || NETSTANDARD2_0
-            settings.DtdProcessing = DtdProcessing.Parse;
-#endif
-            settings.ConformanceLevel = ConformanceLevel.Document;
-            settings.IgnoreComments = true;
-            settings.IgnoreProcessingInstructions = true;
-            settings.IgnoreWhitespace = true;
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Parse,
+                ConformanceLevel = ConformanceLevel.Document,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                IgnoreWhitespace = true,
+            };
             return settings;
         }
 

--- a/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/RDFXMLParser.cs
@@ -107,6 +107,18 @@ namespace VDS.RDF.Parsing
             }
         }
 
+        /// <summary>
+        /// Get the settings to pass through to the underlying XML parser used when parsing in streaming mode.
+        /// </summary>
+        public readonly XmlReaderSettings XmlReaderSettings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Parse,
+            ConformanceLevel = ConformanceLevel.Document,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            IgnoreWhitespace = true,
+        };
+
         #endregion
 
         /// <summary>
@@ -226,7 +238,8 @@ namespace VDS.RDF.Parsing
                 {
                     // Load XML from Stream
                     var doc = new XmlDocument();
-                    doc.Load(input);
+                    var reader = XmlReader.Create(input, XmlReaderSettings);
+                    doc.Load(reader);
 
                     // Create a new Parser Context and Parse
                     var context = new RdfXmlParserContext(handler, doc, _traceparsing, uriFactory);
@@ -234,7 +247,7 @@ namespace VDS.RDF.Parsing
                 }
                 else
                 {
-                    var context = new RdfXmlParserContext(handler, input, uriFactory);
+                    var context = new RdfXmlParserContext(handler, input, uriFactory, XmlReaderSettings);
                     Parse(context);
                 }
             }

--- a/Libraries/dotNetRDF/Parsing/SPARQLXMLParser.cs
+++ b/Libraries/dotNetRDF/Parsing/SPARQLXMLParser.cs
@@ -46,6 +46,22 @@ namespace VDS.RDF.Parsing
         public const string SparqlNamespace = "http://www.w3.org/2005/sparql-results#";
 
         /// <summary>
+        /// Get the settings passed to the underlying XML parser on read.
+        /// </summary>
+        /// <remarks>This property can be used to modify the configuration of the 
+        /// XML parser used to parse SPARQL XML. In particular it makes it possible to 
+        /// disable the processing of the XML DTD in environments where remote XML
+        /// entity references are of concern.</remarks>
+        public readonly XmlReaderSettings XmlReaderSettings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Parse,
+            ConformanceLevel = ConformanceLevel.Document,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            IgnoreWhitespace = true,
+        };
+
+        /// <summary>
         /// Loads a Result Set from an Input.
         /// </summary>
         /// <param name="results">Result Set to load into.</param>
@@ -100,7 +116,7 @@ namespace VDS.RDF.Parsing
             try
             {
                 // Parse the XML
-                var reader = XmlReader.Create(input, GetSettings());
+                var reader = XmlReader.Create(input, XmlReaderSettings);
                 Parse(new SparqlXmlParserContext(reader, handler, uriFactory));
             }
             catch
@@ -146,24 +162,6 @@ namespace VDS.RDF.Parsing
             Load(handler, new StreamReader(File.OpenRead(filename)), uriFactory);
         }
 
-        /// <summary>
-        /// Initialises the XML Reader settings.
-        /// </summary>
-        /// <returns></returns>
-        private XmlReaderSettings GetSettings()
-        {
-            var settings = new XmlReaderSettings();
-#if NETCORE
-            settings.DtdProcessing = DtdProcessing.Ignore;
-#elif NET40
-            settings.DtdProcessing = DtdProcessing.Parse;
-#endif
-            settings.ConformanceLevel = ConformanceLevel.Document;
-            settings.IgnoreComments = true;
-            settings.IgnoreProcessingInstructions = true;
-            settings.IgnoreWhitespace = true;
-            return settings;
-        }
 
         /// <summary>
         /// Parses the XML Result Set format into a set of SPARQLResult objects.

--- a/Testing/unittest/Parsing/TriXTests.cs
+++ b/Testing/unittest/Parsing/TriXTests.cs
@@ -28,6 +28,7 @@ using System.Diagnostics;
 using System.Linq;
 using Xunit;
 using VDS.RDF.Writing;
+using System.Xml;
 
 namespace VDS.RDF.Parsing
 {
@@ -113,6 +114,17 @@ namespace VDS.RDF.Parsing
             var store = new TripleStore();
             _parser.Load(store, @"resources\\trix\emptygraph.trix");
             Assert.Equal(0, store.Graphs.Count);
+        }
+
+        [Fact]
+        public void EntityParsingCanBeDisabled()
+        {
+            var store = new TripleStore();
+            var parser = new TriXParser();
+            parser.XmlReaderSettings.DtdProcessing = DtdProcessing.Prohibit;
+            var thrown = Assert.Throws<RdfParseException>(() =>
+            parser.Load(store, System.IO.Path.Combine("resources", "trix", "entities.trix")));
+            Assert.IsType<XmlException>(thrown.InnerException);
         }
     }
 }

--- a/Testing/unittest/resources/trix/entities.trix
+++ b/Testing/unittest/resources/trix/entities.trix
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE Trix [
+  <!ENTITY who 'Bob'>
+]>
+<Trix xmlns="http://www.w3.org/2004/03/trix/trix-1/">
+  <graph>
+    <triple>
+      <uri>http://example.org/&who;</uri>
+      <uri>http://example.org/wife</uri>
+      <uri>http://example.org/Mary</uri>
+    </triple>
+  </graph>
+</Trix>


### PR DESCRIPTION
The TriX and RDF/XML parsers now expose an XmlReaderSettings property which can be used to provide the settings that will be passed to the underlying XML parser when a Load() method is invoked. The default settings remain the same as in 2.x, but it is now possible to disable DTD and PI processing.

Addresses #308