### PR TITLE
Add TriG-Star writer

### DIFF
--- a/Libraries/dotNetRdf/Core/CachingUriFactory.cs
+++ b/Libraries/dotNetRdf/Core/CachingUriFactory.cs
@@ -78,6 +78,7 @@ namespace VDS.RDF
         /// </remarks>
         public Uri Create(Uri baseUri, string relativeUri)
         {
+            if (baseUri == null) return Create(relativeUri);
             if (!InternUris)
             {
                 return new Uri(baseUri, relativeUri);

--- a/Libraries/dotNetRdf/Writing/Contexts/TriGWriterContext.cs
+++ b/Libraries/dotNetRdf/Writing/Contexts/TriGWriterContext.cs
@@ -33,9 +33,6 @@ namespace VDS.RDF.Writing.Contexts
     /// </summary>
     public class TriGWriterContext : ThreadedStoreWriterContext
     {
-        private int _compressionLevel = WriterCompressionLevel.Default;
-        private bool _n3compatability = false;
-
         /// <summary>
         /// Creates a new TriG Writer context.
         /// </summary>
@@ -48,37 +45,17 @@ namespace VDS.RDF.Writing.Contexts
         public TriGWriterContext(ITripleStore store, TextWriter output, bool prettyPrint, bool hiSpeedAllowed, int compressionLevel, bool n3compatability)
             : base(store, output, prettyPrint, hiSpeedAllowed)
         {
-            _compressionLevel = compressionLevel;
+            CompressionLevel = compressionLevel;
         }
 
         /// <summary>
         /// Gets/Sets the Compression Level.
         /// </summary>
-        public int CompressionLevel
-        {
-            get
-            {
-                return _compressionLevel;
-            }
-            set
-            {
-                _compressionLevel = value;
-            }
-        }
+        public int CompressionLevel { get; set; } = WriterCompressionLevel.Default;
 
         /// <summary>
         /// Gets/Sets N3 Compatability Mode.
         /// </summary>
-        public bool N3CompatabilityMode
-        {
-            get
-            {
-                return _n3compatability;
-            }
-            set
-            {
-                _n3compatability = value;
-            }
-        }
+        public bool N3CompatabilityMode { get; set; } = false;
     }
 }

--- a/Testing/dotNetRdf.Tests/Writing/RdfStarStoreWriterTests.cs
+++ b/Testing/dotNetRdf.Tests/Writing/RdfStarStoreWriterTests.cs
@@ -1,0 +1,190 @@
+﻿using System.Collections.Generic;
+using VDS.RDF.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace VDS.RDF.Writing
+{
+    public abstract class RdfStarStoreWriterTests
+    {
+        protected ITestOutputHelper Output { get; }
+
+        protected RdfStarStoreWriterTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        public abstract IStoreWriter GetWriter();
+        public abstract IStoreReader GetReader();
+
+        public static IEnumerable<object[]> RoundTripTestData = new[]
+        {
+            new object[]
+            {
+                "Triple Node Subject",
+                "<< <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g> ."
+            },
+            new object[]
+            {
+                "Triple Node Object",
+                "<http://example.org/s> <http://example.org/p> << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/g> ."
+            },
+            new object[]
+            {
+                "Annotated Triple",
+                @"<< <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g> .
+                  <http://example.org/s> <http://example.org/p> <http://example.org/o> <http://example.org/g> ."
+            },
+            new object[]
+            {
+                "Multiple Triple Annotations",
+                @"<< <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g> .
+                << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o2> <http://example.org/g> .
+                << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p2> <http://example.org/o> <http://example.org/g> .
+                <http://example.org/s> <http://example.org/p> <http://example.org/o> <http://example.org/g> ."
+            },
+            new object[]
+            {
+                "Multiple Graphs",
+                @"<< <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g1> .
+                  <http://example.org/s> <http://example.org/p> << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/g2> .
+                  << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g3> .
+                  <http://example.org/s> <http://example.org/p> <http://example.org/o> <http://example.org/g3> .
+                  << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o> <http://example.org/g4> .
+                  << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p> <http://example.org/o2> <http://example.org/g4> .
+                  << <http://example.org/s> <http://example.org/p> <http://example.org/o> >> <http://example.org/p2> <http://example.org/o> <http://example.org/g4> .
+                  <http://example.org/s> <http://example.org/p> <http://example.org/o> <http://example.org/g4> ."
+            }
+        };
+
+        protected void RoundTrip(string input)
+        {
+            var store = new TripleStore();
+            var stringWriter = new System.IO.StringWriter();
+            IStoreWriter writer = GetWriter();
+            IStoreReader reader = GetReader();
+
+            store.LoadFromString(input, new NQuadsParser(NQuadsSyntax.Rdf11Star));
+            writer.Save(store, stringWriter);
+
+            var loadStore = new TripleStore();
+            loadStore.LoadFromString(stringWriter.ToString(), reader);
+            TestTools.AssertEqual(store, loadStore, Output);
+        }
+    }
+
+    public class TriGMinimalCompressionWriterTests : RdfStarStoreWriterTests
+    {
+        public TriGMinimalCompressionWriterTests(ITestOutputHelper output):base(output){}
+
+        public override IStoreReader GetReader()
+        {
+            return new TriGParser(TriGSyntax.Rdf11Star);
+        }
+
+        public override IStoreWriter GetWriter()
+        {
+            return new TriGWriter()
+            {
+                CompressionLevel = WriterCompressionLevel.None, Syntax = TriGSyntax.Rdf11Star
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(RoundTripTestData))]
+        public void TestRoundTrip(string testName, string input)
+        {
+            RoundTrip(input);
+        }
+
+    }
+
+    public class TriGThreadedMinimalCompressionWriterTests : RdfStarStoreWriterTests
+    {
+        public TriGThreadedMinimalCompressionWriterTests(ITestOutputHelper output) : base(output) { }
+
+        public override IStoreReader GetReader()
+        {
+            return new TriGParser(TriGSyntax.Rdf11Star);
+        }
+
+        public override IStoreWriter GetWriter()
+        {
+            return new TriGWriter()
+            {
+                CompressionLevel = WriterCompressionLevel.None,
+                UseMultiThreadedWriting = true,
+                Syntax = TriGSyntax.Rdf11Star
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(RoundTripTestData))]
+        public void TestRoundTrip(string testName, string input)
+        {
+            RoundTrip(input);
+        }
+
+    }
+
+    public class TriGHighCompressionWriterTests : RdfStarStoreWriterTests
+    {
+        public TriGHighCompressionWriterTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public override IStoreWriter GetWriter()
+        {
+            return new TriGWriter
+            {
+                CompressionLevel = WriterCompressionLevel.High,
+                HighSpeedModePermitted = false,
+                Syntax = TriGSyntax.Rdf11Star,
+            };
+        }
+
+        public override IStoreReader GetReader()
+        {
+            return new TriGParser(TriGSyntax.Rdf11Star);
+        }
+
+        [Theory]
+        [MemberData(nameof(RoundTripTestData))]
+        public void TestRoundTrip(string testName, string input)
+        {
+            RoundTrip(input);
+        }
+
+    }
+
+    public class TriGThreadedHighCompressionWriterTests : RdfStarStoreWriterTests
+    {
+        public TriGThreadedHighCompressionWriterTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public override IStoreWriter GetWriter()
+        {
+            return new TriGWriter
+            {
+                CompressionLevel = WriterCompressionLevel.High,
+                UseMultiThreadedWriting = true,
+                HighSpeedModePermitted = false,
+                Syntax = TriGSyntax.Rdf11Star,
+            };
+        }
+
+        public override IStoreReader GetReader()
+        {
+            return new TriGParser(TriGSyntax.Rdf11Star);
+        }
+
+        [Theory]
+        [MemberData(nameof(RoundTripTestData))]
+        public void TestRoundTrip(string testName, string input)
+        {
+            RoundTrip(input);
+        }
+
+    }
+}


### PR DESCRIPTION
* Extends the TriGWriter to support TriGSyntax.Rdf11Star syntax mode.
* Changes the default syntax mode to be TriGSyntax.Rdf11Star

NOTE: Although the default output syntax is now TriG-Star, a store that contains no triple nodes will serialize as conformant TriG 1.1.