### PR TITLE
Feature/422 unstar operation

### DIFF
--- a/Libraries/dotNetRdf.Query.Spin/SpinWrappedGraph.cs
+++ b/Libraries/dotNetRdf.Query.Spin/SpinWrappedGraph.cs
@@ -93,6 +93,9 @@ namespace VDS.RDF.Query.Spin
         }
 
         /// <inheritdoc />
+        public IEnumerable<INode> AllQuotedNodes => throw new NotImplementedException();
+
+        /// <inheritdoc />
         public bool Assert(Triple t) {
             if (Readonly) {
                 throw new Exception("This graph is marked as read only");
@@ -182,6 +185,9 @@ namespace VDS.RDF.Query.Spin
 
         /// <inheritdoc />
         public IEnumerable<Triple> QuotedTriples => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public IEnumerable<INode> QuotedNodes => throw new NotImplementedException();
 
         /// <inheritdoc />
         public IUriFactory UriFactory { 
@@ -444,6 +450,12 @@ namespace VDS.RDF.Query.Spin
 
         /// <inheritdoc />
         public GraphDiffReport Difference(IGraph g)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Unstar()
         {
             throw new NotImplementedException();
         }

--- a/Libraries/dotNetRdf/Core/BaseGraph.cs
+++ b/Libraries/dotNetRdf/Core/BaseGraph.cs
@@ -128,6 +128,13 @@ namespace VDS.RDF
             get { return _triples.Asserted.SelectMany(t => t.Nodes).Distinct(); }
         }
 
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> QuotedNodes => _triples.QuotedSubjectNodes.Union(_triples.QuotedObjectNodes);
+
+        /// <inheritdoc />
+        public virtual IEnumerable<INode> AllQuotedNodes => _triples.QuotedSubjectNodes
+            .Union(_triples.QuotedPredicateNodes).Union(_triples.QuotedObjectNodes);
+
         /// <summary>
         /// Gets the Namespace Mapper for this Graph which contains all in use Namespace Prefixes and their URIs.
         /// </summary>
@@ -608,128 +615,14 @@ namespace VDS.RDF
             }
         }
 
-        /// <summary>
-        /// Converts an graph containing quoted triples into to a graph with no quoted triples by
-        /// applying the unstar operation described in https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html#mapping.
-        /// </summary>
-        /// <remarks>The unstar operation modifies the graph in-place by calls to <see cref="IGraph.Assert(VDS.RDF.Triple)"/> an <see cref="IGraph.Retract(VDS.RDF.Triple)"/>.</remarks>
+
+        /// <inheritdoc />
         public void Unstar()
         {
-            UpdateUnstarNodes();
-            ReplaceQuotedTriples();
+            RdfStarHelper.Unstar(this);
         }
 
-        /// <summary>
-        /// Replace any existing IRIs in the namespace `https://w3c.github.io/rdf-star/unstar#` with the IRI with an underscore appended.
-        /// </summary>
-        private void UpdateUnstarNodes()
-        {
-            foreach (Triple t in Triples.Asserted.Union(Triples.Quoted).Where(t => t.Nodes.Any(IsUnstarNode)).ToList())
-            {
-                Retract(t);
-                Assert(new Triple(UpdateUnstarNodes(t.Subject), UpdateUnstarNodes(t.Predicate), UpdateUnstarNodes(t.Object), t.Context));
-            }
-        }
-
-        /// <summary>
-        /// Determine if a node is a URI node in the `https://w3c.github.io/rdf-star/unstar#` namespace.
-        /// </summary>
-        /// <param name="n">The node to be tested.</param>
-        /// <returns></returns>
-        private static bool IsUnstarNode(INode n)
-        {
-            return n is IUriNode un && un.Uri.AbsoluteUri.StartsWith("https://w3c.github.io/rdf-star/unstar#");
-        }
-
-        private INode UpdateUnstarNodes(INode n)
-        {
-            if (IsUnstarNode(n))
-            {
-                return CreateUriNode(UriFactory.Create((n as IUriNode)?.Uri.AbsoluteUri + "_")) ?? n;
-            }
-
-            return n;
-        }
-
-        /// <summary>
-        /// Replace each triple node in the graph with a blank node with properties in the `https://w3c.github.io/rdf-star/unstar#` namespace.
-        /// </summary>
-        private void ReplaceQuotedTriples()
-        {
-            var mappings = new Dictionary<ITripleNode, IBlankNode>(new FastNodeComparer());
-            IUriNode unstarSubject = CreateUriNode("https://w3c.github.io/rdf-star/unstar#subject");
-            IUriNode unstarPredicate = CreateUriNode("https://w3c.github.io/rdf-star/unstar#predicate");
-            IUriNode unstarObject = CreateUriNode("https://w3c.github.io/rdf-star/unstar#object");
-            IUriNode unstarSubjectLexical = CreateUriNode("https://w3c.github.io/rdf-star/unstar#subjectLexical");
-            IUriNode unstarPredicateLexical = CreateUriNode("https://w3c.github.io/rdf-star/unstar#predicateLexical");
-            IUriNode unstarObjectLexical = CreateUriNode("https://w3c.github.io/rdf-star/unstar#objectLexical");
-            var lexicalFormatter = new NTriples11Formatter();
-            
-            // First assign a new blank node to each distinct triple node in the graph.
-            var tripleNodes = AllNodes.OfType<ITripleNode>().ToList();
-            foreach (ITripleNode tn in tripleNodes)
-            {
-                if (!mappings.ContainsKey(tn))
-                {
-                    IBlankNode b = CreateBlankNode();
-                    mappings[tn] = b;
-                }
-            }
-
-            // Now record the unstar triples for each triple node, taking into account that
-            // the subject or object of a triple node may itself be a triple node that is mapped to a blank node.
-            foreach (ITripleNode tn in tripleNodes)
-            {
-                IBlankNode b = mappings[tn];
-                IBlankNode mappedSubject = null, mappedObject = null;
-                if (tn.Triple.Subject is ITripleNode stn)
-                {
-                    mappings.TryGetValue(stn, out mappedSubject);
-                }
-
-                if (tn.Triple.Object is ITripleNode otn)
-                {
-                    mappings.TryGetValue(otn, out mappedObject);
-                }
-
-                Assert(new[]
-                {
-                    new Triple(b, unstarSubject, mappedSubject ?? tn.Triple.Subject),
-                    new Triple(b, unstarPredicate, tn.Triple.Predicate),
-                    new Triple(b, unstarObject, mappedObject ?? tn.Triple.Object),
-                });
-
-                if (mappedSubject == null && tn.Triple.Subject.NodeType != NodeType.Blank)
-                {
-                    Assert(new Triple(b, unstarSubjectLexical,
-                        new LiteralNode(lexicalFormatter.Format(tn.Triple.Subject), false)));
-                }
-
-                Assert(new Triple(b, unstarPredicateLexical,
-                    new LiteralNode(lexicalFormatter.Format(tn.Triple.Predicate), false)));
-
-                if (mappedObject == null && tn.Triple.Object.NodeType != NodeType.Blank)
-                {
-                    Assert(new Triple(b, unstarObjectLexical,
-                        new LiteralNode(lexicalFormatter.Format(tn.Triple.Object), false)));
-                }
-
-            }
-
-            // Now replace triple nodes with their mapped blank nodes in all asserted triples where they occur.
-            foreach (Triple t in Triples)
-            {
-                IBlankNode subjectReplacement = null, objectReplacement = null;
-                var replaceSubject = t.Subject is ITripleNode stn && mappings.TryGetValue(stn, out subjectReplacement);
-                var replaceObject = t.Object is ITripleNode otn && mappings.TryGetValue(otn, out objectReplacement);
-                if (replaceSubject || replaceObject)
-                {
-                    Retract(t);
-                    Assert(new Triple(subjectReplacement ?? t.Subject, t.Predicate, objectReplacement ?? t.Object,
-                        t.Context));
-                }
-            }
-        }
+        
 
         #endregion
 

--- a/Libraries/dotNetRdf/Core/GraphPersistenceWrapper.cs
+++ b/Libraries/dotNetRdf/Core/GraphPersistenceWrapper.cs
@@ -158,6 +158,12 @@ namespace VDS.RDF
         /// <inheritdoc/>
         public IEnumerable<INode> AllNodes => _g.AllNodes;
 
+        /// <inheritdoc />
+        public IEnumerable<INode> QuotedNodes => _g.QuotedNodes;
+
+        /// <inheritdoc />
+        public IEnumerable<INode> AllQuotedNodes => _g.AllQuotedNodes;
+
         /// <summary>
         /// Gets the Triple Collection for the Graph.
         /// </summary>
@@ -821,6 +827,12 @@ namespace VDS.RDF
         public GraphDiffReport Difference(IGraph g)
         {
             return _g.Difference(g);
+        }
+
+        /// <inheritdoc />
+        public void Unstar()
+        {
+            RdfStarHelper.Unstar(this);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Core/IGraph.cs
+++ b/Libraries/dotNetRdf/Core/IGraph.cs
@@ -258,6 +258,13 @@ namespace VDS.RDF
         /// </remarks>
         GraphDiffReport Difference(IGraph g);
 
+        /// <summary>
+        /// Converts an graph containing quoted triples into to a graph with no quoted triples by
+        /// applying the unstar operation described in https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html#mapping.
+        /// </summary>
+        /// <remarks>The unstar operation modifies the graph in-place by calls to <see cref="Assert(VDS.RDF.Triple)"/> an <see cref="Retract(VDS.RDF.Triple)"/>.</remarks>
+        void Unstar();
+
         #endregion
 
         #region Events

--- a/Libraries/dotNetRdf/Core/IGraph.cs
+++ b/Libraries/dotNetRdf/Core/IGraph.cs
@@ -74,6 +74,16 @@ namespace VDS.RDF
         /// </summary>
         IEnumerable<Triple> QuotedTriples { get; }
 
+        /// <summary>
+        /// Gets the unique subject and object nodes of the quoted triples in the graph.
+        /// </summary>
+        IEnumerable<INode> QuotedNodes { get; }
+
+        /// <summary>
+        /// Gets the unique subject, predicate and object nodes of the quoted triples in the graph.
+        /// </summary>
+        IEnumerable<INode> AllQuotedNodes { get; }
+
         #endregion
 
         #region Assertion & Retraction

--- a/Libraries/dotNetRdf/Core/RdfStarHelper.cs
+++ b/Libraries/dotNetRdf/Core/RdfStarHelper.cs
@@ -1,0 +1,166 @@
+﻿/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2021 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using VDS.RDF.Writing.Formatting;
+
+namespace VDS.RDF
+{
+    /// <summary>
+    /// Provides an implementation of the RDF-Star unstar operation that can be shared by both <see cref="BaseGraph"/> and <see cref="GraphPersistenceWrapper"/>.
+    /// </summary>
+    internal class RdfStarHelper
+    {
+        /// <summary>
+        /// Converts an graph containing quoted triples into to a graph with no quoted triples by
+        /// applying the unstar operation described in https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html#mapping.
+        /// </summary>
+        /// <remarks>The unstar operation modifies the graph in-place by calls to <see cref="IGraph.Assert(VDS.RDF.Triple)"/> an <see cref="IGraph.Retract(VDS.RDF.Triple)"/>.</remarks>
+        public static void Unstar(IGraph g)
+        {
+            UpdateUnstarNodes(g);
+            ReplaceQuotedTriples(g);
+        }
+
+        /// <summary>
+        /// Replace any existing IRIs in the namespace `https://w3c.github.io/rdf-star/unstar#` with the IRI with an underscore appended.
+        /// </summary>
+        private static void UpdateUnstarNodes(IGraph g)
+        {
+            foreach (Triple t in g.Triples.Asserted.Union(g.Triples.Quoted).Where(t => t.Nodes.Any(IsUnstarNode)).ToList())
+            {
+                g.Retract(t);
+                g.Assert(new Triple(UpdateUnstarNodes(g, t.Subject), UpdateUnstarNodes(g, t.Predicate), UpdateUnstarNodes(g, t.Object), t.Context));
+            }
+        }
+
+        /// <summary>
+        /// Determine if a node is a URI node in the `https://w3c.github.io/rdf-star/unstar#` namespace.
+        /// </summary>
+        /// <param name="n">The node to be tested.</param>
+        /// <returns></returns>
+        private static bool IsUnstarNode(INode n)
+        {
+            return n is IUriNode un && un.Uri.AbsoluteUri.StartsWith("https://w3c.github.io/rdf-star/unstar#");
+        }
+
+        private static INode UpdateUnstarNodes(INodeFactory g, INode n)
+        {
+            if (IsUnstarNode(n))
+            {
+                return g.CreateUriNode(UriFactory.Create((n as IUriNode)?.Uri.AbsoluteUri + "_")) ?? n;
+            }
+
+            return n;
+        }
+
+        /// <summary>
+        /// Replace each triple node in the graph with a blank node with properties in the `https://w3c.github.io/rdf-star/unstar#` namespace.
+        /// </summary>
+        private static void ReplaceQuotedTriples(IGraph g)
+        {
+            var mappings = new Dictionary<ITripleNode, IBlankNode>(new FastNodeComparer());
+            IUriNode unstarSubject = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#subject"));
+            IUriNode unstarPredicate = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#predicate"));
+            IUriNode unstarObject = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#object"));
+            IUriNode unstarSubjectLexical = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#subjectLexical"));
+            IUriNode unstarPredicateLexical = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#predicateLexical"));
+            IUriNode unstarObjectLexical = g.CreateUriNode(UriFactory.Create("https://w3c.github.io/rdf-star/unstar#objectLexical"));
+            var lexicalFormatter = new NTriples11Formatter();
+
+            // First assign a new blank node to each distinct triple node in the graph.
+            var tripleNodes = g.Nodes.OfType<ITripleNode>().Union(g.QuotedNodes.OfType<ITripleNode>()).ToList();
+            foreach (ITripleNode tn in tripleNodes)
+            {
+                if (!mappings.ContainsKey(tn))
+                {
+                    IBlankNode b = g.CreateBlankNode();
+                    mappings[tn] = b;
+                }
+            }
+
+            // Now record the unstar triples for each triple node, taking into account that
+            // the subject or object of a triple node may itself be a triple node that is mapped to a blank node.
+            foreach (ITripleNode tn in tripleNodes)
+            {
+                IBlankNode b = mappings[tn];
+                IBlankNode mappedSubject = null, mappedObject = null;
+                if (tn.Triple.Subject is ITripleNode stn)
+                {
+                    mappings.TryGetValue(stn, out mappedSubject);
+                }
+
+                if (tn.Triple.Object is ITripleNode otn)
+                {
+                    mappings.TryGetValue(otn, out mappedObject);
+                }
+
+                g.Assert(new[]
+                {
+                    new Triple(b, unstarSubject, mappedSubject ?? tn.Triple.Subject),
+                    new Triple(b, unstarPredicate, tn.Triple.Predicate),
+                    new Triple(b, unstarObject, mappedObject ?? tn.Triple.Object),
+                });
+
+                if (mappedSubject == null && tn.Triple.Subject.NodeType != NodeType.Blank)
+                {
+                    g.Assert(new Triple(b, unstarSubjectLexical,
+                        new LiteralNode(lexicalFormatter.Format(tn.Triple.Subject), false)));
+                }
+
+                g.Assert(new Triple(b, unstarPredicateLexical,
+                    new LiteralNode(lexicalFormatter.Format(tn.Triple.Predicate), false)));
+
+                if (mappedObject == null && tn.Triple.Object.NodeType != NodeType.Blank)
+                {
+                    g.Assert(new Triple(b, unstarObjectLexical,
+                        new LiteralNode(lexicalFormatter.Format(tn.Triple.Object), false)));
+                }
+
+            }
+
+            // Now replace triple nodes with their mapped blank nodes in all asserted triples where they occur.
+            var toReplace = g.Triples
+                .Where(t =>
+                    (t.Subject is ITripleNode stn && mappings.ContainsKey(stn)) ||
+                    (t.Object is ITripleNode otn && mappings.ContainsKey(otn)))
+                .ToList();
+            foreach (Triple t in toReplace)
+            {
+                IBlankNode subjectReplacement = null, objectReplacement = null;
+                var replaceSubject = t.Subject is ITripleNode stn && mappings.TryGetValue(stn, out subjectReplacement);
+                var replaceObject = t.Object is ITripleNode otn && mappings.TryGetValue(otn, out objectReplacement);
+                if (replaceSubject || replaceObject)
+                {
+                    g.Retract(t);
+                    g.Assert(new Triple(subjectReplacement ?? t.Subject, t.Predicate, objectReplacement ?? t.Object,
+                        t.Context));
+                }
+            }
+        }
+    }
+}

--- a/Libraries/dotNetRdf/Core/WrapperGraph.cs
+++ b/Libraries/dotNetRdf/Core/WrapperGraph.cs
@@ -128,6 +128,12 @@ namespace VDS.RDF
         /// <inheritdoc />
         public virtual IEnumerable<Triple> QuotedTriples => _g.QuotedTriples;
 
+        /// <inheritdoc />
+        public IEnumerable<INode> QuotedNodes => _g.QuotedNodes;
+
+        /// <inheritdoc />
+        public IEnumerable<INode> AllQuotedNodes => _g.AllQuotedNodes;
+
         /// <summary>
         /// Asserts a Triple in the Graph.
         /// </summary>
@@ -731,6 +737,12 @@ namespace VDS.RDF
             return _g.Difference(g);
         }
 
+        /// <inheritdoc />
+        public void Unstar()
+        {
+            _g.Unstar();
+        }
+
         /// <summary>
         /// Helper function for Resolving QNames to URIs.
         /// </summary>
@@ -740,6 +752,7 @@ namespace VDS.RDF
         {
             return _g.ResolveQName(qname);
         }
+
 
         #endregion
 

--- a/Libraries/dotNetRdf/Writing/Formatting/NTriplesFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/NTriplesFormatter.cs
@@ -43,7 +43,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Set of characters which must be escaped in Literals.
         /// </summary>
-        private readonly List<string[]> _litEscapes = new List<string[]>
+        protected readonly List<string[]> _litEscapes = new List<string[]>
         {
             new [] { @"\", @"\\" },
             new [] { "\"", "\\\"" },
@@ -148,12 +148,20 @@ namespace VDS.RDF.Writing.Formatting
             }
             else if (l.DataType != null)
             {
-                output.Append("^^<");
-                output.Append(FormatUri(l.DataType));
-                output.Append('>');
+                output.Append(FormatDatatype(l.DataType));
             }
 
             return output.ToString();
+        }
+
+        /// <summary>
+        /// Format the datatype specification for a literal value.
+        /// </summary>
+        /// <param name="datatypeUri">The datatype URI.</param>
+        /// <returns></returns>
+        protected virtual string FormatDatatype(Uri datatypeUri)
+        {
+            return $"^^<{FormatUri(datatypeUri)}>";
         }
 
         /// <summary>
@@ -270,13 +278,25 @@ namespace VDS.RDF.Writing.Formatting
     /// <summary>
     /// Formatter for formatting as NTriples according to the RDF 1.1 specification.
     /// </summary>
+    /// <remarks>The primary difference between this formatter and <see cref="NTriplesFormatter"/> is that this formatter will drop the xsd:string datatype IRI from literals as this is
+    /// the default datatype assigned to string literals by the RDF 1.1 specification.</remarks>
     public class NTriples11Formatter
         : NTriplesFormatter
     {
         /// <summary>
-        /// Creaates a new formatter.
+        /// Creates a new formatter.
         /// </summary>
         public NTriples11Formatter()
             : base(NTriplesSyntax.Rdf11) { }
+
+        /// <summary>
+        /// Return the datatype specification for a literal value.
+        /// </summary>
+        /// <param name="datatypeUri">The datatype URI</param>
+        /// <returns>The formatted datatype specification unless <paramref name="datatypeUri"/> matches the XML Schema String datatype URI, in which case an empty string is returned.</returns>
+        protected override string FormatDatatype(Uri datatypeUri)
+        {
+            return datatypeUri.AbsoluteUri.Equals(XmlSpecsHelper.XmlSchemaDataTypeString) ? string.Empty : base.FormatDatatype(datatypeUri);
+        }
     }
 }

--- a/Testing/dotNetRdf.Tests/Core/RdfStarHelperTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/RdfStarHelperTests.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using VDS.RDF.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace VDS.RDF
+{
+    public class RdfStarHelperTests
+    {
+        private readonly ITestOutputHelper _output;
+        public RdfStarHelperTests(ITestOutputHelper output) {
+            _output = output;
+        }
+
+        [Theory]
+        [InlineData("test1.ttl", "test1.unstar.ttl")]
+        [InlineData("test2.ttl", "test2.unstar.ttl")]
+        [InlineData("test3.ttl", "test3.unstar.ttl")]
+        [InlineData("string-literal-in-tn.ttl", "string-literal-in-tn.unstar.ttl")]
+        [InlineData("no-lexical-for-bnodes.ttl", "no-lexical-for-bnodes.unstar.ttl")]
+        [InlineData("nested-triple-nodes.ttl", "nested-triple-nodes.unstar.ttl")]
+        [InlineData("no-triple-nodes.ttl", "no-triple-nodes.ttl")]
+        [InlineData("test1.unstar.ttl", "test1.unstar.unstar.ttl")]
+        public void TestUnstarOperation(string inputPath, string outputPath)
+        {
+            IGraph inputGraph = new Graph();
+            inputGraph.LoadFromFile(Path.Combine("resources", "rdfstar", inputPath), new TurtleParser(TurtleSyntax.Rdf11Star, true));
+            IGraph expectGraph = new Graph();
+            expectGraph.LoadFromFile(Path.Combine("resources", "rdfstar", outputPath), new TurtleParser(TurtleSyntax.W3C, true));
+            inputGraph.Unstar();
+            var graphDiff = new GraphDiff();
+            GraphDiffReport diffReport = graphDiff.Difference(expectGraph, inputGraph);
+            TestTools.ShowDifferences(diffReport, outputPath, $"unstar('{inputPath}')", _output);
+            Assert.True(diffReport.AreEqual, $"Expected unstar('{inputPath}') to be the same as '{outputPath}', but differences where found.");
+        }
+    }
+}

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/nested-triple-nodes.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/nested-triple-nodes.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+<< << :s :p :o >> :p :o >> :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/nested-triple-nodes.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/nested-triple-nodes.unstar.ttl
@@ -1,0 +1,17 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:z u:subject :s;
+    u:predicate :p;
+    u:object :o;
+    u:subjectLexical "<http://example.org/s>";
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "<http://example.org/o>" .
+
+_:x u:subject _:z;
+    u:predicate :p;
+    u:object :o;
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "<http://example.org/o>" .
+
+_:x :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/no-lexical-for-bnodes.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/no-lexical-for-bnodes.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+<< _:s :p :o >> :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/no-lexical-for-bnodes.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/no-lexical-for-bnodes.unstar.ttl
@@ -1,0 +1,10 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject _:s;
+    u:predicate :p;
+    u:object :o;
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "<http://example.org/o>" .
+
+_:x :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/no-triple-nodes.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/no-triple-nodes.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+:s :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/string-literal-in-tn.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/string-literal-in-tn.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+<< :s :p "o" >> :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/string-literal-in-tn.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/string-literal-in-tn.unstar.ttl
@@ -1,0 +1,11 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject :s;
+    u:predicate :p;
+    u:object "o";
+    u:subjectLexical "<http://example.org/s>";
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "\"o\"" .
+
+_:x :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test1.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test1.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+<< :s :p :o >> :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test1.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test1.unstar.ttl
@@ -1,0 +1,11 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject :s;
+    u:predicate :p;
+    u:object :o;
+    u:subjectLexical "<http://example.org/s>";
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "<http://example.org/o>" .
+
+_:x :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test1.unstar.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test1.unstar.unstar.ttl
@@ -1,0 +1,11 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject_ :s;
+    u:predicate_ :p;
+    u:object_ :o;
+    u:subjectLexical_ "<http://example.org/s>";
+    u:predicateLexical_ "<http://example.org/p>";
+    u:objectLexical_ "<http://example.org/o>" .
+
+_:x :p :o .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test2.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test2.ttl
@@ -1,0 +1,3 @@
+﻿@prefix : <http://example.org> .
+
+:s :p << :s :p :o >> .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test2.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test2.unstar.ttl
@@ -1,0 +1,11 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject :s;
+    u:predicate :p;
+    u:object :o;
+    u:subjectLexical "<http://example.org/s>";
+    u:predicateLexical "<http://example.org/p>";
+    u:objectLexical "<http://example.org/o>" .
+
+:s :p _:x .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test3.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test3.ttl
@@ -1,0 +1,4 @@
+﻿@prefix : <http://example.org> .
+
+<< :a :b :c >> :p :o .
+<< :a :b :c >> :p :o2 .

--- a/Testing/dotNetRdf.Tests/resources/rdfstar/test3.unstar.ttl
+++ b/Testing/dotNetRdf.Tests/resources/rdfstar/test3.unstar.ttl
@@ -1,0 +1,12 @@
+﻿@prefix : <http://example.org/> .
+@prefix u: <https://w3c.github.io/rdf-star/unstar#> .
+
+_:x u:subject :a;
+    u:predicate :b;
+    u:object :c;
+    u:subjectLexical "<http://example.org/a>";
+    u:predicateLexical "<http://example.org/b>";
+    u:objectLexical "<http://example.org/c>" .
+
+_:x :p :o .
+_:x :p :o2 .


### PR DESCRIPTION
* Add support for the RDF-Star unstar operation which converts quoted triples into a sequence of asserted triples.
* Extend the IGraph interface to provide access to the nodes of quoted triples
* Change the NTriples11Formatter to suppress writing an explicit datatype for literals typed as xsd:string.