### PR TITLE
Ensure NOT EXISTS returns true if the pattern contains unbound varaibles

### DIFF
--- a/Libraries/dotNetRdf/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRdf/JsonLd/DefaultDocumentLoader.cs
@@ -126,6 +126,7 @@ namespace VDS.RDF.JsonLd
 
         private static IEnumerable<WebLink> ParseLinkHeaders(IEnumerable<string> linkHeaderValues)
         {
+            if (linkHeaderValues == null) yield break;
             foreach (var linkHeaderValue in linkHeaderValues)
             {
                 if (WebLink.TryParse(linkHeaderValue, out WebLink link)) yield return link;

--- a/Libraries/dotNetRdf/Query/LeviathanQueryProcessor.cs
+++ b/Libraries/dotNetRdf/Query/LeviathanQueryProcessor.cs
@@ -781,28 +781,21 @@ namespace VDS.RDF.Query
             }
             else if (context.InputMultiset is IdentityMultiset)
             {
-                if (filter.SparqlFilter.Variables.Any())
+
+                try
                 {
-                    // If we get an IdentityMultiset then the FILTER only has an effect if there are no
-                    // variables - otherwise it is not in scope and causes the Output to become Null
-                    context.InputMultiset = new NullMultiset();
-                }
-                else
-                {
-                    try
-                    {
-                        if (!filter.SparqlFilter.Expression.Accept(_expressionProcessor, context, 0).AsSafeBoolean())
-                        {
-                            context.OutputMultiset = new NullMultiset();
-                            return context.OutputMultiset;
-                        }
-                    }
-                    catch
+                    if (!filter.SparqlFilter.Expression.Accept(_expressionProcessor, context, 0).AsSafeBoolean())
                     {
                         context.OutputMultiset = new NullMultiset();
                         return context.OutputMultiset;
                     }
                 }
+                catch
+                {
+                    context.OutputMultiset = new NullMultiset();
+                    return context.OutputMultiset;
+                }
+
             }
             else
             {


### PR DESCRIPTION
* Remove optimisation from the implementation of Filter to ensure that filter evaluation is not skipped when there are unbound variables in the pattern as this can result in NOT EXISTS filters incorrectly returning false.
* Update a failing test that was using an external service to provide a JSON-LD context to use a mock server instead.
Fixes #456 