### PR TITLE
Fix capitalisation of assembly names

### DIFF
--- a/Libraries/dotNetRdf.AspNet/dotNetRdf.AspNet.csproj
+++ b/Libraries/dotNetRdf.AspNet/dotNetRdf.AspNet.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotNetRdf.HtmlSchema\dotNetRdf.HtmlSchema.csproj" />
-    <ProjectReference Include="..\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/Libraries/dotNetRdf.Data.DataTables/dotNetRdf.Data.DataTables.csproj
+++ b/Libraries/dotNetRdf.Data.DataTables/dotNetRdf.Data.DataTables.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Data.DataTables</AssemblyName>
-    <AssemblyTitle>dotNetRdf DataTables</AssemblyTitle>
+    <AssemblyTitle>dotNetRDF DataTables</AssemblyTitle>
     <Description>Package which allow integrating dotNetRDF with System.Data.DataTable</Description>
     <PackageId>dotNetRdf.Data.DataTables</PackageId>
     <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>

--- a/Libraries/dotNetRdf.Data.Virtuoso/dotNetRdf.Data.Virtuoso.csproj
+++ b/Libraries/dotNetRdf.Data.Virtuoso/dotNetRdf.Data.Virtuoso.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Data.Virtuoso</AssemblyName>
-    <AssemblyTitle>dotNetRdf.Data.Virtuoso</AssemblyTitle>
+    <AssemblyTitle>dotNetRDF Virtuoso connector</AssemblyTitle>
     <Description>Provides support for using OpenLink Virtuoso as a backend triplestore with dotNetRDF</Description>
     <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>net472</TargetFrameworks>

--- a/Libraries/dotNetRdf.Dynamic/dotNetRdf.Dynamic.csproj
+++ b/Libraries/dotNetRdf.Dynamic/dotNetRdf.Dynamic.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/Libraries/dotNetRdf.Ontology/dotNetRdf.Ontology.csproj
+++ b/Libraries/dotNetRdf.Ontology/dotNetRdf.Ontology.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/dotNetRdf.Query.FullText/dotNetRdf.Query.FullText.csproj
+++ b/Libraries/dotNetRdf.Query.FullText/dotNetRdf.Query.FullText.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRdf.Query.FullText</AssemblyTitle>
     <AssemblyName>dotNetRdf.Query.FullText</AssemblyName>
+    <AssemblyTitle>dotNetRDF Full Text Query Support</AssemblyTitle>
     <Description>Provides Full Text SPARQL support as a plugin for the dotNetRDF Leviathan SPARQL Engine using Lucene.Net</Description>
     <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>

--- a/Libraries/dotNetRdf.Query.Spin/dotNetRdf.Query.Spin.csproj
+++ b/Libraries/dotNetRdf.Query.Spin/dotNetRdf.Query.Spin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Query.Spin</AssemblyName>
-    <AssemblyTitle>dotNetRDF SPIN</AssemblyTitle>
+    <AssemblyTitle>dotNetRDF SPIN Support</AssemblyTitle>
     <Description>A library which provides a full SPIN implementation using dotNetRDF's Leviathan SPARQL engine</Description>
     <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/Libraries/dotNetRdf.Shacl/dotNetRdf.Shacl.csproj
+++ b/Libraries/dotNetRdf.Shacl/dotNetRdf.Shacl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Shacl</AssemblyName>
-    <AssemblyTitle>dotNetRdf SHACL</AssemblyTitle>
+    <AssemblyTitle>dotNetRdf SHACL Support</AssemblyTitle>
     <Description>Provides support for validating RDF graphs with the W3C Shape Constraint Language.</Description>
     <PackageId>dotNetRdf.Shacl</PackageId>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Libraries/dotNetRdf.Skos/dotNetRdf.Skos.csproj
+++ b/Libraries/dotNetRdf.Skos/dotNetRdf.Skos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Skos</AssemblyName>
-    <AssemblyTitle>dotNetRDF SKOS API</AssemblyTitle>
+    <AssemblyTitle>dotNetRdf SKOS API</AssemblyTitle>
     <Description>Provides a convience API for working the RDF graphs that contain SKOS Concept Schemes.</Description>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <RootNamespace>VDS.RDF.Skos</RootNamespace>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,34 +5,34 @@
 
 ---
 
-**WARNING** You are currently looking at the branch for development of the upcoming dotNetRdf 3.0 release.
-If you are looking for the code for the current dotNetRdf 2.x release [please check out the `maintenance/2.x` branch](https://github.com/dotnetrdf/dotnetrdf/tree/maintenance/2.x)
+**WARNING** You are currently looking at the branch for development of the upcoming dotNetRDF 3.0 release.
+If you are looking for the code for the current dotNetRDF 2.x release [please check out the `maintenance/2.x` branch](https://github.com/dotnetrdf/dotnetrdf/tree/maintenance/2.x)
 
 ---
 
-dotNetRdf is a powerful and flexible API for working with RDF and SPARQL in .NET environments.
+dotNetRDF is a powerful and flexible API for working with RDF and SPARQL in .NET environments.
 
-dotNetRdf is licensed under the MIT License, see the LICENSE.txt file in this repository
+dotNetRDF is licensed under the MIT License, see the LICENSE.txt file in this repository
 
-The `main` branch of this repository is now used for development of dotNetRdf 3.0. This major update is currently a work in progress and introduces a number of breaking API changes, new features including support for [RDF-Star and SPARQL-Star](https://w3c.github.io/rdf-star/cg-spec), and it also restructures the packaging of the code to minimize dependencies and better separate out core functionality from higher-level APIs.
+The `main` branch of this repository is now used for development of dotNetRDF 3.0. This major update is currently a work in progress and introduces a number of breaking API changes, new features including support for [RDF-Star and SPARQL-Star](https://w3c.github.io/rdf-star/cg-spec), and it also restructures the packaging of the code to minimize dependencies and better separate out core functionality from higher-level APIs.
 
-The restructured NuGet packages for dotNetRdf 3.0 are:
+The restructured NuGet packages for dotNetRDF 3.0 are:
 
 - **dotNetRdf** - contains the core libraries. This includes support for reading and writing RDF; and for managing and querying RDF data in-memory.
 - **dotNetRdf.AspNet** - provides a framework for hosting RDF data in an IIS web application. This includes implementations of the SPARQL Protocol and SPARQL Graph Store Protocol.
 - **dotNetRdf.Client** - provides support for working with a range of triple stores. 
 - **dotNetRdf.Data.DataTables** - a package which integrates RDF data with System.Data.DataTable
-- **dotNetRdf.Data.Virtuoso** - provides support for using OpenLink Virtuoso as a backend store with dotNetRdf.
+- **dotNetRdf.Data.Virtuoso** - provides support for using OpenLink Virtuoso as a backend store with dotNetRDF.
 - **dotNetRdf.Dynamic** - provides an API for accessing and updating RDF graphs using .NET's dynamic objects.
 - **dotNetRdf.HtmlSchema** - provides an RDF writer that generates HTML documentation for an ontology that uses the RDF Schema vocabulary.
 - **dotNetRdf.Inferencing** - provides some basic inferencing support including RDF-Schema, SKOS and a small subset of OWL reasoning.
 - **dotNetRdf.Ontology** - provides an API for manipulating an OWL ontology.
-- **dotNetRdf.Query.FullText** - provides a full-text query plugin for dotNetRdf's Leviathan SPARQL query engine. The text indexing is provided by Lucene.
-- **dotNetRdf.Query.Spin** - provides an implementation of [SPIN](http://spinrdf.org/) using dotNetRdf's Leviathan SPARQL query engine.
+- **dotNetRdf.Query.FullText** - provides a full-text query plugin for dotNetRDF's Leviathan SPARQL query engine. The text indexing is provided by Lucene.
+- **dotNetRdf.Query.Spin** - provides an implementation of [SPIN](http://spinrdf.org/) using dotNetRDF's Leviathan SPARQL query engine.
 - **dotNetRdf.Shacl** - provides an API for validating a graph using [SHACL](https://www.w3.org/TR/shacl/).
 - **dotNetRdf.Skos** - provides an API for working with a [SKOS](https://www.w3.org/TR/skos-reference/) taxonomy.
 
-As of release 3.0 of dotNetRdf, we provide support for the following .NET frameworks:
+As of release 3.0 of dotNetRDF, we provide support for the following .NET frameworks:
 
 - .NET 4.7.2+
 - .NET Standard 2.0
@@ -46,7 +46,7 @@ The documentation and examples will be gradually updated and published on the "l
 
 ## Asking Questions and Reporting Bugs
 
-If you have a question about using dotNetRdf, please post it on [StackOverflow using the tag `dotnetrdf`](https://stackoverflow.com/questions/tagged/dotnetrdf).
+If you have a question about using dotNetRDF, please post it on [StackOverflow using the tag `dotnetrdf`](https://stackoverflow.com/questions/tagged/dotnetrdf).
 
 Bugs and feature requests can be submitted to our [issues list on GitHub](https://github.com/dotnetrdf/dotnetrdf/issues). When submitting a bug report, please
 include as much detail as possible. Code and/or data that reproduces the problem you are reporting will make it much more likely that your issue gets addressed 
@@ -54,7 +54,7 @@ quickly.
 
 ## Developers
 
-dotNetRdf is developed by the following people:
+dotNetRDF is developed by the following people:
 
  - Rob Vesse
  - Ron Michael Zettlemoyer
@@ -63,12 +63,12 @@ dotNetRdf is developed by the following people:
  - Tomasz Pluskiewicz
  - Samu Lang
 
-dotNetRdf also benefits from many community contributors who contribute in the form of bug reports, patches, suggestions and other feedback, 
+dotNetRDF also benefits from many community contributors who contribute in the form of bug reports, patches, suggestions and other feedback, 
 please see the [Acknowledgements](https://github.com/dotnetrdf/dotnetrdf/blob/master/Acknowledgments.txt) file for a full list.
 
 ## Pull Requests
 
 We are always pleased to receive pull requests that fix bugs or add features. 
 When fixing a bug, please make sure that it has been reported on the [issues list](https://github.com/dotnetrdf/dotnetrdf/issues) first.
-If you plan to work on a new feature for dotNetRdf, it would be good to raise that on the issues list before you commit too much time to it.
+If you plan to work on a new feature for dotNetRDF, it would be good to raise that on the issues list before you commit too much time to it.
 

--- a/Testing/SparqlAnalyzer/SparqlAnalyzer.csproj
+++ b/Testing/SparqlAnalyzer/SparqlAnalyzer.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\..\Libraries\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Testing/dotNetRdf.Connectors.Allegrograph.Tests/dotNetRdf.Connectors.Allegrograph.Tests.csproj
+++ b/Testing/dotNetRdf.Connectors.Allegrograph.Tests/dotNetRdf.Connectors.Allegrograph.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Libraries\dotNetRdf.Client\dotNetRdf.Client.csproj" />
-    <ProjectReference Include="..\..\Libraries\dotNetRDF\dotNetRDF.csproj" />
-    <ProjectReference Include="..\dotNetRDF.Connectors.Tests\dotNetRDF.Connectors.Tests.csproj" />
+    <ProjectReference Include="..\..\Libraries\dotNetRdf\dotNetRdf.csproj" />
+    <ProjectReference Include="..\dotNetRdf.Connectors.Tests\dotNetRdf.Connectors.Tests.csproj" />
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 

--- a/Testing/dotNetRdf.Connectors.FourStore.Tests/dotNetRdf.Connectors.FourStore.Tests.csproj
+++ b/Testing/dotNetRdf.Connectors.FourStore.Tests/dotNetRdf.Connectors.FourStore.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRdf.Connectors.Sesame.Tests</AssemblyTitle>
+    <AssemblyTitle>dotNetRDF FourStore Connector Tests</AssemblyTitle>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <AssemblyName>dotNetRDF.Connectors.Sesame.Tests</AssemblyName>
+    <AssemblyName>dotNetRdf.Connectors.FourStore.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
     <RootNamespace>VDS.RDF.Storage</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
+++ b/Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRdf.Connectors.Fuseki.Tests</AssemblyTitle>
+    <AssemblyTitle>dotNetRDF Fuseki Connector Tests</AssemblyTitle>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <AssemblyName>dotNetRDF.Connectors.Fuseki.Tests</AssemblyName>
+    <AssemblyName>dotNetRdf.Connectors.Fuseki.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
     <RootNamespace>VDS.RDF.Storage</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/Testing/dotNetRdf.Connectors.Tests/dotNetRdf.Connectors.Tests.csproj
+++ b/Testing/dotNetRdf.Connectors.Tests/dotNetRdf.Connectors.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRDF.Connectors.Tests</AssemblyTitle>
+    <AssemblyTitle>dotNetRdf.Connectors.Tests</AssemblyTitle>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <AssemblyName>dotNetRDF.Connectors.Tests</AssemblyName>
+    <AssemblyName>dotNetRdf.Connectors.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
     <RootNamespace>VDS.RDF.Storage</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/Testing/dotNetRdf.Connectors.Virtuoso.Tests/dotNetRdf.Connectors.Virtuoso.Tests.csproj
+++ b/Testing/dotNetRdf.Connectors.Virtuoso.Tests/dotNetRdf.Connectors.Virtuoso.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRDF.Connectors.Virtuoso.Tests</AssemblyTitle>
+    <AssemblyTitle>dotNetRdf.Connectors.Virtuoso.Tests</AssemblyTitle>
     <TargetFrameworks>net472</TargetFrameworks>
-    <AssemblyName>dotNetRDF.Connectors.Virtuoso.Tests</AssemblyName>
+    <AssemblyName>dotNetRdf.Connectors.Virtuoso.Tests</AssemblyName>
 	<IsPackable>false</IsPackable>
     <RootNamespace>VDS.RDF.Storage</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Testing/dotNetRdf.TestSupport/dotNetRdf.TestSupport.csproj
+++ b/Testing/dotNetRdf.TestSupport/dotNetRdf.TestSupport.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\..\Libraries\dotNetRdf\dotNetRdf.csproj" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/Testing/dotNetRdf.Tests/dotNetRdf.Tests.csproj
+++ b/Testing/dotNetRdf.Tests/dotNetRdf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>dotNetRDF.Test</AssemblyTitle>
+    <AssemblyTitle>dotNetRdf.Test</AssemblyTitle>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>dotNetRdf.Test</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\dotNetRDF\dotNetRDF.csproj" />
+    <ProjectReference Include="..\..\Libraries\dotNetRdf\dotNetRdf.csproj" />
     <ProjectReference Include="..\dotNetRdf.TestSupport\dotNetRdf.TestSupport.csproj" />
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>


### PR DESCRIPTION
Work for issue #471
Rename dotNetRDF -> dotNetRdf in assembly names and project file references.
Consistently use dotNetRDF as the project name in the README