### PR TITLE
Update Lucene.Net dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,18 +22,21 @@ jobs:
     
   fullTextTests:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        framework: ["net472", "netcoreapp3.1"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Test Full-Text Indexing
-      run: dotnet test -c Release --filter "Category=fulltext" --framework net472 --collect:"XPlat Code Coverage"
+      run: dotnet test -c Release --filter "Category=fulltext" --framework ${{ matrix.framework }} --collect:"XPlat Code Coverage" Testing\unittest
     - name: Upload Code Coverage
       uses: actions/upload-artifact@v2
       with:
-        name: code-coverage FullText net472
-        path: Testing\${{matrix.suite}}\TestResults\**\coverage.cobertura.xml
+        name: code-coverage FullText ${{ matrix.framework }}
+        path: Testing\unittest\TestResults\**\coverage.cobertura.xml
       
   fusekiTests:
     runs-on: ubuntu-latest

--- a/Libraries/dotNetRDF.Query.FullText/FullText/Search/Lucene/DocCollector.cs
+++ b/Libraries/dotNetRDF.Query.FullText/FullText/Search/Lucene/DocCollector.cs
@@ -35,7 +35,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
     /// Collector Implementation used as part of our Lucene.Net integration.
     /// </summary>
     class DocCollector
-        : Collector
+        : ICollector
     {
         private Scorer _scorer;
         private int _currBase = 0;
@@ -82,25 +82,14 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
             }
         }
 
-        /// <summary>
-        /// Returns that documents are accepted out of order.
-        /// </summary>
-        /// <returns></returns>
-        public override bool AcceptsDocsOutOfOrder
-        {
-            get
-            {
-                return true;
-            }
-        }
 
         /// <summary>
         /// Collects a document if it meets the score threshold (if any).
         /// </summary>
         /// <param name="doc">Document ID.</param>
-        public override void Collect(int doc)
+        public void Collect(int doc)
         {
-            double score = _scorer.Score();
+            double score =_scorer.GetScore();
             if (!Double.IsNaN(_scoreThreshold))
             {
                 if (score >= _scoreThreshold)
@@ -117,20 +106,33 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <summary>
         /// Sets the Next Reader.
         /// </summary>
-        /// <param name="reader">Index Reader.</param>
-        /// <param name="docBase">Document Base.</param>
-        public override void SetNextReader(IndexReader reader, int docBase)
+        /// <param name="context">Index Reader context.</param>
+        public void SetNextReader(AtomicReaderContext context)
         {
-            _currBase = docBase;
+            _currBase = context.DocBase;
         }
+
 
         /// <summary>
         /// Sets the Scorer.
         /// </summary>
         /// <param name="scorer">Scorer.</param>
-        public override void SetScorer(Scorer scorer)
+        public void SetScorer(Scorer scorer)
         {
             _scorer = scorer;
         }
+
+        /// <summary>
+        /// Returns that documents are accepted out of order.
+        /// </summary>
+        /// <returns></returns>
+        public bool AcceptsDocsOutOfOrder
+        {
+            get
+            {
+                return true;
+            }
+        }
+
     }
 }

--- a/Libraries/dotNetRDF.Query.FullText/FullText/Search/Lucene/LuceneSearchProvider.cs
+++ b/Libraries/dotNetRDF.Query.FullText/FullText/Search/Lucene/LuceneSearchProvider.cs
@@ -27,8 +27,8 @@
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Store;
-using LucUtil = Lucene.Net.Util;
 using VDS.RDF.Query.FullText.Schema;
+using Lucene.Net.Util;
 
 namespace VDS.RDF.Query.FullText.Search.Lucene
 {
@@ -46,7 +46,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <param name="analyzer">Analyzer.</param>
         /// <param name="schema">Index Schema.</param>
         /// <param name="autoSync">Whether to keep the search provider in sync with the index.</param>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, Analyzer analyzer, IFullTextIndexSchema schema, bool autoSync)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, Analyzer analyzer, IFullTextIndexSchema schema, bool autoSync)
             : base(ver, indexDir, analyzer, schema, autoSync) { }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <param name="indexDir">Directory.</param>
         /// <param name="analyzer">Analyzer.</param>
         /// <param name="schema">Index Schema.</param>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, Analyzer analyzer, IFullTextIndexSchema schema)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, Analyzer analyzer, IFullTextIndexSchema schema)
             : this(ver, indexDir, analyzer, schema, true) { }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="DefaultIndexSchema">DefaultIndexSchema</see> as the schema.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, Analyzer analyzer, bool autoSync)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, Analyzer analyzer, bool autoSync)
             : this(ver, indexDir, analyzer, new DefaultIndexSchema(), autoSync) { }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="DefaultIndexSchema">DefaultIndexSchema</see> as the schema.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, Analyzer analyzer)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, Analyzer analyzer)
             : this(ver, indexDir, analyzer, true) { }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="StandardAnalyzer">StandardAnalyzer</see> as the analyzer.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, IFullTextIndexSchema schema, bool autoSync)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, IFullTextIndexSchema schema, bool autoSync)
             : this(ver, indexDir, new StandardAnalyzer(ver), schema, autoSync) { }
 
         
@@ -107,7 +107,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="StandardAnalyzer">StandardAnalyzer</see> as the analyzer.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, IFullTextIndexSchema schema)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, IFullTextIndexSchema schema)
             : this(ver, indexDir, schema, true) { }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="DefaultIndexSchema">DefaultIndexSchema</see> as the schema and the <see cref="StandardAnalyzer">StandardAnalyzer</see> as the analyzer.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir, bool autoSync)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir, bool autoSync)
             : this(ver, indexDir, new StandardAnalyzer(ver), new DefaultIndexSchema(), autoSync) { }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace VDS.RDF.Query.FullText.Search.Lucene
         /// <remarks>
         /// Uses the <see cref="DefaultIndexSchema">DefaultIndexSchema</see> as the schema and the <see cref="StandardAnalyzer">StandardAnalyzer</see> as the analyzer.
         /// </remarks>
-        public LuceneSearchProvider(LucUtil.Version ver, Directory indexDir)
+        public LuceneSearchProvider(LuceneVersion ver, Directory indexDir)
             : this(ver, indexDir, true) { }
     }
 }

--- a/Libraries/dotNetRDF.Query.FullText/FullTextObjectFactory.cs
+++ b/Libraries/dotNetRDF.Query.FullText/FullTextObjectFactory.cs
@@ -25,12 +25,10 @@
 */
 
 using System;
-using System.Collections.Generic;
 using DirInfo = System.IO.DirectoryInfo;
 using System.Linq;
 using System.Reflection;
 using Lucene.Net.Analysis;
-using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using VDS.RDF.Query;
@@ -41,7 +39,8 @@ using VDS.RDF.Query.FullText.Schema;
 using VDS.RDF.Query.FullText.Search;
 using VDS.RDF.Query.FullText.Search.Lucene;
 using VDS.RDF.Query.Optimisation;
-using LucVersion = Lucene.Net.Util.Version;
+using Lucene.Net.Util;
+using Lucene.Net.Analysis.Standard;
 
 namespace VDS.RDF.Configuration
 {   
@@ -263,7 +262,7 @@ namespace VDS.RDF.Configuration
                         {
                             //Create an Analyzer
                             //Try to create passing Lucene Version wherever possible
-                            if (targetType.GetConstructor(new Type[] { typeof(LucVersion) }) != null)
+                            if (targetType.GetConstructor(new Type[] { typeof(LuceneVersion) }) != null)
                             {
                                 obj = Activator.CreateInstance(targetType, new Object[] { GetLuceneVersion(ver) });
                             }
@@ -300,7 +299,8 @@ namespace VDS.RDF.Configuration
                             {
                                 if (ConfigurationLoader.GetConfigurationBoolean(g, objNode, g.CreateUriNode(g.UriFactory.Create(FullTextHelper.FullTextConfigurationNamespace + "ensureIndex")), false))
                                 {
-                                    var writer = new IndexWriter((Directory)obj, new StandardAnalyzer(GetLuceneVersion(ver)), IndexWriter.MaxFieldLength.UNLIMITED);
+                                    var conf = new IndexWriterConfig(GetLuceneVersion(ver), new StandardAnalyzer(GetLuceneVersion(ver)));
+                                    var writer = new IndexWriter((Directory)obj, conf);
                                     writer.Dispose();
                                 }
                             }
@@ -348,24 +348,44 @@ namespace VDS.RDF.Configuration
         /// </summary>
         /// <param name="ver">Version.</param>
         /// <returns></returns>
-        private LucVersion GetLuceneVersion(int ver)
+        private LuceneVersion GetLuceneVersion(int ver)
         {
             switch (ver)
             {
-                case 2000:
-                    return LucVersion.LUCENE_20;
-                case 2100:
-                    return LucVersion.LUCENE_21;
-                case 2200:
-                    return LucVersion.LUCENE_22;
-                case 2300:
-                    return LucVersion.LUCENE_23;
-                case 2400:
-                    return LucVersion.LUCENE_24;
-                case 2900:
-                    return LucVersion.LUCENE_29;
+                case 3000:
+                    return LuceneVersion.LUCENE_30;
+                case 3100:
+                    return LuceneVersion.LUCENE_31;
+                case 3200:
+                    return LuceneVersion.LUCENE_32;
+                case 3300:
+                    return LuceneVersion.LUCENE_33;
+                case 3400:
+                    return LuceneVersion.LUCENE_34;
+                case 3500:
+                    return LuceneVersion.LUCENE_35;
+                case 3600:
+                    return LuceneVersion.LUCENE_36;
+                case 4000:
+                    return LuceneVersion.LUCENE_40;
+                case 4100:
+                    return LuceneVersion.LUCENE_41;
+                case 4200:
+                    return LuceneVersion.LUCENE_42;
+                case 4300:
+                    return LuceneVersion.LUCENE_43;
+                case 4400:
+                    return LuceneVersion.LUCENE_44;
+                case 4500:
+                    return LuceneVersion.LUCENE_45;
+                case 4600:
+                    return LuceneVersion.LUCENE_46;
+                case 4700:
+                    return LuceneVersion.LUCENE_47;
+                case 4800:
+                    return LuceneVersion.LUCENE_48;
                 default:
-                    return LucVersion.LUCENE_29;
+                    return LuceneVersion.LUCENE_48;
             }
         }
     }

--- a/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
+++ b/Libraries/dotNetRDF.Query.FullText/dotNetRDF.Query.FullText.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRDF.Query.FullText</AssemblyTitle>
-    <AssemblyName>dotNetRDF.Query.FullText</AssemblyName>
+    <AssemblyTitle>dotNetRdf.Query.FullText</AssemblyTitle>
+    <AssemblyName>dotNetRdf.Query.FullText</AssemblyName>
     <Description>Provides Full Text SPARQL support as a plugin for the dotNetRDF Leviathan SPARQL Engine using Lucene.Net</Description>
     <VersionPrefix>$(Version)</VersionPrefix>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>dotNetRDF.Query.FullText</PackageId>
+    <PackageId>dotNetRdf.Query.FullText</PackageId>
     <PackageTags>RDF;Semantic;Web;SPARQL;Query;Full;Text;Lucene</PackageTags>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
     <DebugType>full</DebugType>
@@ -28,7 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net" Version="3.0.3" />
+    <PackageReference Include="Lucene.Net" Version="4.8.*-*"  />
+    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.*-*"/>
     <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
@@ -40,9 +41,5 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);NET40</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiStoreTests.cs
+++ b/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiStoreTests.cs
@@ -27,7 +27,7 @@ using Xunit;
 
 namespace VDS.RDF.Storage
 {
-    [Collection("RdfServer")]
+    [Collection("Fuseki Test Collection")]
     public class FusekiStoreTests : BasePersistentTripleStoreTests
     {
         public FusekiStoreTests(RdfServerFixture serverFixture) : base(serverFixture){}

--- a/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiStoreTests.cs
+++ b/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiStoreTests.cs
@@ -27,7 +27,7 @@ using Xunit;
 
 namespace VDS.RDF.Storage
 {
-    [Collection("Fuseki Test Collection")]
+    [Collection("RdfServer")]
     public class FusekiStoreTests : BasePersistentTripleStoreTests
     {
         public FusekiStoreTests(RdfServerFixture serverFixture) : base(serverFixture){}

--- a/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiWriteToStoreHandlerTests.cs
+++ b/Testing/dotNetRDF.Connectors.Fuseki.Tests/FusekiWriteToStoreHandlerTests.cs
@@ -23,11 +23,14 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using Xunit;
+
 namespace VDS.RDF.Storage
 {
     /// <summary>
     /// Summary description for WriteToStoreHandlerTests
     /// </summary>
+    [Collection("Fuseki Test Collection")]
     public class FusekiWriteToStoreHandlerTests: WriteToStoreHandlerTests
     {
         protected override IStorageProvider GetConnection()

--- a/Testing/dotNetRDF.Connectors.Fuseki.Tests/RdfServerCollection.cs
+++ b/Testing/dotNetRDF.Connectors.Fuseki.Tests/RdfServerCollection.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace VDS.RDF.Storage
 {
-    [CollectionDefinition("RdfServer")]
+    [CollectionDefinition("RdfServer", DisableParallelization = true)]
     public class RdfServerCollection : ICollectionFixture<RdfServerFixture>
     {
     }

--- a/Testing/unittest/Query/FullText/FullTextConfigTests.cs
+++ b/Testing/unittest/Query/FullText/FullTextConfigTests.cs
@@ -87,7 +87,7 @@ namespace VDS.RDF.Query.FullText
             IGraph g = GetBaseGraph();
             INode obj = g.CreateBlankNode();
             g.Assert(obj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(obj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(obj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             TestTools.ShowGraph(g);
 
@@ -104,7 +104,7 @@ namespace VDS.RDF.Query.FullText
             IGraph g = GetBaseGraph();
             INode obj = g.CreateBlankNode();
             g.Assert(obj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(obj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(obj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
             g.Assert(obj, g.CreateUriNode("dnr-ft:version"), (2400).ToLiteral(g));
 
             TestTools.ShowGraph(g);
@@ -170,7 +170,7 @@ namespace VDS.RDF.Query.FullText
             //Add and Test the analyzer Config
             INode analyzerObj = g.CreateBlankNode();
             g.Assert(analyzerObj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             ConfigurationLoader.AddObjectFactory(_factory);
 
@@ -222,7 +222,7 @@ namespace VDS.RDF.Query.FullText
             //Add and Test the analyzer Config
             INode analyzerObj = g.CreateBlankNode();
             g.Assert(analyzerObj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             ConfigurationLoader.AddObjectFactory(_factory);
 
@@ -274,7 +274,7 @@ namespace VDS.RDF.Query.FullText
             //Add and Test the analyzer Config
             INode analyzerObj = g.CreateBlankNode();
             g.Assert(analyzerObj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             ConfigurationLoader.AddObjectFactory(_factory);
 
@@ -327,7 +327,7 @@ namespace VDS.RDF.Query.FullText
             //Add and Test the analyzer Config
             INode analyzerObj = g.CreateBlankNode();
             g.Assert(analyzerObj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             ConfigurationLoader.AddObjectFactory(_factory);
 
@@ -374,7 +374,7 @@ namespace VDS.RDF.Query.FullText
             //Add and Test the analyzer Config
             INode analyzerObj = g.CreateBlankNode();
             g.Assert(analyzerObj, g.CreateUriNode("rdf:type"), g.CreateUriNode("dnr-ft:Analyzer"));
-            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"));
+            g.Assert(analyzerObj, g.CreateUriNode("dnr:type"), g.CreateLiteralNode("Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net.Analysis.Common"));
 
             //Add and Test the schema config
             INode schemaObj = g.CreateBlankNode();
@@ -504,7 +504,8 @@ namespace VDS.RDF.Query.FullText
         [Fact]
         public void FullTextConfigSerializeIndexerLuceneSubjects()
         {
-            var indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+            var testHarness = new LuceneTestHarness();
+            var indexer = new LuceneSubjectsIndexer(testHarness.Index, testHarness.Analyzer, testHarness.Schema);
             var context = new ConfigurationSerializationContext();
             INode obj = context.Graph.CreateBlankNode();
             context.NextSubject = obj;
@@ -522,7 +523,8 @@ namespace VDS.RDF.Query.FullText
         [Fact]
         public void FullTextConfigSerializeIndexerLuceneObjects()
         {
-            var indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+            var testHarness = new LuceneTestHarness();
+            var indexer = new LuceneObjectsIndexer(testHarness.Index, testHarness.Analyzer, testHarness.Schema);
             var context = new ConfigurationSerializationContext();
             INode obj = context.Graph.CreateBlankNode();
             context.NextSubject = obj;
@@ -540,7 +542,8 @@ namespace VDS.RDF.Query.FullText
         [Fact]
         public void FullTextConfigSerializeIndexerLucenePredicates()
         {
-            var indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+            var testHarness = new LuceneTestHarness();
+            var indexer = new LucenePredicatesIndexer(testHarness.Index, testHarness.Analyzer, testHarness.Schema);
             var context = new ConfigurationSerializationContext();
             INode obj = context.Graph.CreateBlankNode();
             context.NextSubject = obj;
@@ -558,12 +561,13 @@ namespace VDS.RDF.Query.FullText
         [Fact]
         public void FullTextConfigSerializeFullTextOptimiser()
         {
+            var testHarness = new LuceneTestHarness();
             try
             {
-                var writer = new IndexWriter(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, IndexWriter.MaxFieldLength.UNLIMITED);
-                writer.Dispose();
+                // Ensure we have a properly initialised search index in the RAM directory
+                using (var indexer = new LucenePredicatesIndexer(testHarness.Index, testHarness.Analyzer, testHarness.Schema)) { };
 
-                var optimiser = new FullTextOptimiser(new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index, LuceneTestHarness.Schema));
+                var optimiser = new FullTextOptimiser(new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, testHarness.Index, testHarness.Schema));
                 var context = new ConfigurationSerializationContext();
                 INode obj = context.Graph.CreateBlankNode();
                 context.NextSubject = obj;
@@ -578,7 +582,7 @@ namespace VDS.RDF.Query.FullText
             }
             finally
             {
-                LuceneTestHarness.Index.Dispose();
+                testHarness.Index.Dispose();
             }
         }
     }

--- a/Testing/unittest/Query/FullText/FullTextDatasetTests.cs
+++ b/Testing/unittest/Query/FullText/FullTextDatasetTests.cs
@@ -102,6 +102,7 @@ namespace VDS.RDF.Query.FullText
             //Lucene Index
             Directory dir = new RAMDirectory();
             var indexer = new LuceneSubjectsIndexer(dir, new StandardAnalyzer(LuceneTestHarness.LuceneVersion), new DefaultIndexSchema());
+            indexer.Flush();
             var searcher = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, dir);
 
             //Test Dataset

--- a/Testing/unittest/Query/FullText/FullTextGraphScopingTests.cs
+++ b/Testing/unittest/Query/FullText/FullTextGraphScopingTests.cs
@@ -36,6 +36,7 @@ using VDS.RDF.Query.FullText.Indexing.Lucene;
 using VDS.RDF.Query.FullText.Search.Lucene;
 using VDS.RDF.Query.FullText.Schema;
 using VDS.RDF.Query.Optimisation;
+using Lucene.Net.Util;
 
 namespace VDS.RDF.Query.FullText
 {
@@ -59,7 +60,7 @@ namespace VDS.RDF.Query.FullText
             StringParser.ParseDataset(_store, data, new NQuadsParser());
 
             _index = new RAMDirectory();
-            using (var indexer = new LuceneSubjectsIndexer(_index, new StandardAnalyzer(LucUtil.Version.LUCENE_30), new DefaultIndexSchema()))
+            using (var indexer = new LuceneSubjectsIndexer(_index, new StandardAnalyzer(LuceneVersion.LUCENE_48), new DefaultIndexSchema()))
             {
                 foreach (IGraph g in _store.Graphs)
                 {
@@ -72,7 +73,7 @@ namespace VDS.RDF.Query.FullText
         public void FullTextGraphScoping1()
         {
             //With no Graph scope all results should be returned
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 IEnumerable<IFullTextSearchResult> results = searcher.Match("sample");
                 Assert.Equal(3, results.Count());
@@ -83,7 +84,7 @@ namespace VDS.RDF.Query.FullText
         public void FullTextGraphScoping2()
         {
             //With Graph scope to g1 only one result should be returned
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 IEnumerable<IFullTextSearchResult> results = searcher.Match(new [] { new UriNode(new  Uri("http://g1")) }, "sample");
                 Assert.Single(results);
@@ -96,7 +97,7 @@ namespace VDS.RDF.Query.FullText
         public void FullTextGraphScoping3()
         {
             //With Graph scope to g2 only two results should be returned
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 IEnumerable<IFullTextSearchResult> results = searcher.Match(new [] { new UriNode(new Uri("http://g2")) }, "sample");
                 Assert.Equal(2, results.Count());
@@ -110,7 +111,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //No results should be returned as no results in default graph
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + "SELECT * WHERE { ?s pf:textMatch 'sample' }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };
@@ -127,7 +128,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //1 result should be returned as only one result in the given graph g1
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + " SELECT * WHERE { GRAPH <http://g1> { ?s pf:textMatch 'sample' } }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };
@@ -144,7 +145,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //2 results should be returned as two results in the given graph g2
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + " SELECT * WHERE { GRAPH <http://g2> { ?s pf:textMatch 'sample' } }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };
@@ -161,7 +162,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //All results should be returned because all graphs are considered
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + " SELECT * WHERE { GRAPH ?g { ?s pf:textMatch 'sample' } }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };
@@ -178,7 +179,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //Interaction of graph scope with limit
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + " SELECT * WHERE { GRAPH <http://g2> { ?s pf:textMatch ( 'sample' 1 ) } }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };
@@ -196,7 +197,7 @@ namespace VDS.RDF.Query.FullText
             var processor = new LeviathanQueryProcessor(_store);
 
             //Interaction of graph scope with limit
-            using (var searcher = new LuceneSearchProvider(LucUtil.Version.LUCENE_30, _index, new StandardAnalyzer(LucUtil.Version.LUCENE_30)))
+            using (var searcher = new LuceneSearchProvider(LuceneVersion.LUCENE_48, _index, new StandardAnalyzer(LuceneVersion.LUCENE_48)))
             {
                 SparqlQuery q = _parser.ParseFromString(FullTextPrefix + " SELECT * WHERE { GRAPH <http://g2> { ?s pf:textMatch ( 'sample' 5 ) } }");
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(searcher) };

--- a/Testing/unittest/Query/FullText/FullTextIncrementalIndexAndSearch.cs
+++ b/Testing/unittest/Query/FullText/FullTextIncrementalIndexAndSearch.cs
@@ -98,6 +98,7 @@ namespace VDS.RDF.Query.FullText
             //Lucene Index
             Directory dir = new RAMDirectory();
             var indexer = new LuceneSubjectsIndexer(dir, new StandardAnalyzer(LuceneTestHarness.LuceneVersion), new DefaultIndexSchema());
+            indexer.Flush();
             var searcher = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, dir);
 
             //Test Graph

--- a/Testing/unittest/Query/FullText/FullTextSparqlTests.cs
+++ b/Testing/unittest/Query/FullText/FullTextSparqlTests.cs
@@ -53,6 +53,7 @@ namespace VDS.RDF.Query.FullText
         private SparqlQueryParser _parser = new SparqlQueryParser();
         private INamespaceMapper _nsmap;
         private ISparqlDataset _dataset;
+        private LuceneTestHarness _testHarness = new LuceneTestHarness();
 
         private INamespaceMapper GetQueryNamespaces()
         {
@@ -95,7 +96,7 @@ namespace VDS.RDF.Query.FullText
             Console.WriteLine("Parsed Query:");
             Console.WriteLine(formatter.Format(q));
 
-            var provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+            var provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
             var factory = new FullTextPropertyFunctionFactory();
             try
             {
@@ -126,7 +127,7 @@ namespace VDS.RDF.Query.FullText
             {
                 PropertyFunctionFactory.RemoveFactory(factory);
                 provider.Dispose();
-                LuceneTestHarness.Index.Dispose();
+                _testHarness.Index.Dispose();
             }
         }
 
@@ -145,7 +146,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
+            RunTest(new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
+            RunTest(new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
         }
 
         [Fact]
@@ -171,7 +172,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
+            RunTest(new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
         }
 
         [Fact]
@@ -184,7 +185,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
 
         [Fact]
@@ -197,7 +198,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
 
         [Fact]
@@ -210,7 +211,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
         }
 
         [Fact]
@@ -223,7 +224,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
         }
 
         [Fact]
@@ -236,7 +237,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
         }
 
         [Fact]
@@ -249,7 +250,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
 
         [Fact]
@@ -262,7 +263,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
 
         [Fact]
@@ -275,7 +276,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
+            RunTest(new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?s pf:textMatch 'http' }", expected);
         }
 
         [Fact]
@@ -288,7 +289,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
+            RunTest(new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch 'http' } ORDER BY DESC(?score)", expected);
         }
 
         [Fact]
@@ -301,7 +302,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
+            RunTest(new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.5) } ORDER BY DESC(?score)", expected, false);
         }
 
         [Fact]
@@ -314,7 +315,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 1.0 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
 
         [Fact]
@@ -327,7 +328,7 @@ namespace VDS.RDF.Query.FullText
                                   && ((ILiteralNode)t.Object).Value.ToLower().Contains("http")
                             select t).Count();
 
-            RunTest(new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
+            RunTest(new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT ?score ?match WHERE { (?match ?score) pf:textMatch ('http' 3) } ORDER BY DESC(?score)", Math.Min(expected, 3), false);
         }
     }
 }

--- a/Testing/unittest/Query/FullText/FullTextSparqlTests2.cs
+++ b/Testing/unittest/Query/FullText/FullTextSparqlTests2.cs
@@ -50,6 +50,7 @@ namespace VDS.RDF.Query.FullText
         private SparqlQueryParser _parser = new SparqlQueryParser();
         private INamespaceMapper _nsmap;
         private ISparqlDataset _dataset;
+        private LuceneTestHarness _testHarness = new LuceneTestHarness();
 
         public FullTextSparqlTests2()
         {
@@ -91,7 +92,7 @@ namespace VDS.RDF.Query.FullText
             }
             Console.WriteLine();
 
-            var provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+            var provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
             try
             {
                 q.AlgebraOptimisers = new IAlgebraOptimiser[] { new FullTextOptimiser(provider) };
@@ -118,14 +119,14 @@ namespace VDS.RDF.Query.FullText
             finally
             {
                 provider.Dispose();
-                LuceneTestHarness.Index.Dispose();
+                _testHarness.Index.Dispose();
             }
         }
 
         [Fact]
         public void FullTextSparqlComplexLuceneSubjects1()
         {
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a <http://example.org/noSuchThing> }", Enumerable.Empty<INode>());
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a <http://example.org/noSuchThing> }", Enumerable.Empty<INode>());
         }
 
         [Fact]
@@ -139,7 +140,7 @@ namespace VDS.RDF.Query.FullText
             expected.RemoveAll(n => !_dataset.ContainsTriple(new Triple(n, factory.CreateUriNode(new Uri(RdfSpecsHelper.RdfType)), factory.CreateUriNode(new Uri(NamespaceMapper.RDFS + "Class")))));
             Assert.True(expected.Any());
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class }", expected);
         }
 
         [Fact]
@@ -153,7 +154,7 @@ namespace VDS.RDF.Query.FullText
             expected.RemoveAll(n => !_dataset.ContainsTriple(new Triple(n, factory.CreateUriNode(new Uri(RdfSpecsHelper.RdfType)), factory.CreateUriNode(new Uri(NamespaceMapper.RDFS + "Class")))));
             Assert.True(expected.Any());
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match a rdfs:Class . { ?match pf:textMatch 'http' } }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match a rdfs:Class . { ?match pf:textMatch 'http' } }", expected);
         }
 
         [Fact]
@@ -168,7 +169,7 @@ namespace VDS.RDF.Query.FullText
             expected.RemoveAll(n => !_dataset.GetTriplesWithPredicateObject(factory.CreateUriNode(new Uri(NamespaceMapper.RDFS + "domain")), n).Any());
             Assert.True(expected.Any());
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class . ?property rdfs:domain ?match }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class . ?property rdfs:domain ?match }", expected);
         }
 
         [Fact]
@@ -183,7 +184,7 @@ namespace VDS.RDF.Query.FullText
             expected.RemoveAll(n => !_dataset.GetTriplesWithPredicateObject(factory.CreateUriNode(new Uri(NamespaceMapper.RDFS + "domain")), n).Any());
 
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class . ?property rdfs:domain ?match . OPTIONAL { ?property rdfs:label ?label } }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . ?match a rdfs:Class . ?property rdfs:domain ?match . OPTIONAL { ?property rdfs:label ?label } }", expected);
         }
 
         [Fact]
@@ -195,7 +196,7 @@ namespace VDS.RDF.Query.FullText
                                     select t.Subject).ToList();
             var factory = new NodeFactory();
 
-            RunTest(new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . OPTIONAL { ?match ?p ?o } }", expected);
+            RunTest(new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema), "SELECT * WHERE { ?match pf:textMatch 'http' . OPTIONAL { ?match ?p ?o } }", expected);
         }
     }
 }

--- a/Testing/unittest/Query/FullText/IndexCreationTests.cs
+++ b/Testing/unittest/Query/FullText/IndexCreationTests.cs
@@ -44,6 +44,8 @@ namespace VDS.RDF.Query.FullText
     [Collection("FullText")]
     public class IndexCreationTests
     {
+        private LuceneTestHarness _testHarness = new LuceneTestHarness();
+
         private IGraph GetTestData()
         {
             var g = new Graph();
@@ -57,7 +59,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextIndexer indexer = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -72,7 +74,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextIndexer indexer = null;
             try
             {
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -87,7 +89,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextIndexer indexer = null;
             try
             {
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -106,7 +108,7 @@ namespace VDS.RDF.Query.FullText
                 int origCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     origCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -120,7 +122,7 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("Prior to indexing search returns " + origCount + " result(s)");
 
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 IGraph g = GetTestData();
                 indexer.Index(g);
                 indexer.Dispose();
@@ -129,7 +131,7 @@ namespace VDS.RDF.Query.FullText
                 int currCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -143,13 +145,13 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("After indexing search returns " + currCount + " result(s)");
 
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Unindex(g);
                 indexer.Dispose();
                 indexer = null;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     Console.WriteLine("After unindexing search returns " + currCount + " result(s)");
                 }
@@ -163,7 +165,7 @@ namespace VDS.RDF.Query.FullText
             finally
             {
                 if (indexer != null) indexer.Dispose();
-                LuceneTestHarness.Index.Dispose();
+                _testHarness.Index.Dispose();
             }
         }
 
@@ -177,7 +179,7 @@ namespace VDS.RDF.Query.FullText
                 int origCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     origCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -191,7 +193,7 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("Prior to indexing search returns " + origCount + " result(s)");
 
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 IGraph g = GetTestData();
                 indexer.Index(g);
                 indexer.Dispose();
@@ -200,7 +202,7 @@ namespace VDS.RDF.Query.FullText
                 int currCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -214,13 +216,13 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("After indexing search returns " + currCount + " result(s)");
 
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Unindex(g);
                 indexer.Dispose();
                 indexer = null;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     Console.WriteLine("After unindexing search returns " + currCount + " result(s)");
                 }
@@ -234,7 +236,7 @@ namespace VDS.RDF.Query.FullText
             finally
             {
                 if (indexer != null) indexer.Dispose();
-                LuceneTestHarness.Index.Dispose();
+                _testHarness.Index.Dispose();
             }
         }
 
@@ -248,7 +250,7 @@ namespace VDS.RDF.Query.FullText
                 int origCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     origCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -262,7 +264,7 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("Prior to indexing search returns " + origCount + " result(s)");
 
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 IGraph g = GetTestData();
                 indexer.Index(g);
                 indexer.Dispose();
@@ -271,7 +273,7 @@ namespace VDS.RDF.Query.FullText
                 int currCount;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     provider.Dispose();
                 }
@@ -285,13 +287,13 @@ namespace VDS.RDF.Query.FullText
                 }
                 Console.WriteLine("After indexing search returns " + currCount + " result(s)");
 
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Unindex(g);
                 indexer.Dispose();
                 indexer = null;
                 try
                 {
-                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                    provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                     currCount = provider.Match("http").Count();
                     Console.WriteLine("After unindexing search returns " + currCount + " result(s)");
                 }
@@ -305,7 +307,7 @@ namespace VDS.RDF.Query.FullText
             finally
             {
                 if (indexer != null) indexer.Dispose();
-                LuceneTestHarness.Index.Dispose();
+                _testHarness.Index.Dispose();
             }
         }
 
@@ -315,7 +317,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextIndexer indexer = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, new DefaultIndexSchema());
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, new DefaultIndexSchema());
                 
                 var g = new Graph();
                 INode example = g.CreateLiteralNode("This is an example node which we'll index multiple times");
@@ -326,7 +328,7 @@ namespace VDS.RDF.Query.FullText
                 }
                 indexer.Index(g);
 
-                var searcher = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                var searcher = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 Assert.Equal(10, searcher.Match("example").Count());
 
                 for (var i = 9; i >= 0; i--)

--- a/Testing/unittest/Query/FullText/IndexSearchTests.cs
+++ b/Testing/unittest/Query/FullText/IndexSearchTests.cs
@@ -43,6 +43,12 @@ namespace VDS.RDF.Query.FullText
     [Collection("FullText")]
     public class IndexSearchTests
     {
+        private LuceneTestHarness _testHarness;
+        public IndexSearchTests()
+        {
+            _testHarness = new LuceneTestHarness();
+        }
+
         private IGraph GetTestData()
         {
             var g = new Graph();
@@ -57,7 +63,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -67,7 +73,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http"))
@@ -89,7 +95,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -99,7 +105,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;
@@ -124,7 +130,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -134,7 +140,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http", 0.75d))
@@ -157,7 +163,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneObjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneObjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -167,7 +173,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;
@@ -193,7 +199,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -203,7 +209,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http"))
@@ -225,7 +231,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -235,7 +241,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;
@@ -260,7 +266,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -270,7 +276,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http", 0.75d))
@@ -293,7 +299,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LuceneSubjectsIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LuceneSubjectsIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -303,7 +309,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;
@@ -329,7 +335,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -339,7 +345,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http"))
@@ -361,7 +367,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -371,7 +377,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;
@@ -396,7 +402,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -406,7 +412,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 foreach (IFullTextSearchResult result in provider.Match("http", 0.75d))
@@ -429,7 +435,7 @@ namespace VDS.RDF.Query.FullText
             IFullTextSearchProvider provider = null;
             try
             {
-                indexer = new LucenePredicatesIndexer(LuceneTestHarness.Index, LuceneTestHarness.Analyzer, LuceneTestHarness.Schema);
+                indexer = new LucenePredicatesIndexer(_testHarness.Index, _testHarness.Analyzer, _testHarness.Schema);
                 indexer.Index(GetTestData());
             }
             finally
@@ -439,7 +445,7 @@ namespace VDS.RDF.Query.FullText
 
             try
             {
-                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, LuceneTestHarness.Index);
+                provider = new LuceneSearchProvider(LuceneTestHarness.LuceneVersion, _testHarness.Index);
                 var formatter = new NTriplesFormatter();
 
                 var i = 0;

--- a/Testing/unittest/Query/FullText/LuceneTestHarness.cs
+++ b/Testing/unittest/Query/FullText/LuceneTestHarness.cs
@@ -39,16 +39,16 @@ using VDS.RDF.Query.FullText.Schema;
 
 namespace VDS.RDF.Query.FullText
 {
-    public static class LuceneTestHarness
+    public class LuceneTestHarness
     {
-        private static bool _init = false;
-        private static Directory _indexDir;
-        private static IFullTextIndexSchema _schema;
-        private static Analyzer _analyzer;
+        private bool _init = false;
+        private Directory _indexDir;
+        private IFullTextIndexSchema _schema;
+        private Analyzer _analyzer;
 
-        public readonly static Lucene.Net.Util.Version LuceneVersion = Lucene.Net.Util.Version.LUCENE_30;
+        public readonly static Lucene.Net.Util.LuceneVersion LuceneVersion = Lucene.Net.Util.LuceneVersion.LUCENE_48;
 
-        private static void Init()
+        public LuceneTestHarness()
         {
             _indexDir = new RAMDirectory();
             _schema = new DefaultIndexSchema();
@@ -56,32 +56,19 @@ namespace VDS.RDF.Query.FullText
             _init = true;
         }
 
-        public static Directory Index
+        public Directory Index
         {
-            get
-            {
-                if (!_init) Init();
-                if (!_indexDir.isOpen_ForNUnit) Init();
-                return _indexDir;
-            }
+            get => _indexDir;
         }
 
-        public static IFullTextIndexSchema Schema
+        public IFullTextIndexSchema Schema
         {
-            get
-            {
-                if (!_init) Init();
-                return _schema;
-            }
+            get => _schema;
         }
 
-        public static Analyzer Analyzer
+        public Analyzer Analyzer
         {
-            get
-            {
-                if (!_init) Init();
-                return _analyzer;
-            }
+            get => _analyzer;
         }
     }
 }


### PR DESCRIPTION
* Updates the Lucene.NET library being used to the latest version (4.8.0-beta).
* Updates the Fuseki connector test suite which was failing intermittently due to a conflict between different test collections. The "fix" for now is to ensure that xUnit runs the conflicting tests in sequence.

Fixes #359