### PR TITLE
Update SPARQL JSON and XML result writers to support Triple nodes

### DIFF
--- a/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarJsonFormatterTests.cs
+++ b/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarJsonFormatterTests.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using VDS.RDF.Query;
+using VDS.RDF.Writing;
+using Xunit;
+
+namespace VDS.RDF.TestSuite.RdfStar
+{
+    public class SparqlStarJsonFormatterTests
+    {
+        [Fact]
+        public void ItHandlesFormattingATripleNode()
+        {
+            var results = new List<ISparqlResult>
+            {
+                new SparqlResult(new[]
+                {
+                    new KeyValuePair<string, INode>("x",
+                        new TripleNode(new Triple(new UriNode(new Uri("http://example.org/s")),
+                            new UriNode(new Uri("http://example.org/p")), new LiteralNode("o", (Uri)null, false))))
+                })
+            };
+            var resultSet = new SparqlResultSet(results);
+            ISparqlResultsWriter writer = new SparqlJsonWriter();
+            var output = StringWriter.Write(resultSet, writer);
+            var jsonNode = JObject.Parse(output);
+            var expectJson =
+                @"{ type: 'triple', value: { subject: { type: 'uri', value: 'http://example.org/s' }, predicate: { type: 'uri', value: 'http://example.org/p' }, object: { type: 'literal', value: 'o' } } }";
+            var expectJsonNode = JObject.Parse(expectJson);
+            JToken tripleNodeResult = jsonNode["results"]?["bindings"]?[0]?["x"];
+            Assert.NotNull(tripleNodeResult);
+            Assert.True(JToken.DeepEquals(expectJsonNode, tripleNodeResult));
+        }
+    }
+}

--- a/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarJsonWriterTests.cs
+++ b/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarJsonWriterTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace VDS.RDF.TestSuite.RdfStar
 {
-    public class SparqlStarJsonFormatterTests
+    public class SparqlStarJsonWriterTests
     {
         [Fact]
         public void ItHandlesFormattingATripleNode()

--- a/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarXmlWriterTests.cs
+++ b/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarXmlWriterTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VDS.RDF.Parsing;
+using VDS.RDF.Query;
+using VDS.RDF.Writing;
+using Xunit;
+using StringWriter = VDS.RDF.Writing.StringWriter;
+
+namespace VDS.RDF.TestSuite.RdfStar
+{
+    public class SparqlStarXmlWriterTests
+    {
+        [Fact]
+        public void ItSupportsWritingATripleNodeBinding()
+        {
+            var tn = new TripleNode(new Triple(new UriNode(new Uri("http://example.org/s")),
+                new UriNode(new Uri("http://example.org/p")), new LiteralNode("o",  false)));
+            var results = new List<ISparqlResult>
+            {
+                new SparqlResult(new[]
+                {
+                    new KeyValuePair<string, INode>("x", tn)
+                })
+            };
+            var resultSet = new SparqlResultSet(results);
+            ISparqlResultsWriter writer = new SparqlXmlWriter();
+            var output = StringWriter.Write(resultSet, writer);
+
+            var parser = new SparqlXmlParser();
+            var roundTrippedResultSet = new SparqlResultSet();
+            using (var input = new StringReader(output))
+            {
+                parser.Load(roundTrippedResultSet, input);
+            }
+
+            Assert.Single(roundTrippedResultSet);
+            Assert.Equal(tn, roundTrippedResultSet[0]["x"]);
+        }
+    }
+}


### PR DESCRIPTION
Allows these formats to serialize the results of SPARQL-Star queries against RDF-Star graphs.
Closes #420 