### PR TITLE
Enable injection of UriFactory on QNameOutputMapper

### DIFF
--- a/Libraries/dotNetRdf/Parsing/Handlers/WriteThroughHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/WriteThroughHandler.cs
@@ -124,11 +124,11 @@ namespace VDS.RDF.Parsing.Handlers
                     {
                         if (ps.Length == 1)
                         {
-                            if (ps[0].ParameterType.Equals(qnameMapperType))
+                            if (ps[0].ParameterType == qnameMapperType)
                             {
                                 _formatter = Activator.CreateInstance(_formatterType, new object[] { _formattingMapper }) as ITripleFormatter;
                             }
-                            else if (ps[0].ParameterType.Equals(nsMapperType))
+                            else if (ps[0].ParameterType == nsMapperType)
                             {
                                 _formatter = Activator.CreateInstance(_formatterType, new object[] { _formattingMapper }) as ITripleFormatter;
                             }

--- a/Libraries/dotNetRdf/Writing/Contexts/BaseWriterContext.cs
+++ b/Libraries/dotNetRdf/Writing/Contexts/BaseWriterContext.cs
@@ -58,7 +58,7 @@ namespace VDS.RDF.Writing.Contexts
         {
             Graph = g;
             Output = output;
-            QNameMapper = new QNameOutputMapper(Graph.NamespaceMap);
+            QNameMapper = new QNameOutputMapper(Graph.NamespaceMap, Graph.UriFactory);
             UriFactory = g.UriFactory;
         }
 

--- a/Libraries/dotNetRdf/Writing/Formatting/IGraphFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/IGraphFormatter.cs
@@ -44,8 +44,9 @@ namespace VDS.RDF.Writing.Formatting
         /// Generates the header section for the Graph.
         /// </summary>
         /// <param name="namespaces">Namespaces.</param>
+        /// <param name="uriFactory">UriFactory to use when creating new Uri instances.</param>
         /// <returns></returns>
-        string FormatGraphHeader(INamespaceMapper namespaces);
+        string FormatGraphHeader(INamespaceMapper namespaces, IUriFactory uriFactory=null);
 
         /// <summary>
         /// Generates a generic header section.

--- a/Libraries/dotNetRdf/Writing/Formatting/Notation3Formatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/Notation3Formatter.cs
@@ -81,8 +81,13 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new Notation 3 Formatter.
         /// </summary>
+        public Notation3Formatter():this(UriFactory.Root){}
+
+        /// <summary>
+        /// Creates a new Notation 3 Formatter.
+        /// </summary>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        public Notation3Formatter(IUriFactory uriFactory = null)
+        public Notation3Formatter(IUriFactory uriFactory)
             : base("Notation 3", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
@@ -91,6 +96,13 @@ namespace VDS.RDF.Writing.Formatting
         /// <param name="g">Graph.</param>
         public Notation3Formatter(IGraph g)
             : base("Notation 3", new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
+
+        /// <summary>
+        /// Creates a new Notation 3 Formatter using the given Namespace Map.
+        /// </summary>
+        /// <param name="nsmap">Namespace Map.</param>
+        public Notation3Formatter(INamespaceMapper nsmap)
+            : base("Notation 3", new QNameOutputMapper(nsmap, UriFactory.Root)) { }
 
         /// <summary>
         /// Creates a new Notation 3 Formatter using the given Namespace Map.

--- a/Libraries/dotNetRdf/Writing/Formatting/Notation3Formatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/Notation3Formatter.cs
@@ -81,22 +81,24 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new Notation 3 Formatter.
         /// </summary>
-        public Notation3Formatter()
-            : base("Notation 3", new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public Notation3Formatter(IUriFactory uriFactory = null)
+            : base("Notation 3", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new Notation 3 Formatter using the given Graph.
         /// </summary>
         /// <param name="g">Graph.</param>
         public Notation3Formatter(IGraph g)
-            : base("Notation 3", new QNameOutputMapper(g.NamespaceMap)) { }
+            : base("Notation 3", new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new Notation 3 Formatter using the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
-        public Notation3Formatter(INamespaceMapper nsmap)
-            : base("Notation 3", new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public Notation3Formatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base("Notation 3", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Formats a Variable Node for Notation 3.

--- a/Libraries/dotNetRdf/Writing/Formatting/RdfXmlFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/RdfXmlFormatter.cs
@@ -52,7 +52,7 @@ namespace VDS.RDF.Writing.Formatting
         /// <returns></returns>
         public string FormatGraphHeader(IGraph g)
         {
-            _mapper = new QNameOutputMapper(g.NamespaceMap);
+            _mapper = new QNameOutputMapper(g.NamespaceMap, g.UriFactory);
             var output = new StringBuilder();
             output.Append(GetGraphHeaderBase());
             foreach (var prefix in g.NamespaceMap.Prefixes)
@@ -81,10 +81,11 @@ namespace VDS.RDF.Writing.Formatting
         /// Formats a Graph Header by creating an <strong>&lt;rdf:RDF&gt;</strong> element and adding namespace definitions.
         /// </summary>
         /// <param name="namespaces">Namespaces.</param>
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
         /// <returns></returns>
-        public string FormatGraphHeader(INamespaceMapper namespaces)
+        public string FormatGraphHeader(INamespaceMapper namespaces, IUriFactory uriFactory = null)
         {
-            _mapper = new QNameOutputMapper(namespaces);
+            _mapper = new QNameOutputMapper(namespaces, uriFactory);
             var output = new StringBuilder();
             output.Append(GetGraphHeaderBase());
             foreach (var prefix in namespaces.Prefixes)

--- a/Libraries/dotNetRdf/Writing/Formatting/SparqlFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/SparqlFormatter.cs
@@ -53,22 +53,24 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new SPARQL Formatter.
         /// </summary>
-        public SparqlFormatter()
-            : base("SPARQL", new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public SparqlFormatter(IUriFactory uriFactory = null)
+            : base("SPARQL", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new SPARQL Formatter using the given Graph.
         /// </summary>
         /// <param name="g">Graph.</param>
         public SparqlFormatter(IGraph g)
-            : base("SPARQL", new QNameOutputMapper(g.NamespaceMap)) { }
+            : base("SPARQL", new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new SPARQL Formatter using the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
-        public SparqlFormatter(INamespaceMapper nsmap)
-            : base("SPARQL", new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public SparqlFormatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base("SPARQL", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Determines whether a QName is valid.

--- a/Libraries/dotNetRdf/Writing/Formatting/SparqlFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/SparqlFormatter.cs
@@ -53,8 +53,15 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new SPARQL Formatter.
         /// </summary>
+        public SparqlFormatter()
+            : base("SPARQL", new QNameOutputMapper()) { }
+
+
+        /// <summary>
+        /// Creates a new SPARQL Formatter.
+        /// </summary>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        public SparqlFormatter(IUriFactory uriFactory = null)
+        public SparqlFormatter(IUriFactory uriFactory)
             : base("SPARQL", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
@@ -68,8 +75,15 @@ namespace VDS.RDF.Writing.Formatting
         /// Creates a new SPARQL Formatter using the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
+        public SparqlFormatter(INamespaceMapper nsmap)
+            : this(nsmap, UriFactory.Root) { }
+
+        /// <summary>
+        /// Creates a new SPARQL Formatter using the given Namespace Map.
+        /// </summary>
+        /// <param name="nsmap">Namespace Map.</param>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        public SparqlFormatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+        public SparqlFormatter(INamespaceMapper nsmap, IUriFactory uriFactory)
             : base("SPARQL", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Writing/Formatting/TurtleFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/TurtleFormatter.cs
@@ -124,8 +124,9 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
-        public TurtleFormatter() 
-            : base("Turtle", new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public TurtleFormatter(IUriFactory uriFactory = null) 
+            : base("Turtle", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter that uses the given QName mapper.
@@ -139,21 +140,23 @@ namespace VDS.RDF.Writing.Formatting
         /// </summary>
         /// <param name="g">Graph.</param>
         public TurtleFormatter(IGraph g)
-            : base("Turtle", new QNameOutputMapper(g.NamespaceMap)) { }
+            : base("Turtle", new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter for the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
-        public TurtleFormatter(INamespaceMapper nsmap)
-            : base("Turtle", new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public TurtleFormatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base("Turtle", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
         /// <param name="formatName">Format Name.</param>
-        protected TurtleFormatter(string formatName)
-            : base(formatName, new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        protected TurtleFormatter(string formatName, IUriFactory uriFactory = null)
+            : base(formatName, new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
@@ -161,15 +164,16 @@ namespace VDS.RDF.Writing.Formatting
         /// <param name="formatName">Format Name.</param>
         /// <param name="g">Graph.</param>
         protected TurtleFormatter(string formatName, IGraph g)
-            : base(formatName, new QNameOutputMapper(g.NamespaceMap)) { }
+            : base(formatName, new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
         /// <param name="formatName">Format Name.</param>
         /// <param name="nsmap">Namespace Map.</param>
-        protected TurtleFormatter(string formatName, INamespaceMapper nsmap)
-            : base(formatName, new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        protected TurtleFormatter(string formatName, INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base(formatName, new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
@@ -278,7 +282,7 @@ namespace VDS.RDF.Writing.Formatting
         }
 
         /// <summary>
-        /// Formats a Namespace Decalaration as a @prefix declaration.
+        /// Formats a Namespace Declaration as a @prefix declaration.
         /// </summary>
         /// <param name="prefix">Namespace Prefix.</param>
         /// <param name="namespaceUri">Namespace URI.</param>
@@ -308,8 +312,9 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
-        public TurtleW3CFormatter() 
-            : base("Turtle (W3C)", new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public TurtleW3CFormatter(IUriFactory uriFactory = null) 
+            : base("Turtle (W3C)", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter that uses the given QName mapper.
@@ -323,21 +328,23 @@ namespace VDS.RDF.Writing.Formatting
         /// </summary>
         /// <param name="g">Graph.</param>
         public TurtleW3CFormatter(IGraph g)
-            : base("Turtle (W3C)", new QNameOutputMapper(g.NamespaceMap)) { }
+            : base("Turtle (W3C)", new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter for the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
-        public TurtleW3CFormatter(INamespaceMapper nsmap)
-            : base("Turtle (W3C)", new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        public TurtleW3CFormatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base("Turtle (W3C)", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
         /// <param name="formatName">Format Name.</param>
-        protected TurtleW3CFormatter(string formatName)
-            : base(formatName, new QNameOutputMapper()) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        protected TurtleW3CFormatter(string formatName, IUriFactory uriFactory = null)
+            : base(formatName, new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
@@ -345,15 +352,16 @@ namespace VDS.RDF.Writing.Formatting
         /// <param name="formatName">Format Name.</param>
         /// <param name="g">Graph.</param>
         protected TurtleW3CFormatter(string formatName, IGraph g)
-            : base(formatName, new QNameOutputMapper(g.NamespaceMap)) { }
+            : base(formatName, new QNameOutputMapper(g.NamespaceMap, g.UriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
         /// <param name="formatName">Format Name.</param>
         /// <param name="nsmap">Namespace Map.</param>
-        protected TurtleW3CFormatter(string formatName, INamespaceMapper nsmap)
-            : base(formatName, new QNameOutputMapper(nsmap)) { }
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        protected TurtleW3CFormatter(string formatName, INamespaceMapper nsmap, IUriFactory uriFactory = null)
+            : base(formatName, new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.

--- a/Libraries/dotNetRdf/Writing/Formatting/TurtleFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/TurtleFormatter.cs
@@ -312,8 +312,14 @@ namespace VDS.RDF.Writing.Formatting
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
+        public TurtleW3CFormatter()
+            : this(UriFactory.Root) { }
+
+        /// <summary>
+        /// Creates a new Turtle Formatter.
+        /// </summary>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        public TurtleW3CFormatter(IUriFactory uriFactory = null) 
+        public TurtleW3CFormatter(IUriFactory uriFactory) 
             : base("Turtle (W3C)", new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
@@ -334,16 +340,30 @@ namespace VDS.RDF.Writing.Formatting
         /// Creates a new Turtle Formatter for the given Namespace Map.
         /// </summary>
         /// <param name="nsmap">Namespace Map.</param>
+        public TurtleW3CFormatter(INamespaceMapper nsmap)
+            : this(nsmap, UriFactory.Root) { }
+
+        /// <summary>
+        /// Creates a new Turtle Formatter for the given Namespace Map.
+        /// </summary>
+        /// <param name="nsmap">Namespace Map.</param>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        public TurtleW3CFormatter(INamespaceMapper nsmap, IUriFactory uriFactory = null)
+        public TurtleW3CFormatter(INamespaceMapper nsmap, IUriFactory uriFactory)
             : base("Turtle (W3C)", new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>
         /// Creates a new Turtle Formatter.
         /// </summary>
         /// <param name="formatName">Format Name.</param>
-        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        protected TurtleW3CFormatter(string formatName, IUriFactory uriFactory = null)
+        protected TurtleW3CFormatter(string formatName)
+            : this(formatName, UriFactory.Root) { }
+        
+        /// <summary>
+         /// Creates a new Turtle Formatter.
+         /// </summary>
+         /// <param name="formatName">Format Name.</param>
+         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        protected TurtleW3CFormatter(string formatName, IUriFactory uriFactory)
             : base(formatName, new QNameOutputMapper(uriFactory)) { }
 
         /// <summary>
@@ -359,8 +379,16 @@ namespace VDS.RDF.Writing.Formatting
         /// </summary>
         /// <param name="formatName">Format Name.</param>
         /// <param name="nsmap">Namespace Map.</param>
+        protected TurtleW3CFormatter(string formatName, INamespaceMapper nsmap)
+            : this(formatName, nsmap, UriFactory.Root) { }
+
+        /// <summary>
+        /// Creates a new Turtle Formatter.
+        /// </summary>
+        /// <param name="formatName">Format Name.</param>
+        /// <param name="nsmap">Namespace Map.</param>
         /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
-        protected TurtleW3CFormatter(string formatName, INamespaceMapper nsmap, IUriFactory uriFactory = null)
+        protected TurtleW3CFormatter(string formatName, INamespaceMapper nsmap, IUriFactory uriFactory)
             : base(formatName, new QNameOutputMapper(nsmap, uriFactory)) { }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Writing/SPARQLHTMLWriter.cs
+++ b/Libraries/dotNetRdf/Writing/SPARQLHTMLWriter.cs
@@ -92,10 +92,11 @@ namespace VDS.RDF.Writing
         /// </summary>
         /// <param name="results"></param>
         /// <param name="output"></param>
-        private void GenerateOutput(SparqlResultSet results, TextWriter output)
+        /// <param name="uriFactory">The factory to use when creating new Uri instances.</param>
+        private void GenerateOutput(SparqlResultSet results, TextWriter output, IUriFactory uriFactory = null)
         {
             var writer = new HtmlTextWriter(output);
-            var qnameMapper = new QNameOutputMapper(DefaultNamespaces != null ? DefaultNamespaces : new NamespaceMapper(true));
+            var qnameMapper = new QNameOutputMapper(DefaultNamespaces ?? new NamespaceMapper(true), uriFactory);
 
             // Page Header
             writer.Write("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">");


### PR DESCRIPTION
Add constructor parameters to allow the UriFactory instance to be used by the QNameOutputMapper to be specified. Updated as many call sites as feasible.