### PR TITLE
Replace Equals(object) overload with IEquatable<IGraph>

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+*.cs text
 Testing/dotNetRdf.Tests/resources/turtle/*   -text
 Testing/dotNetRdf.Tests/resources/turtle11/*   -text
 Testing/dotNetRdf.Tests/resources/turtle11-unofficial/*   -text

--- a/Libraries/dotNetRdf/Core/BaseGraph.cs
+++ b/Libraries/dotNetRdf/Core/BaseGraph.cs
@@ -27,7 +27,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using VDS.RDF.Writing.Formatting;
 
 namespace VDS.RDF
 {
@@ -631,28 +630,16 @@ namespace VDS.RDF
         /// <summary>
         /// Determines whether a Graph is equal to another Object.
         /// </summary>
-        /// <param name="obj">Object to test.</param>
+        /// <param name="other">Other graph to compare to.</param>
         /// <returns></returns>
         /// <remarks>
-        /// <para>
-        /// A Graph can only be equal to another Object which is an <see cref="IGraph">IGraph</see>.
-        /// </para>
         /// <para>
         /// Graph Equality is determined by a somewhat complex algorithm which is explained in the remarks of the other overload for Equals.
         /// </para>
         /// </remarks>
-        [Obsolete("This override is potentially misleading as BaseGraph objects are mutable. Callers should instead use the GraphMatcher class to check for graph isomorphism. This override will be removed in a future release.")]
-        public override bool Equals(object obj)
+        public bool Equals(IGraph other)
         {
-            return obj switch
-            {
-                // Graphs can't be equal to null
-                null => false,
-                IGraph g => Equals(g, out _),
-                _ => false
-            };
-
-            // Graphs can only be equal to other Graphs
+            return Equals(other, out _);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Core/Graph.cs
+++ b/Libraries/dotNetRdf/Core/Graph.cs
@@ -35,7 +35,7 @@ namespace VDS.RDF
     /// </summary>
     /// <threadsafety instance="false">Safe for multi-threaded read-only access but unsafe if one/more threads may modify the Graph by using the <see cref="Graph.Assert(Triple)">Assert</see>, <see cref="Graph.Retract(Triple)">Retract</see> or <see cref="BaseGraph.Merge(IGraph)">Merge</see> methods.</threadsafety>
     public class Graph
-        : BaseGraph
+        : BaseGraph, IEquatable<Graph>
     {
         #region Constructor
 
@@ -164,6 +164,16 @@ namespace VDS.RDF
         }
 
         #endregion
+
+        /// <summary>
+        /// Implements equality testing between <see cref="Graph"/> instances.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(Graph other)
+        {
+            return Equals((IGraph)other);
+        }
 
         #region Triple Assertion & Retraction
 

--- a/Libraries/dotNetRdf/Core/GraphPersistenceWrapper.cs
+++ b/Libraries/dotNetRdf/Core/GraphPersistenceWrapper.cs
@@ -701,24 +701,14 @@ namespace VDS.RDF
             return tmp;
         }
 
-
-
         /// <summary>
-        /// Determines whether a Graph is equal to another Object.
+        /// Determines whether this graph is equal to another graph.
         /// </summary>
-        /// <param name="obj">Object to test.</param>
+        /// <param name="other">Object to test.</param>
         /// <returns></returns>
-        /// <remarks>
-        /// This override is deprecated as this class is not an immutable class. To compare two graphs for isomorphism (also known as graph equality) please use the <see cref="GraphMatcher"/> utility class instead.
-        /// </remarks>
-        [Obsolete("The use of the Equals method for determining graph equality is deprecated and this override will be removed in a future release. To compare two graphs, please use the GraphMatcher class instead.")]
-        public override bool Equals(object obj)
+        public bool Equals(IGraph other)
         {
-            if (obj is IGraph graph)
-            {
-                return Equals(graph, out _);
-            }
-            return false;
+            return Equals(other, out _);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Core/IGraph.cs
+++ b/Libraries/dotNetRdf/Core/IGraph.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF
     /// Most implementations will probably want to inherit from the abstract class <see cref="BaseGraph">BaseGraph</see> since it contains reference implementations of various algorithms (Graph Equality/Graph Difference/Sub-Graph testing etc) which will save considerable work in implementation and ensure consistent behaviour of some methods across implementations.
     /// </para>
     /// </remarks>
-    public interface IGraph : INodeFactory, IDisposable, ITripleIndex
+    public interface IGraph : INodeFactory, IDisposable, ITripleIndex, IEquatable<IGraph>
     {
         #region Properties
 

--- a/Libraries/dotNetRdf/Core/NonIndexedThreadSafeGraph.cs
+++ b/Libraries/dotNetRdf/Core/NonIndexedThreadSafeGraph.cs
@@ -25,26 +25,30 @@
 */
 using System.Threading;
 
-namespace VDS.RDF;
-
-/// <summary>
-/// A Thread Safe version of the <see cref="Graph">Graph</see> class.
-/// </summary>
-/// <threadsafety instance="true">Should be safe for almost any concurrent read and write access scenario, internally managed using a <see cref="ReaderWriterLockSlim">ReaderWriterLockSlim</see>.  If you encounter any sort of Threading/Concurrency issue please report to the. <a href="mailto:dotnetrdf-bugs@lists.sourceforge.net">dotNetRDF Bugs Mailing List</a></threadsafety>
-/// <remarks>
-/// <para>
-/// Performance will be marginally worse than a normal <see cref="Graph">Graph</see> but in multi-threaded scenarios this will likely be offset by the benefits of multi-threading.
-/// </para>
-/// <para>
-/// Since this is a non-indexed version load performance will be better but query performance better.
-/// </para>
-/// </remarks>
-public class NonIndexedThreadSafeGraph
-    : ThreadSafeGraph
+namespace VDS.RDF
 {
+
     /// <summary>
-    /// Creates a new non-indexed Thread Safe Graph.
+    /// A Thread Safe version of the <see cref="Graph">Graph</see> class.
     /// </summary>
-    public NonIndexedThreadSafeGraph()
-        : base(new ThreadSafeTripleCollection()) { }
+    /// <threadsafety instance="true">Should be safe for almost any concurrent read and write access scenario, internally managed using a <see cref="ReaderWriterLockSlim">ReaderWriterLockSlim</see>.  If you encounter any sort of Threading/Concurrency issue please report to the. <a href="mailto:dotnetrdf-bugs@lists.sourceforge.net">dotNetRDF Bugs Mailing List</a></threadsafety>
+    /// <remarks>
+    /// <para>
+    /// Performance will be marginally worse than a normal <see cref="Graph">Graph</see> but in multi-threaded scenarios this will likely be offset by the benefits of multi-threading.
+    /// </para>
+    /// <para>
+    /// Since this is a non-indexed version load performance will be better but query performance better.
+    /// </para>
+    /// </remarks>
+    public class NonIndexedThreadSafeGraph
+        : ThreadSafeGraph
+    {
+        /// <summary>
+        /// Creates a new non-indexed Thread Safe Graph.
+        /// </summary>
+        public NonIndexedThreadSafeGraph()
+            : base(new ThreadSafeTripleCollection())
+        {
+        }
+    }
 }

--- a/Libraries/dotNetRdf/Core/NonIndexedThreadSafeGraph.cs
+++ b/Libraries/dotNetRdf/Core/NonIndexedThreadSafeGraph.cs
@@ -1,0 +1,50 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2021 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+using System.Threading;
+
+namespace VDS.RDF;
+
+/// <summary>
+/// A Thread Safe version of the <see cref="Graph">Graph</see> class.
+/// </summary>
+/// <threadsafety instance="true">Should be safe for almost any concurrent read and write access scenario, internally managed using a <see cref="ReaderWriterLockSlim">ReaderWriterLockSlim</see>.  If you encounter any sort of Threading/Concurrency issue please report to the. <a href="mailto:dotnetrdf-bugs@lists.sourceforge.net">dotNetRDF Bugs Mailing List</a></threadsafety>
+/// <remarks>
+/// <para>
+/// Performance will be marginally worse than a normal <see cref="Graph">Graph</see> but in multi-threaded scenarios this will likely be offset by the benefits of multi-threading.
+/// </para>
+/// <para>
+/// Since this is a non-indexed version load performance will be better but query performance better.
+/// </para>
+/// </remarks>
+public class NonIndexedThreadSafeGraph
+    : ThreadSafeGraph
+{
+    /// <summary>
+    /// Creates a new non-indexed Thread Safe Graph.
+    /// </summary>
+    public NonIndexedThreadSafeGraph()
+        : base(new ThreadSafeTripleCollection()) { }
+}

--- a/Libraries/dotNetRdf/Core/ThreadSafeGraph.cs
+++ b/Libraries/dotNetRdf/Core/ThreadSafeGraph.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF
     /// <threadsafety instance="true">Should be safe for almost any concurrent read and write access scenario, internally managed using a <see cref="ReaderWriterLockSlim">ReaderWriterLockSlim</see>.  If you encounter any sort of Threading/Concurrency issue please report to the. <a href="mailto:dotnetrdf-bugs@lists.sourceforge.net">dotNetRDF Bugs Mailing List</a></threadsafety>
     /// <remarks>Performance will be marginally worse than a normal <see cref="Graph">Graph</see> but in multi-threaded scenarios this will likely be offset by the benefits of multi-threading.</remarks>
     public class ThreadSafeGraph
-        : Graph
+        : Graph, IEquatable<ThreadSafeGraph>
     {
         /// <summary>
         /// Locking Manager for the Graph.
@@ -69,7 +69,7 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="name">The graph name.</param>
         public ThreadSafeGraph(IRefNode name):
-            this(new ThreadSafeTripleCollection(new TreeIndexedTripleCollection(true))) { }
+            this(name, new ThreadSafeTripleCollection(new TreeIndexedTripleCollection(true))) { }
 
         /// <summary>
         /// Creates a new named thread-safe graph using the given triple collection.
@@ -88,6 +88,15 @@ namespace VDS.RDF
         public ThreadSafeGraph(IRefNode name, ThreadSafeTripleCollection tripleCollection)
             :base(name, tripleCollection){ }
 
+        /// <summary>
+        /// Implements equality testing between <see cref="ThreadSafeGraph"/> instances.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ThreadSafeGraph other)
+        {
+            return Equals((IGraph)other);
+        }
 
         #region Triple Assertion and Retraction
 
@@ -203,7 +212,7 @@ namespace VDS.RDF
         /// <returns>Either the Blank Node or null if no Node with the given Identifier exists.</returns>
         public override IBlankNode GetBlankNode(string nodeId)
         {
-            IBlankNode b = null;
+            IBlankNode b;
             try
             {
                 _lockManager.EnterReadLock();
@@ -224,7 +233,7 @@ namespace VDS.RDF
         /// <remarks>The LiteralNode in the Graph must have no Language or DataType set.</remarks>
         public override ILiteralNode GetLiteralNode(string literal)
         {
-            ILiteralNode l = null;
+            ILiteralNode l;
             try
             {
                 _lockManager.EnterReadLock();
@@ -245,7 +254,7 @@ namespace VDS.RDF
         /// <returns>Either the LiteralNode Or null if no Node with the given Value and Language Specifier exists.</returns>
         public override ILiteralNode GetLiteralNode(string literal, string langspec)
         {
-            ILiteralNode l = null;
+            ILiteralNode l;
             try
             {
                 _lockManager.EnterReadLock();
@@ -266,7 +275,7 @@ namespace VDS.RDF
         /// <returns>Either the LiteralNode Or null if no Node with the given Value and Data Type exists.</returns>
         public override ILiteralNode GetLiteralNode(string literal, Uri datatype)
         {
-            ILiteralNode l = null;
+            ILiteralNode l;
             try
             {
                 _lockManager.EnterReadLock();
@@ -286,7 +295,7 @@ namespace VDS.RDF
         /// <returns></returns>
         public override IUriNode GetUriNode(string qname)
         {
-            IUriNode u = null;
+            IUriNode u;
             try
             {
                 _lockManager.EnterReadLock();
@@ -306,7 +315,7 @@ namespace VDS.RDF
         /// <returns>Either the UriNode Or null if no Node with the given Uri exists.</returns>
         public override IUriNode GetUriNode(Uri uri)
         {
-            IUriNode u = null;
+            IUriNode u;
             try
             {
                 _lockManager.EnterReadLock();
@@ -330,7 +339,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriples(INode n)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -350,7 +359,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriples(Uri uri)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -370,7 +379,7 @@ namespace VDS.RDF
         /// <returns></returns>
         public override IEnumerable<Triple> GetTriplesWithObject(INode n)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -390,7 +399,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriplesWithObject(Uri u)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -410,7 +419,7 @@ namespace VDS.RDF
         /// <returns></returns>
         public override IEnumerable<Triple> GetTriplesWithPredicate(INode n)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -430,7 +439,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriplesWithPredicate(Uri u)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -450,7 +459,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriplesWithSubject(INode n)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -470,7 +479,7 @@ namespace VDS.RDF
         /// <returns>Zero/More Triples.</returns>
         public override IEnumerable<Triple> GetTriplesWithSubject(Uri u)
         {
-            var triples = new List<Triple>();
+            List<Triple> triples;
             try
             {
                 _lockManager.EnterReadLock();
@@ -484,27 +493,5 @@ namespace VDS.RDF
         }
 
         #endregion
-    }
-
-    /// <summary>
-    /// A Thread Safe version of the <see cref="Graph">Graph</see> class.
-    /// </summary>
-    /// <threadsafety instance="true">Should be safe for almost any concurrent read and write access scenario, internally managed using a <see cref="ReaderWriterLockSlim">ReaderWriterLockSlim</see>.  If you encounter any sort of Threading/Concurrency issue please report to the. <a href="mailto:dotnetrdf-bugs@lists.sourceforge.net">dotNetRDF Bugs Mailing List</a></threadsafety>
-    /// <remarks>
-    /// <para>
-    /// Performance will be marginally worse than a normal <see cref="Graph">Graph</see> but in multi-threaded scenarios this will likely be offset by the benefits of multi-threading.
-    /// </para>
-    /// <para>
-    /// Since this is a non-indexed version load performance will be better but query performance better.
-    /// </para>
-    /// </remarks>
-    public class NonIndexedThreadSafeGraph
-        : ThreadSafeGraph
-    {
-        /// <summary>
-        /// Creates a new non-indexed Thread Safe Graph.
-        /// </summary>
-        public NonIndexedThreadSafeGraph()
-            : base(new ThreadSafeTripleCollection()) { }
     }
 }

--- a/Libraries/dotNetRdf/Core/WrapperGraph.cs
+++ b/Libraries/dotNetRdf/Core/WrapperGraph.cs
@@ -611,22 +611,13 @@ namespace VDS.RDF
         }
 
         /// <summary>
-        /// Determines whether a Graph is equal to another Object.
+        /// Determines whether this graph is equal to another graph.
         /// </summary>
-        /// <param name="obj">Object to test.</param>
+        /// <param name="other">Graph to test.</param>
         /// <returns></returns>
-        /// <remarks>
-        /// This override is deprecated as this class is not an immutable class. To compare two graphs for isomorphism (also known as graph equality) please use the <see cref="GraphMatcher"/> utility class instead.
-        /// </remarks>
-        [Obsolete("The use of the Equals method for determining graph equality is deprecated and this override will be removed in a future release. To compare two graphs, please use the GraphMatcher class instead.")]
-        public override bool Equals(object obj)
+        public bool Equals(IGraph other)
         {
-            if (obj is IGraph graph)
-            {
-                return Equals(graph, out Dictionary<INode, INode> _);
-            }
-
-            return false;
+            return Equals(other, out _);
         }
 
         /// <summary>

--- a/Testing/dotNetRdf.Tests/Core/HardGraphMatching.cs
+++ b/Testing/dotNetRdf.Tests/Core/HardGraphMatching.cs
@@ -243,7 +243,7 @@ namespace VDS.RDF
             var h = new Graph();
             h.LoadFromFile("resources/turtle11/first.ttl");
 
-            Assert.Equal(g, h);
+            Assert.Equal<IGraph>(g, h);
         }
 
         [Fact]
@@ -519,7 +519,7 @@ namespace VDS.RDF
 ].
 ");
 
-            Assert.Equal(g1, g2);
+            Assert.Equal<IGraph>(g1, g2);
         }
     }
 }

--- a/Testing/dotNetRdf.Tests/Parsing/Handlers/ChainedHandlerTests.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/Handlers/ChainedHandlerTests.cs
@@ -83,7 +83,7 @@ namespace VDS.RDF.Parsing.Handlers
             parser.Load(handler, "chained_handler_tests_temp.ttl");
 
             Assert.Equal(g.Triples.Count, h.Triples.Count);
-            Assert.Equal(g, h);
+            Assert.Equal<IGraph>(g, h);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace VDS.RDF.Parsing.Handlers
             Assert.Equal(100, g.Triples.Count);
             Assert.Equal(100, h.Triples.Count);
             Assert.Equal(g.Triples.Count, h.Triples.Count);
-            Assert.Equal(g, h);
+            Assert.Equal<IGraph>(g, h);
         }
         
         [Fact]


### PR DESCRIPTION
Addresses issue #457

- IGraph interface now extends IEquatable<IGraph>
- Graph and ThreadSafeGraph also implement their own class-specific IEquatable interfaces (this makes equality testing more convenient when comparing two Graph instances)
- Fixed a few compiler warnings in ThreadSafeGraph
- Split out NonIndexedThreadSafeGraph into its own source file.