### PR TITLE
Simplify Triple implementation

### DIFF
--- a/Libraries/dotNetRdf.Client/Storage/FourStoreConnector.cs
+++ b/Libraries/dotNetRdf.Client/Storage/FourStoreConnector.cs
@@ -307,14 +307,21 @@ namespace VDS.RDF.Storage
         /// </remarks>
         public void UpdateGraph(Uri graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
         {
-            if (graphUri == null)
-            {
-                throw new RdfStorageException("Cannot update a Graph without a Graph URI on a 4store Server");
-            }
-            else
-            {
-                UpdateGraph(graphUri.ToString(), additions, removals);
-            }
+            UpdateGraph(graphUri.ToSafeString(), additions, removals);
+        }
+
+        /// <summary>
+        /// Updates a graph in the store.
+        /// </summary>
+        /// <param name="graphName">Name of the graph to update.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        /// <remarks>
+        /// May throw an error since the default builds of 4store don't support Triple level updates.  There are builds that do support this and the user can instantiate the connector with support for this enabled if they wish, if they do so and the underlying 4store doesn't support updates errors will occur when updates are attempted.
+        /// </remarks>
+        public void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            UpdateGraph(graphName.ToSafeString(), additions, removals);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf.Client/Storage/SesameHTTPProtocolConnector.cs
+++ b/Libraries/dotNetRdf.Client/Storage/SesameHTTPProtocolConnector.cs
@@ -543,6 +543,12 @@ namespace VDS.RDF.Storage
             UpdateGraph(graphUri.ToSafeString(), additions, removals);
         }
 
+        /// <inheritdoc />
+        public virtual void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            UpdateGraph(graphName.ToSafeString(), additions, removals);
+        }
+
         /// <summary>
         /// Updates a Graph.
         /// </summary>

--- a/Libraries/dotNetRdf.Data.DataTables/DataTableHandler.cs
+++ b/Libraries/dotNetRdf.Data.DataTables/DataTableHandler.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Data;
+using VDS.RDF.Parsing;
 using VDS.RDF.Parsing.Handlers;
 
 namespace VDS.RDF.Data.DataTables
@@ -89,6 +90,22 @@ namespace VDS.RDF.Data.DataTables
             return true;
         }
 
+        /// <summary>
+        /// Handles a quad by turning it into a row in the Data Table
+        /// </summary>
+        /// <param name="t">Triple</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// This implementation does not support handling triples in any graph other than the default graph. 
+        /// To customize how a Triple is converted into a row in the table derive from this class and override this method
+        /// </remarks>
+        /// <exception cref="RdfParseException">Raised if <paramref name="graph"/> is not null, as this implementation only supports triples in the default graph.</exception>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            if (graph == null) return HandleTripleInternal(t);
+            throw new RdfParseException("The DataTableHandler does not support handling triples in a named graph.");
+        }
         /// <summary>
         /// Indicates that the Handler accepts all triples
         /// </summary>

--- a/Libraries/dotNetRdf.Data.Virtuoso/VirtuosoConnectorBase.cs
+++ b/Libraries/dotNetRdf.Data.Virtuoso/VirtuosoConnectorBase.cs
@@ -566,6 +566,23 @@ namespace VDS.RDF.Storage
             UpdateGraph(u, additions, removals);
         }
 
+        /// <inheritdoc />
+        public override void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            switch (graphName)
+            {
+                case null:
+                    UpdateGraph((Uri)null, additions, removals);
+                    break;
+                case IUriNode graphUri:
+                    UpdateGraph(graphUri.Uri, additions, removals);
+                    break;
+                case IBlankNode blankNode:
+                    throw new RdfStorageException(
+                        "The Virtuoso connector does not support updating graphs with a blank node name.");
+            }
+        }
+
         /// <summary>
         /// Deletes a Graph from the Virtuoso store.
         /// </summary>

--- a/Libraries/dotNetRdf.Shacl/Validation/ReportDescribe.cs
+++ b/Libraries/dotNetRdf.Shacl/Validation/ReportDescribe.cs
@@ -55,7 +55,7 @@ namespace VDS.RDF.Shacl.Validation
                         }
                     }
 
-                    if (!handler.HandleTriple(RewriteDescribeBNodes(new Triple(mappedSubject ?? originalSubject, t.Predicate, @object, t.Graph), bnodeMapping, handler)))
+                    if (!handler.HandleTriple(RewriteDescribeBNodes(new Triple(mappedSubject ?? originalSubject, t.Predicate, @object), bnodeMapping, handler)))
                     {
                         ParserHelper.Stop();
                     }

--- a/Libraries/dotNetRdf/Core/IRdfHandler.cs
+++ b/Libraries/dotNetRdf/Core/IRdfHandler.cs
@@ -70,6 +70,14 @@ namespace VDS.RDF
         bool HandleTriple(Triple t);
 
         /// <summary>
+        /// Handles a Quad (Triple + Graph).
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns>Should return <strong>true</strong> if parsing should continue or <strong>false</strong> if it should be aborted.</returns>
+        bool HandleQuad(Triple t, IRefNode graph);
+
+        /// <summary>
         /// Gets whether the Handler will always handle all data (i.e. won't terminate parsing early).
         /// </summary>
         bool AcceptsAll

--- a/Libraries/dotNetRdf/Core/Triple.cs
+++ b/Libraries/dotNetRdf/Core/Triple.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF
     public sealed class Triple
         : IComparable<Triple>
     {
-        private readonly IRefNode _graphName;
+        // private readonly IRefNode _graphName;
         private readonly int _hashcode;
 
         /// <summary>
@@ -68,10 +68,11 @@ namespace VDS.RDF
         /// <param name="g">Graph.</param>
         /// <remarks>Will throw an RdfException if the Nodes don't belong to the same Graph/Node Factory.</remarks>
         /// <exception cref="RdfException">Thrown if the Nodes aren't all from the same Graph/Node Factory.</exception>
+        [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public Triple(INode subj, INode pred, INode obj, IGraph g)
             : this(subj, pred, obj)
         {
-            Graph = g;
+            // Graph = g;
         }
 
         /// <summary>
@@ -89,49 +90,52 @@ namespace VDS.RDF
             Context = context;
         }
 
-        /// <summary>
-        /// Creates a Triple and associates it with the given Graph URI permanently (though not with a specific Graph as such).
-        /// </summary>
-        /// <param name="subj">Subject of the Triple.</param>
-        /// <param name="pred">Predicate of the Triple.</param>
-        /// <param name="obj">Object of the Triple.</param>
-        /// <param name="graphUri">Graph URI.</param>
-        /// <remarks>Will throw an RdfException if the Nodes don't belong to the same Graph/Node Factory.</remarks>
-        /// <exception cref="RdfException">Thrown if the Nodes aren't all from the same Graph/Node Factory.</exception>
-        public Triple(INode subj, INode pred, INode obj, Uri graphUri)
-            : this(subj, pred, obj)
-        {
-            _graphName = graphUri == null ? null : new UriNode(graphUri);
-        }
+        ///// <summary>
+        ///// Creates a Triple and associates it with the given Graph URI permanently (though not with a specific Graph as such).
+        ///// </summary>
+        ///// <param name="subj">Subject of the Triple.</param>
+        ///// <param name="pred">Predicate of the Triple.</param>
+        ///// <param name="obj">Object of the Triple.</param>
+        ///// <param name="graphUri">Graph URI.</param>
+        ///// <remarks>Will throw an RdfException if the Nodes don't belong to the same Graph/Node Factory.</remarks>
+        ///// <exception cref="RdfException">Thrown if the Nodes aren't all from the same Graph/Node Factory.</exception>
+        //[Obsolete("This constructor is obsolete and will be remove in a future version.")]
+        //public Triple(INode subj, INode pred, INode obj, Uri graphUri)
+        //    : this(subj, pred, obj)
+        //{
+        //    // _graphName = graphUri == null ? null : new UriNode(graphUri);
+        //}
 
-        /// <summary>
-        /// Constructs a Triple from Nodes that belong to the same Graph/Node Factory with some Context.
-        /// </summary>
-        /// <param name="subj">Subject of the Triple.</param>
-        /// <param name="pred">Predicate of the Triple.</param>
-        /// <param name="obj">Object of the Triple.</param>
-        /// <param name="context">Context Information for the Triple.</param>
-        /// <param name="graphUri">Graph URI.</param>
-        /// <remarks>Will throw an RdfException if the Nodes don't belong to the same Graph/Node Factory.</remarks>
-        /// <exception cref="RdfException">Thrown if the Nodes aren't all from the same Graph/Node Factory.</exception>
-        public Triple(INode subj, INode pred, INode obj, ITripleContext context, Uri graphUri)
-            : this(subj, pred, obj, graphUri)
-        {
-            Context = context;
-        }
+        ///// <summary>
+        ///// Constructs a Triple from Nodes that belong to the same Graph/Node Factory with some Context.
+        ///// </summary>
+        ///// <param name="subj">Subject of the Triple.</param>
+        ///// <param name="pred">Predicate of the Triple.</param>
+        ///// <param name="obj">Object of the Triple.</param>
+        ///// <param name="context">Context Information for the Triple.</param>
+        ///// <param name="graphUri">Graph URI.</param>
+        ///// <remarks>Will throw an RdfException if the Nodes don't belong to the same Graph/Node Factory.</remarks>
+        ///// <exception cref="RdfException">Thrown if the Nodes aren't all from the same Graph/Node Factory.</exception>
+        //[Obsolete("This constructor is obsolete and will be remove in a future version.")]
+        //public Triple(INode subj, INode pred, INode obj, ITripleContext context, Uri graphUri)
+        //    : this(subj, pred, obj, graphUri)
+        //{
+        //    Context = context;
+        //}
 
-        /// <summary>
-        /// Constructs a triple associated with the specified graph.
-        /// </summary>
-        /// <param name="subj">Subject of the Triple.</param>
-        /// <param name="pred">Predicate of the Triple.</param>
-        /// <param name="obj">Object of the Triple.</param>
-        /// <param name="graph">Name of the graph the triple is associated with</param>
-        public Triple(IRefNode subj, IRefNode pred, INode obj, IRefNode graph):
-            this(subj, pred, obj)
-        {
-            _graphName = graph;
-        }
+        ///// <summary>
+        ///// Constructs a triple associated with the specified graph.
+        ///// </summary>
+        ///// <param name="subj">Subject of the Triple.</param>
+        ///// <param name="pred">Predicate of the Triple.</param>
+        ///// <param name="obj">Object of the Triple.</param>
+        ///// <param name="graph">Name of the graph the triple is associated with</param>
+        //[Obsolete("This constructor is obsolete and will be remove in a future version.")]
+        //public Triple(IRefNode subj, IRefNode pred, INode obj, IRefNode graph):
+        //    this(subj, pred, obj)
+        //{
+        //    _graphName = graph;
+        //}
 
         /// <summary>
         /// Gets the Subject of the Triple.
@@ -152,38 +156,40 @@ namespace VDS.RDF
         /// Gets the Graph this Triple was created for.
         /// </summary>
         /// <remarks>This is not necessarily the actual Graph this Triple is asserted in since this property is set from the Subject of the Triple when it is created and it is possible to create a Triple without asserting it into an actual Graph or to then assert it into a different Graph.</remarks>
-        public IGraph Graph { get; } = null;
+        // [Obsolete("This property is obsolete and will be removed in a future version.")]
+        //public IGraph Graph { get; } = null;
 
         /// <summary>
         /// Gets the Uri of the Graph this Triple was created for.
         /// </summary>
         /// <remarks>This is not necessarily the actual Graph Uri of the Graph this Triple is asserted in since this property is set from the Subject of the Triple when it is created and it is possible to create a Triple without asserting it into an actual Graph or to then assert it into a different Graph.</remarks>
-        [Obsolete("Replaced by GraphName")]
-        public Uri GraphUri
-        {
-            get
-            {
-                IRefNode graphNode = GraphName;
-                return graphNode switch
-                {
-                    IUriNode uriNode => uriNode.Uri,
-                    IBlankNode => throw new RdfException(
-                        "Attempt to read the GraphUri of a triple that targets a graph with a blank node name. Use GraphName instead of GraphUri."),
-                    _ => null
-                };
-            }
-        }
+        //[Obsolete("This property is obsolete and will be removed in a future version.")]
+        //public Uri GraphUri
+        //{
+        //    get
+        //    {
+        //        return null;
+        //        //IRefNode graphNode = GraphName;
+        //        //return graphNode switch
+        //        //{
+        //        //    IUriNode uriNode => uriNode.Uri,
+        //        //    IBlankNode => throw new RdfException(
+        //        //        "Attempt to read the GraphUri of a triple that targets a graph with a blank node name. Use GraphName instead of GraphUri."),
+        //        //    _ => null
+        //        //};
+        //    }
+        //}
 
-        /// <summary>
-        /// Gets the name of the graph that this triple was created for.
-        /// </summary>
-        public IRefNode GraphName
-        {
-            get
-            {
-                return _graphName ?? Graph?.Name;
-            }
-        }
+        ///// <summary>
+        ///// Gets the name of the graph that this triple was created for.
+        ///// </summary>
+        //public IRefNode GraphName
+        //{
+        //    get
+        //    {
+        //        return _graphName ?? Graph?.Name;
+        //    }
+        //}
 
         /// <summary>
         /// Gets the Context Information for this Triple.
@@ -343,17 +349,21 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="compress">Controls whether URIs will be compressed to QNames in the String representation.</param>
         /// <returns></returns>
+        /// <remarks>As of dotNetRdf 3.0, this method is obsolete and does not perform an URI to QName compression. To produce a compressed string, use
+        /// the <see cref="ToString(ITripleFormatter)"/> overload passing in a formatter configured with the desired <see cref="INamespaceMapper"/>.</remarks>
+        [Obsolete("This method is obsolete and will be removed in a future version. Use ToString() or ToString(ITripleFormatter) instead.")]
         public string ToString(bool compress)
         {
-            if (!compress || Graph == null)
-            {
-                return ToString();
-            }
-            else
-            {
-                var formatter = new TurtleFormatter(Graph.NamespaceMap);
-                return formatter.Format(this);
-            }
+            //if (!compress || Graph == null)
+            //{
+            //    return ToString();
+            //}
+            //else
+            //{
+            //    var formatter = new TurtleFormatter(Graph.NamespaceMap);
+            //    return formatter.Format(this);
+            //}
+            return ToString();
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Parsing/Handlers/AnyHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/AnyHandler.cs
@@ -94,6 +94,18 @@ namespace VDS.RDF.Parsing.Handlers
         }
 
         /// <summary>
+        /// Handles Triples by setting the <see cref="AnyHandler.Any">Any</see> flag and terminating parsing.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            _any = true;
+            return false;
+        }
+
+        /// <summary>
         /// Gets that this handler does not accept all triples since it stops as soon as it sees the first triple.
         /// </summary>
         public override bool AcceptsAll

--- a/Libraries/dotNetRdf/Parsing/Handlers/BaseHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/BaseHandler.cs
@@ -346,11 +346,37 @@ namespace VDS.RDF.Parsing.Handlers
         }
 
         /// <summary>
+        /// Handles Quads.
+        /// </summary>
+        /// <param name="t">Triple to handle.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        /// <exception cref="RdfParseException">Raised if the handler is not currently in a state to handle quads.</exception>
+        public bool HandleQuad(Triple t, IRefNode graph)
+        {
+            if (!_inUse) throw new RdfParseException("Cannot Handle Quad as this RDF Handler is not currently in-use");
+            return HandleQuadInternal(t, graph);
+        }
+
+        /// <summary>
         /// Must be overridden by derived handlers to take appropriate Triple handling action.
         /// </summary>
         /// <param name="t">Triple.</param>
         /// <returns></returns>
         protected abstract bool HandleTripleInternal(Triple t);
+
+        /// <summary>
+        /// Must be overridden by derived handlers to take appropriate Quad handling action.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">Name of the graph containing the triple.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Implementations that expect to only handle triples in the un-named graph SHOULD
+        /// provide an implementation for this method that checks if <paramref name="graph"/>
+        /// is null and if so perform their standard triple handling processing.
+        /// </remarks>
+        protected abstract bool HandleQuadInternal(Triple t, IRefNode graph);
 
         /// <summary>
         /// Gets whether the Handler will accept all Triples i.e. it will never abort handling early.

--- a/Libraries/dotNetRdf/Parsing/Handlers/CountHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/CountHandler.cs
@@ -32,7 +32,7 @@ namespace VDS.RDF.Parsing.Handlers
     public class CountHandler 
         : BaseRdfHandler
     {
-        private int _counter = 0;
+        private int _counter;
 
         /// <summary>
         /// Creates a Handler which counts Triples.
@@ -55,6 +55,18 @@ namespace VDS.RDF.Parsing.Handlers
         /// <param name="t">Triple.</param>
         /// <returns></returns>
         protected override bool HandleTripleInternal(Triple t)
+        {
+            _counter++;
+            return true;
+        }
+
+        /// <summary>
+        /// Handles the Quad by incrementing the Triple count.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
         {
             _counter++;
             return true;

--- a/Libraries/dotNetRdf/Parsing/Handlers/GraphUriRewriteHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/GraphUriRewriteHandler.cs
@@ -35,8 +35,8 @@ namespace VDS.RDF.Parsing.Handlers
     public class GraphUriRewriteHandler
         : BaseRdfHandler, IWrappingRdfHandler
     {
-        private IRdfHandler _handler;
-        private Uri _graphUri;
+        private readonly IRdfHandler _handler;
+        private readonly IRefNode _graphName;
 
         /// <summary>
         /// Creates a new Graph URI rewriting handler.
@@ -47,7 +47,18 @@ namespace VDS.RDF.Parsing.Handlers
             : base()
         {
             _handler = handler;
-            _graphUri = graphUri;
+            _graphName = new UriNode(graphUri);
+        }
+
+        /// <summary>
+        /// Creates a new Graph URI rewriting handler.
+        /// </summary>
+        /// <param name="handler">Handler to wrap.</param>
+        /// <param name="graphName">Graph name to rewrite to.</param>
+        public GraphUriRewriteHandler(IRdfHandler handler, IRefNode graphName)
+        {
+            _handler = handler;
+            _graphName = graphName;
         }
 
         /// <summary>
@@ -108,8 +119,18 @@ namespace VDS.RDF.Parsing.Handlers
         /// <returns></returns>
         protected override bool HandleTripleInternal(Triple t)
         {
-            t = new Triple(t.Subject, t.Predicate, t.Object, _graphUri);
-            return _handler.HandleTriple(t);
+            return _handler.HandleQuad(t, _graphName);
+        }
+
+        /// <summary>
+        /// Handles a quad by rewriting the graph name and passing it to the inner handler.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            return _handler.HandleQuad(t, _graphName);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Parsing/Handlers/HandlerExtensions.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/HandlerExtensions.cs
@@ -90,7 +90,10 @@ namespace VDS.RDF.Parsing.Handlers
                     // Finally handle triples
                     foreach (Triple t in g.Triples)
                     {
-                        if (!handler.HandleTriple(t)) ParserHelper.Stop();
+                        if (!handler.HandleTriple(t))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
 
@@ -119,7 +122,10 @@ namespace VDS.RDF.Parsing.Handlers
                 handler.StartRdf();
                 foreach (Triple t in ts)
                 {
-                    if (!handler.HandleTriple(t)) ParserHelper.Stop();
+                    if (!handler.HandleTriple(t))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
                 handler.EndRdf(false);
             }

--- a/Libraries/dotNetRdf/Parsing/Handlers/MultiHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/MultiHandler.cs
@@ -145,6 +145,21 @@ namespace VDS.RDF.Parsing.Handlers
         }
 
         /// <summary>
+        /// Handles a quad by getting all inner handlers to handler it.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Handling ends if any of the Handlers indicates it should stop but all Handlers are given the chance to finish the current handling action first.
+        /// </remarks>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            var results = _handlers.Select(h => h.HandleQuad(t, graph)).ToList();
+            return results.All(x => x);
+        }
+
+        /// <summary>
         /// Gets whether this Handler accepts all Triples based on whether all inner handlers do so.
         /// </summary>
         public override bool AcceptsAll

--- a/Libraries/dotNetRdf/Parsing/Handlers/NullHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/NullHandler.cs
@@ -52,6 +52,17 @@ namespace VDS.RDF.Parsing.Handlers
         }
 
         /// <summary>
+        /// Handles a quad by doing nothing.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Indicates that the Handler accepts all Triples.
         /// </summary>
         public override bool AcceptsAll

--- a/Libraries/dotNetRdf/Parsing/Handlers/StoreCountHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/StoreCountHandler.cs
@@ -34,7 +34,6 @@ namespace VDS.RDF.Parsing.Handlers
     /// </summary>
     public class StoreCountHandler : BaseRdfHandler
     {
-        private int _counter = 0;
         private HashSet<string> _graphs;
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace VDS.RDF.Parsing.Handlers
         /// </summary>
         protected override void StartRdfInternal()
         {
-            _counter = 0;
+            TripleCount = 0;
             _graphs = new HashSet<string>();
         }
 
@@ -59,42 +58,37 @@ namespace VDS.RDF.Parsing.Handlers
         /// <returns></returns>
         protected override bool HandleTripleInternal(Triple t)
         {
-            _counter++;
-            _graphs.Add(t.GraphUri.ToSafeString());
+            TripleCount++;
+            _graphs.Add(String.Empty);
+            return true;
+        }
+
+        /// <summary>
+        /// Handles Triples/Quads by counting the Triples and distinct Graph URIs.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            TripleCount++;
+            _graphs.Add(graph.ToSafeString());
             return true;
         }
 
         /// <summary>
         /// Gets the count of Triples.
         /// </summary>
-        public int TripleCount
-        {
-            get
-            {
-                return _counter;
-            }
-        }
+        public int TripleCount { get; private set; }
 
         /// <summary>
         /// Gets the count of distinct Graph URIs.
         /// </summary>
-        public int GraphCount
-        {
-            get 
-            {
-                return _graphs.Count;
-            }
-        }
+        public int GraphCount => _graphs.Count;
 
         /// <summary>
         /// Gets that this Handler accepts all Triples.
         /// </summary>
-        public override bool AcceptsAll
-        {
-            get 
-            {
-                return true; 
-            }
-        }
+        public override bool AcceptsAll => true;
     }
 }

--- a/Libraries/dotNetRdf/Parsing/Handlers/StoreHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/StoreHandler.cs
@@ -65,19 +65,36 @@ namespace VDS.RDF.Parsing.Handlers
         }
 
         /// <summary>
-        /// Handles Triples by asserting them into the appropriate Graph creating the Graph if necessary.
+        /// Handles Triples by asserting them into the un-named graph creating the graph if necessary.
         /// </summary>
         /// <param name="t">Triple.</param>
         /// <returns></returns>
         protected override bool HandleTripleInternal(Triple t)
         {
-            IRefNode targetGraphName = t.GraphName;
-            if (!Store.HasGraph(targetGraphName))
+            if (!Store.HasGraph((IRefNode)null))
             {
-                var g = new Graph(t.GraphName);
+                var g = new Graph();
                 Store.Add(g);
             }
-            IGraph target = Store[targetGraphName];
+            IGraph target = Store[(IRefNode)null];
+            target.Assert(t);
+            return true;
+        }
+
+        /// <summary>
+        /// Handles Triples by asserting them into the appropriate graph creating the graph if necessary.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            if (!Store.HasGraph(graph))
+            {
+                var g = new Graph(graph);
+                Store.Add(g);
+            }
+            IGraph target = Store[graph];
             target.Assert(t);
             return true;
         }

--- a/Libraries/dotNetRdf/Parsing/Handlers/StripStringHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/StripStringHandler.cs
@@ -43,7 +43,7 @@ namespace VDS.RDF.Parsing.Handlers
         /// <param name="handler">Inner handler to use.</param>
         public StripStringHandler(IRdfHandler handler) : base(handler)
         {
-            _handler = handler ?? throw new ArgumentNullException("handler");
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
         /// <summary>
@@ -51,10 +51,26 @@ namespace VDS.RDF.Parsing.Handlers
         /// </summary>
         protected override bool HandleTripleInternal(Triple t)
         {
-            if (t.Object is ILiteralNode literal && EqualityHelper.AreUrisEqual(literal.DataType, DataTypeString))
-                t = new Triple(t.Subject, t.Predicate, new LiteralNode(literal.Value, false));
+            return _handler.HandleTriple(StripString(t));
+        }
 
-            return _handler.HandleTriple(t);
+
+        /// <summary>
+        /// Handles triples by stripping explicit xsd:string datatype on object literals before delegating to inner handler.
+        /// </summary>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            return _handler.HandleQuad(StripString(t), graph);
+        }
+
+        private static Triple StripString(Triple t)
+        {
+            if (t.Object is ILiteralNode literal && EqualityHelper.AreUrisEqual(literal.DataType, DataTypeString))
+            {
+                return new Triple(t.Subject, t.Predicate, new LiteralNode(literal.Value, false));
+            }
+
+            return t;
         }
 
         #region Delegate to inner handler

--- a/Libraries/dotNetRdf/Parsing/Handlers/UniqueBlankNodesHandler.cs
+++ b/Libraries/dotNetRdf/Parsing/Handlers/UniqueBlankNodesHandler.cs
@@ -43,7 +43,7 @@ namespace VDS.RDF.Parsing.Handlers
     public class UniqueBlankNodesHandler
         : BaseRdfHandler, IWrappingRdfHandler
     {
-        private IRdfHandler _handler;
+        private readonly IRdfHandler _handler;
 
         /// <summary>
         /// Creates a new Unique Blank Nodes handler.
@@ -51,8 +51,7 @@ namespace VDS.RDF.Parsing.Handlers
         /// <param name="handler"></param>
         public UniqueBlankNodesHandler(IRdfHandler handler)
         {
-            if (handler == null) throw new ArgumentNullException("handler");
-            _handler = handler;
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
         /// <summary>
@@ -122,6 +121,17 @@ namespace VDS.RDF.Parsing.Handlers
         protected override bool HandleTripleInternal(Triple t)
         {
             return _handler.HandleTriple(t);
+        }
+
+        /// <summary>
+        /// Handles a quad.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">The name of the graph containing the triple.</param>
+        /// <returns></returns>
+        protected override bool HandleQuadInternal(Triple t, IRefNode graph)
+        {
+            return _handler.HandleQuad(t, graph);
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf/Parsing/JsonLdParser.cs
@@ -191,7 +191,7 @@ namespace VDS.RDF.Parsing
                                     INode typeNode = MakeNode(handler, type, graphNode);
                                     if (typeNode != null)
                                     {
-                                        handler.HandleTriple(new Triple(subjectNode, rdfTypeNode, typeNode, graphNode));
+                                        handler.HandleQuad(new Triple(subjectNode, rdfTypeNode, typeNode), graphNode);
                                     }
                                 }
                             }
@@ -204,7 +204,7 @@ namespace VDS.RDF.Parsing
                                     INode objectNode = MakeNode(handler, item, graphNode);
                                     if (predicateNode != null && objectNode != null)
                                     {
-                                        handler.HandleTriple(new Triple(subjectNode, predicateNode, objectNode, graphNode));
+                                        handler.HandleQuad(new Triple(subjectNode, predicateNode, objectNode), graphNode);
                                     }
                                 }
                             }
@@ -302,25 +302,25 @@ namespace VDS.RDF.Parsing
                     IBlankNode literalNode = handler.CreateBlankNode();
                     Uri xsdString =
                         UriFactory.Root.Create(XmlSpecsHelper.XmlSchemaDataTypeString);
-                    handler.HandleTriple(new Triple(
+                    handler.HandleQuad(new Triple(
                         literalNode,
                         handler.CreateUriNode(UriFactory.Root.Create(RdfSpecsHelper.RdfValue)),
-                        handler.CreateLiteralNode(literalValue, xsdString),
-                        graphName));
+                        handler.CreateLiteralNode(literalValue, xsdString)),
+                        graphName);
                     if (!string.IsNullOrEmpty(language))
                     {
-                        handler.HandleTriple(new Triple(
+                        handler.HandleQuad(new Triple(
                             literalNode,
                             handler.CreateUriNode(UriFactory.Root.Create(RdfSpecsHelper.RdfLanguage)),
-                            handler.CreateLiteralNode(language, xsdString),
-                            graphName));
+                            handler.CreateLiteralNode(language, xsdString)),
+                            graphName);
                     }
 
-                    handler.HandleTriple(new Triple(
+                    handler.HandleQuad(new Triple(
                         literalNode,
                         handler.CreateUriNode(UriFactory.Root.Create(RdfSpecsHelper.RdfDirection)),
-                        handler.CreateLiteralNode(direction, xsdString),
-                        graphName));
+                        handler.CreateLiteralNode(direction, xsdString)),
+                        graphName);
 
                     return literalNode;
                 }
@@ -368,10 +368,10 @@ namespace VDS.RDF.Parsing
                 INode obj = MakeNode(handler, list[ix], graphName);
                 if (obj != null)
                 {
-                    handler.HandleTriple(new Triple(subject, rdfFirst, obj, graphName));
+                    handler.HandleQuad(new Triple(subject, rdfFirst, obj), graphName);
                 }
                 INode rest = (ix + 1 < list.Count) ? bNodes[ix + 1] : (INode)rdfNil;
-                handler.HandleTriple(new Triple(subject, rdfRest, rest, graphName));
+                handler.HandleQuad(new Triple(subject, rdfRest, rest), graphName);
             }
             return bNodes[0];
         }

--- a/Libraries/dotNetRdf/Parsing/NQuadsParser.cs
+++ b/Libraries/dotNetRdf/Parsing/NQuadsParser.cs
@@ -345,7 +345,10 @@ namespace VDS.RDF.Parsing
             INode predicate = NTriplesParser.TryParsePredicate(context);
             INode obj = NTriplesParser.TryParseObject(context);
             IRefNode graphName = TryParseContext(context);
-            if (!context.Handler.HandleTriple(new Triple(subj as IRefNode, predicate as IRefNode, obj, graphName))) ParserHelper.Stop();
+            if (!context.Handler.HandleQuad(new Triple(subj as IRefNode, predicate as IRefNode, obj), graphName))
+            {
+                ParserHelper.Stop();
+            }
         }
 
 

--- a/Libraries/dotNetRdf/Parsing/NTriplesParser.cs
+++ b/Libraries/dotNetRdf/Parsing/NTriplesParser.cs
@@ -349,7 +349,10 @@ namespace VDS.RDF.Parsing
             TryParseLineTerminator(context);
 
             // Assert the Triple
-            if (!context.Handler.HandleTriple(new Triple(subj, pred, obj))) ParserHelper.Stop();
+            if (!context.Handler.HandleTriple(new Triple(subj, pred, obj)))
+            {
+                ParserHelper.Stop();
+            }
         }
 
         internal static INode TryParseSubject(TokenisingParserContext context)

--- a/Libraries/dotNetRdf/Parsing/Notation3Parser.cs
+++ b/Libraries/dotNetRdf/Parsing/Notation3Parser.cs
@@ -986,12 +986,18 @@ namespace VDS.RDF.Parsing
                 // Assert the Triple
                 if (!reverse)
                 {
-                    if (!context.Handler.HandleTriple(new Triple(subj, pred, obj, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(subj, pred, obj, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
                 else
                 {
                     // When reversed this means the predicate was Implied By (<=)
-                    if (!context.Handler.HandleTriple(new Triple(obj, pred, subj, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(obj, pred, subj, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
 
                 // Expect a comma/semicolon/dot terminator if we are to continue
@@ -1112,8 +1118,15 @@ namespace VDS.RDF.Parsing
 
                     case Token.RIGHTBRACKET:
                         // We might terminate here if someone put a comment before the end of the Collection
-                        if (!context.Handler.HandleTriple(new Triple(subj, rdfFirst, obj, context.VariableContext))) ParserHelper.Stop();
-                        if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, rdfNil, context.VariableContext))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(subj, rdfFirst, obj, context.VariableContext)))
+                        {
+                            ParserHelper.Stop();
+                        }
+
+                        if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, rdfNil, context.VariableContext)))
+                        {
+                            ParserHelper.Stop();
+                        }
                         return;
 
                     case Token.QNAME:
@@ -1138,19 +1151,28 @@ namespace VDS.RDF.Parsing
                 }
 
                 // Assert the relevant Triples
-                if (!context.Handler.HandleTriple(new Triple(subj, rdfFirst, obj, context.VariableContext))) ParserHelper.Stop();
+                if (!context.Handler.HandleTriple(new Triple(subj, rdfFirst, obj, context.VariableContext)))
+                {
+                    ParserHelper.Stop();
+                }
                 if (context.Tokens.Peek().TokenType == Token.RIGHTBRACKET)
                 {
                     // End of the Collection
                     context.Tokens.Dequeue();
-                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, rdfNil, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, rdfNil, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                     return;
                 }
                 else
                 {
                     // More stuff in the collection
                     nextSubj = context.Handler.CreateBlankNode();
-                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, nextSubj, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, nextSubj, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                     subj = nextSubj;
                 }
             } while (true);
@@ -1255,11 +1277,17 @@ namespace VDS.RDF.Parsing
 
                 if (forward)
                 {
-                    if (!context.Handler.HandleTriple(new Triple(firstItem, secondItem, path, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(firstItem, secondItem, path, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
                 else
                 {
-                    if (!context.Handler.HandleTriple(new Triple(path, secondItem, firstItem, context.VariableContext))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(path, secondItem, firstItem, context.VariableContext)))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
 
                 // Does the Path continue?

--- a/Libraries/dotNetRdf/Parsing/RDFJSONParser.cs
+++ b/Libraries/dotNetRdf/Parsing/RDFJSONParser.cs
@@ -493,7 +493,10 @@ namespace VDS.RDF.Parsing
                     }
 
                     // Assert as a Triple
-                    if (!context.Handler.HandleTriple(new Triple(subj, pred, obj))) ParserHelper.Stop();
+                    if (!context.Handler.HandleTriple(new Triple(subj, pred, obj)))
+                    {
+                        ParserHelper.Stop();
+                    }
                 }
             }
             else

--- a/Libraries/dotNetRdf/Parsing/RDFXMLParser.cs
+++ b/Libraries/dotNetRdf/Parsing/RDFXMLParser.cs
@@ -702,7 +702,10 @@ namespace VDS.RDF.Parsing
                 // Assert a Triple regarding Type
                 pred = context.Handler.CreateUriNode(context.UriFactory.Create(RdfSpecsHelper.RdfType));
                 obj = Resolve(context, element);//context.Handler.CreateUriNode(element.QName);
-                if (!context.Handler.HandleTriple(new Triple(subj, pred, obj))) ParserHelper.Stop();
+                if (!context.Handler.HandleTriple(new Triple(subj, pred, obj)))
+                {
+                    ParserHelper.Stop();
+                }
             }
 
             // Go back over Attributes looking for property attributes
@@ -720,7 +723,10 @@ namespace VDS.RDF.Parsing
                         var uriref = new UriReferenceEvent(attr.Value, attr.SourceXml);
                         obj = Resolve(context, uriref, element.BaseUri);
 
-                        if (!context.Handler.HandleTriple(new Triple(subj, pred, obj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(subj, pred, obj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                     else
                     {
@@ -737,7 +743,10 @@ namespace VDS.RDF.Parsing
                             obj = context.Handler.CreateLiteralNode(attr.Value, element.Language);
                         }
 
-                        if (!context.Handler.HandleTriple(new Triple(subj, pred, obj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(subj, pred, obj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
             }

--- a/Libraries/dotNetRdf/Parsing/RdfAParserBase.cs
+++ b/Libraries/dotNetRdf/Parsing/RdfAParserBase.cs
@@ -759,7 +759,10 @@ namespace VDS.RDF.Parsing
                 {
                     foreach (INode dtObj in ParseComplexAttribute(context, evalContext, GetAttribute(currElement, "typeof")))
                     {
-                        if (!context.Handler.HandleTriple(new Triple(newSubj, rdfType, dtObj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(newSubj, rdfType, dtObj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
             }
@@ -776,14 +779,20 @@ namespace VDS.RDF.Parsing
                 {
                     foreach (INode pred in ParseComplexAttribute(context, evalContext, GetAttribute(currElement, "rel")))
                     {
-                        if (!context.Handler.HandleTriple(new Triple(newSubj, pred, currObj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(newSubj, pred, currObj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
                 if (rev)
                 {
                     foreach (INode pred in ParseComplexAttribute(context, evalContext, GetAttribute(currElement, "rev")))
                     {
-                        if (!context.Handler.HandleTriple(new Triple(currObj, pred, newSubj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(currObj, pred, newSubj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
             }
@@ -930,7 +939,10 @@ namespace VDS.RDF.Parsing
                 {
                     foreach (INode pred in ParseAttribute(context, evalContext, GetAttribute(currElement, "property")))
                     {
-                        if (!context.Handler.HandleTriple(new Triple(newSubj, pred, currLiteral))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(newSubj, pred, currLiteral)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
             }
@@ -946,11 +958,17 @@ namespace VDS.RDF.Parsing
                 {
                     if (i.Direction == IncompleteTripleDirection.Forward)
                     {
-                        if (!context.Handler.HandleTriple(new Triple(evalContext.ParentSubject, i.Predicate, newSubj))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(evalContext.ParentSubject, i.Predicate, newSubj)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                     else
                     {
-                        if (!context.Handler.HandleTriple(new Triple(newSubj, i.Predicate, evalContext.ParentSubject))) ParserHelper.Stop();
+                        if (!context.Handler.HandleTriple(new Triple(newSubj, i.Predicate, evalContext.ParentSubject)))
+                        {
+                            ParserHelper.Stop();
+                        }
                     }
                 }
             }

--- a/Libraries/dotNetRdf/Parsing/TriGParser.cs
+++ b/Libraries/dotNetRdf/Parsing/TriGParser.cs
@@ -1053,8 +1053,11 @@ namespace VDS.RDF.Parsing
 
                 ok = true;
 
-                var triple = new Triple(subj, pred, objNode, graphNode);
-                if (!context.Handler.HandleTriple(triple)) ParserHelper.Stop();
+                var triple = new Triple(subj, pred, objNode);
+                if (!context.Handler.HandleQuad(triple, graphNode))
+                {
+                    ParserHelper.Stop();
+                }
 
                 next = context.Tokens.Peek();
                 if (next.TokenType == Token.STARTANNOTATION)
@@ -1205,21 +1208,21 @@ namespace VDS.RDF.Parsing
                 }
 
                 // Create the subj rdf:first item Triple
-                if (!context.Handler.HandleTriple((new Triple(subj, rdfFirst, item, graphNode)))) ParserHelper.Stop();
+                if (!context.Handler.HandleQuad(new Triple(subj, rdfFirst, item), graphNode)) ParserHelper.Stop();
 
                 // Create the rdf:rest Triple
                 if (context.Tokens.Peek().TokenType == Token.RIGHTBRACKET)
                 {
                     // End of Collection
                     context.Tokens.Dequeue();
-                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, rdfNil, graphNode))) ParserHelper.Stop();
+                    if (!context.Handler.HandleQuad(new Triple(subj, rdfRest, rdfNil), graphNode)) ParserHelper.Stop();
                     return;
                 }
                 else
                 {
                     // Continuing Collection
                     temp = context.Handler.CreateBlankNode();
-                    if (!context.Handler.HandleTriple(new Triple(subj, rdfRest, temp, graphNode))) ParserHelper.Stop();
+                    if (!context.Handler.HandleQuad(new Triple(subj, rdfRest, temp), graphNode)) ParserHelper.Stop();
                     subj = (IBlankNode)temp;
                 }
             } while (true);

--- a/Libraries/dotNetRdf/Parsing/TriXParser.cs
+++ b/Libraries/dotNetRdf/Parsing/TriXParser.cs
@@ -313,7 +313,11 @@ namespace VDS.RDF.Parsing
             }
 
             // Assert the resulting Triple
-            if (!handler.HandleTriple(new Triple(subj, pred, obj, graphUri))) ParserHelper.Stop();
+            IRefNode graphName = graphUri == null ? null : handler.CreateUriNode(graphUri);
+            if (!handler.HandleQuad(new Triple(subj, pred, obj), graphName))
+            {
+                ParserHelper.Stop();
+            }
         }
 
         private INode TryParseNode(XmlReader reader, IRdfHandler handler, TripleSegment segment, IUriFactory uriFactory)

--- a/Libraries/dotNetRdf/Storage/BaseAsyncSafeConnector.cs
+++ b/Libraries/dotNetRdf/Storage/BaseAsyncSafeConnector.cs
@@ -102,6 +102,14 @@ namespace VDS.RDF.Storage
         /// <summary>
         /// Updates a Graph in the Store.
         /// </summary>
+        /// <param name="graphName">Name of the Graph to update.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        public abstract void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals);
+
+        /// <summary>
+        /// Updates a Graph in the Store.
+        /// </summary>
         /// <param name="graphUri">URI of the Graph to update.</param>
         /// <param name="additions">Triples to be added.</param>
         /// <param name="removals">Triples to be removed.</param>

--- a/Libraries/dotNetRdf/Storage/BaseStardogConnector.cs
+++ b/Libraries/dotNetRdf/Storage/BaseStardogConnector.cs
@@ -611,6 +611,19 @@ namespace VDS.RDF.Storage
             }
         }
 
+        /// <inheritdoc />
+        public void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            if (graphName is IUriNode u)
+            {
+                UpdateGraph(u.Uri, additions, removals);
+            }
+            else
+            {
+                throw new RdfStorageException("Updating a blank-node named graph is not supported.");
+            }
+        }
+
         /// <summary>
         /// Updates a Graph in the Stardog Store.
         /// </summary>
@@ -700,6 +713,7 @@ namespace VDS.RDF.Storage
                 throw;
             }
         }
+
 
         /// <summary>
         /// Updates a Graph in the Stardog store.

--- a/Libraries/dotNetRdf/Storage/DatasetFileManager.cs
+++ b/Libraries/dotNetRdf/Storage/DatasetFileManager.cs
@@ -225,6 +225,12 @@ namespace VDS.RDF.Storage
             throw new RdfStorageException("The DatasetFileManager provides a read-only connection");
         }
 
+        /// <inheritdoc />
+        public override void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            throw new RdfStorageException("The DatasetFileManager provides a read-only connection");
+        }
+
         /// <summary>
         /// Returns that Updates are not supported since this is a read-only connection.
         /// </summary>

--- a/Libraries/dotNetRdf/Storage/IStorageProvider.cs
+++ b/Libraries/dotNetRdf/Storage/IStorageProvider.cs
@@ -121,6 +121,27 @@ namespace VDS.RDF.Storage
         /// <summary>
         /// Updates a Graph in the Store.
         /// </summary>
+        /// <param name="graphName">Name of the Graph to update.</param>
+        /// <param name="additions">Triples to add to the Graph.</param>
+        /// <param name="removals">Triples to remove from the Graph.</param>
+        /// <remarks>
+        /// <para>
+        /// <strong>Note:</strong> Not all Stores are capable of supporting update at the individual Triple level and as such it is acceptable for such a Store to throw a <see cref="NotSupportedException">NotSupportedException</see> or an <see cref="RdfStorageException">RdfStorageException</see> if the Store cannot provide this functionality.
+        /// </para>
+        /// <para>
+        /// Behaviour of this method with regards to non-existent Graph is up to the implementor, it may create a new empty Graph and apply the updates to that or it may throw an error.  Implementors <strong>should</strong> state in the XML comments for their implementation what behaviour is implemented.
+        /// </para>
+        /// <para>
+        /// Implementers <strong>MUST</strong> allow for either the additions or removals argument to be null.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="NotSupportedException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level.</exception>
+        /// <exception cref="RdfStorageException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level or if some error occurs while attempting the Update.</exception>
+        void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals);
+
+        /// <summary>
+        /// Updates a Graph in the Store.
+        /// </summary>
         /// <param name="graphUri">Uri of the Graph to update.</param>
         /// <param name="additions">Triples to add to the Graph.</param>
         /// <param name="removals">Triples to remove from the Graph.</param>
@@ -137,6 +158,7 @@ namespace VDS.RDF.Storage
         /// </remarks>
         /// <exception cref="NotSupportedException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level.</exception>
         /// <exception cref="RdfStorageException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level or if some error occurs while attempting the Update.</exception>
+        [Obsolete("Replaced by UpdateGraph(IRefNode, IEnumerable<Triple>, IEnumerable<Triple>)")]
         void UpdateGraph(Uri graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals);
 
         /// <summary>
@@ -158,6 +180,7 @@ namespace VDS.RDF.Storage
         /// </remarks>
         /// <exception cref="NotSupportedException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level.</exception>
         /// <exception cref="RdfStorageException">May be thrown if the underlying Store is not capable of doing Updates at the Triple level or if some error occurs while attempting the Update.</exception>
+        [Obsolete("Replaced by UpdateGraph(IRefNode, IEnumerable<Triple>, IEnumerable<Triple>)")] 
         void UpdateGraph(string graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals);
 
         /// <summary>

--- a/Libraries/dotNetRdf/Storage/InMemoryManager.cs
+++ b/Libraries/dotNetRdf/Storage/InMemoryManager.cs
@@ -173,19 +173,7 @@ namespace VDS.RDF.Storage
         public override void UpdateGraph(Uri graphUri, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
         {
             IRefNode graphName = graphUri == null ? null : new UriNode(graphUri);
-            if (!_dataset.HasGraph(graphName))
-            {
-                _dataset.AddGraph(new Graph(graphName));
-            }
-
-            if ((additions != null && additions.Any()) || (removals != null && removals.Any()))
-            {
-                IGraph g = _dataset.GetModifiableGraph(graphName);
-                if (additions != null && additions.Any()) g.Assert(additions.ToList());
-                if (removals != null && removals.Any()) g.Retract(removals.ToList());
-            }
-
-            _dataset.Flush();
+            UpdateGraph(graphName, additions, removals);
         }
 
         /// <summary>
@@ -198,16 +186,37 @@ namespace VDS.RDF.Storage
         {
             if (graphUri == null)
             {
-                UpdateGraph((Uri)null, additions, removals);
+                UpdateGraph((IRefNode)null, additions, removals);
             }
             else if (graphUri.Equals(string.Empty))
             {
-                UpdateGraph((Uri)null, additions, removals);
+                UpdateGraph((IRefNode)null, additions, removals);
             }
             else
             {
-                UpdateGraph(UriFactory.Create(graphUri), additions, removals);
+                UpdateGraph(new UriNode(UriFactory.Create(graphUri)), additions, removals);
             }
+        }
+
+        /// <inheritdoc />
+        public override void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            if (!_dataset.HasGraph(graphName))
+            {
+                _dataset.AddGraph(new Graph(graphName));
+            }
+
+            var addList = additions?.ToList();
+            var removeList = removals?.ToList();
+
+            if ((addList != null && addList.Any()) || (removeList != null && removeList.Any()))
+            {
+                IGraph g = _dataset.GetModifiableGraph(graphName);
+                if (addList != null && addList.Any()) g.Assert(addList);
+                if (removeList != null && removeList.Any()) g.Retract(removeList);
+            }
+
+            _dataset.Flush();
         }
 
         /// <summary>

--- a/Libraries/dotNetRdf/Storage/ParsingSparqlConnector.cs
+++ b/Libraries/dotNetRdf/Storage/ParsingSparqlConnector.cs
@@ -283,6 +283,17 @@ namespace VDS.RDF.Storage
         }
 
         /// <summary>
+        /// Throws an error since this Manager is read-only.
+        /// </summary>
+        /// <param name="graphName">Graph name.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        public virtual void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            throw new RdfStorageException("The SparqlConnector provides a read-only connection");
+        }
+
+        /// <summary>
         /// Returns that Updates are not supported since this connection is read-only.
         /// </summary>
         public virtual bool UpdateSupported

--- a/Libraries/dotNetRdf/Storage/ReadOnlyConnector.cs
+++ b/Libraries/dotNetRdf/Storage/ReadOnlyConnector.cs
@@ -153,6 +153,18 @@ namespace VDS.RDF.Storage
         }
 
         /// <summary>
+        /// Throws an exception since you cannot update a Graph using a read-only connection.
+        /// </summary>
+        /// <param name="graphName">Name of the Graph.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        /// <exception cref="RdfStorageException">Thrown since you cannot update a Graph using a read-only connection.</exception>
+        public void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            throw new RdfStorageException("The Read-Only Connector is a read-only connection");
+        }
+
+        /// <summary>
         /// Returns that Update is not supported.
         /// </summary>
         public bool UpdateSupported

--- a/Libraries/dotNetRdf/Storage/SparqlConnector.cs
+++ b/Libraries/dotNetRdf/Storage/SparqlConnector.cs
@@ -384,6 +384,17 @@ namespace VDS.RDF.Storage
         }
 
         /// <summary>
+        /// Throws an error since this Manager is read-only.
+        /// </summary>
+        /// <param name="graphName">Graph name.</param>
+        /// <param name="additions">Triples to be added.</param>
+        /// <param name="removals">Triples to be removed.</param>
+        public virtual void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            throw new RdfStorageException("The SparqlConnector provides a read-only connection");
+        }
+
+        /// <summary>
         /// Returns that Updates are not supported since this connection is read-only.
         /// </summary>
         public virtual bool UpdateSupported

--- a/Libraries/dotNetRdf/Storage/SparqlHttpProtocolConnector.cs
+++ b/Libraries/dotNetRdf/Storage/SparqlHttpProtocolConnector.cs
@@ -383,6 +383,12 @@ namespace VDS.RDF.Storage
             }
         }
 
+        /// <inheritdoc />
+        public virtual void UpdateGraph(IRefNode graphName, IEnumerable<Triple> additions, IEnumerable<Triple> removals)
+        {
+            UpdateGraph(graphName.ToSafeString(), additions, removals);
+        }
+
         /// <summary>
         /// Deletes a Graph from the store.
         /// </summary>

--- a/Libraries/dotNetRdf/Update/LeviathanUpdateProcessor.cs
+++ b/Libraries/dotNetRdf/Update/LeviathanUpdateProcessor.cs
@@ -1115,7 +1115,7 @@ namespace VDS.RDF.Update
                                     try
                                     {
                                         Triple t = p.Construct(constructContext);
-                                        t = new Triple(t.Subject, t.Predicate, t.Object, destUri);
+                                        t = new Triple(t.Subject, t.Predicate, t.Object);
                                         insertedTriples.Add(t);
                                     }
                                     catch (RdfQueryException)

--- a/Libraries/dotNetRdf/Writing/Formatting/BaseFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/BaseFormatter.cs
@@ -106,6 +106,18 @@ namespace VDS.RDF.Writing.Formatting
         }
 
         /// <summary>
+        /// Formats a triple in the context of a graph as a string.
+        /// </summary>
+        /// <param name="t">The triple.</param>
+        /// <param name="graph">The graph containing the triple.</param>
+        /// <returns></returns>
+        public virtual string Format(Triple t, IRefNode graph)
+        {
+            if (graph == null) return this.Format(t);
+            throw new RdfOutputException(WriterErrorMessages.QuadsUnserializable(_format));
+        }
+
+        /// <summary>
         /// Formats a URI Node as a String for the given Format.
         /// </summary>
         /// <param name="u">URI Node.</param>

--- a/Libraries/dotNetRdf/Writing/Formatting/IQuadFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/IQuadFormatter.cs
@@ -3,7 +3,7 @@
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
 // 
-// Copyright (c) 2009-2021 dotNetRDF Project (http://dotnetrdf.org/)
+// Copyright (c) 2009-2022 dotNetRDF Project (http://dotnetrdf.org/)
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,39 +23,18 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // </copyright>
 */
+namespace VDS.RDF.Writing.Formatting;
 
-namespace VDS.RDF.Writing.Formatting
+/// <summary>
+/// Interface for formatting triples in the context of a graph.
+/// </summary>
+public interface IQuadFormatter
 {
     /// <summary>
-    /// Interface for formatters designed to format entire RDF Graphs.
+    /// Formats a triple in the context of a graph as a string.
     /// </summary>
-    public interface IGraphFormatter : ITripleFormatter
-    {
-        /// <summary>
-        /// Generates the header section for the Graph.
-        /// </summary>
-        /// <param name="g">Graph.</param>
-        /// <returns></returns>
-        string FormatGraphHeader(IGraph g);
-
-        /// <summary>
-        /// Generates the header section for the Graph.
-        /// </summary>
-        /// <param name="namespaces">Namespaces.</param>
-        /// <param name="uriFactory">UriFactory to use when creating new Uri instances.</param>
-        /// <returns></returns>
-        string FormatGraphHeader(INamespaceMapper namespaces, IUriFactory uriFactory=null);
-
-        /// <summary>
-        /// Generates a generic header section.
-        /// </summary>
-        /// <returns></returns>
-        string FormatGraphHeader();
-
-        /// <summary>
-        /// Generates the footer section.
-        /// </summary>
-        /// <returns></returns>
-        string FormatGraphFooter();
-    }
+    /// <param name="t">Triple.</param>
+    /// <param name="graph">Containing graph name.</param>
+    /// <returns></returns>
+    string Format(Triple t, IRefNode graph);
 }

--- a/Libraries/dotNetRdf/Writing/Formatting/IQuadFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/IQuadFormatter.cs
@@ -23,18 +23,19 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // </copyright>
 */
-namespace VDS.RDF.Writing.Formatting;
-
-/// <summary>
-/// Interface for formatting triples in the context of a graph.
-/// </summary>
-public interface IQuadFormatter
+namespace VDS.RDF.Writing.Formatting
 {
     /// <summary>
-    /// Formats a triple in the context of a graph as a string.
+    /// Interface for formatting triples in the context of a graph.
     /// </summary>
-    /// <param name="t">Triple.</param>
-    /// <param name="graph">Containing graph name.</param>
-    /// <returns></returns>
-    string Format(Triple t, IRefNode graph);
+    public interface IQuadFormatter
+    {
+        /// <summary>
+        /// Formats a triple in the context of a graph as a string.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <param name="graph">Containing graph name.</param>
+        /// <returns></returns>
+        string Format(Triple t, IRefNode graph);
+    }
 }

--- a/Libraries/dotNetRdf/Writing/Formatting/NQuadsFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/NQuadsFormatter.cs
@@ -24,7 +24,6 @@
 // </copyright>
 */
 
-using System;
 using VDS.RDF.Parsing;
 
 namespace VDS.RDF.Writing.Formatting
@@ -33,7 +32,7 @@ namespace VDS.RDF.Writing.Formatting
     /// Formatter which formats Triples as NQuads adding an additional URI at the end of the Triple if there is a Graph URI associated with the Triple.
     /// </summary>
     public class NQuadsFormatter
-        : NTriplesFormatter
+        : NTriplesFormatter, IQuadFormatter
     {
         /// <summary>
         /// Creates a new NQuads Formatter.
@@ -73,17 +72,18 @@ namespace VDS.RDF.Writing.Formatting
         }
 
         /// <summary>
-        /// Formats a Triple as a String.
+        /// Formats a Triple (optionally in the context of a graph) as a String.
         /// </summary>
         /// <param name="t">Triple.</param>
+        /// <param name="graph">The graph containing the triple.</param>
         /// <returns></returns>
-        public override string Format(Triple t)
+        public override string Format(Triple t, IRefNode graph)
         {
-            if (t.GraphUri == null)
+            if (graph == null)
             {
                 return base.Format(t);
             }
-            return Format(t.Subject, TripleSegment.Subject) + " " + Format(t.Predicate, TripleSegment.Predicate) + " " + Format(t.Object, TripleSegment.Object) + " <" + FormatUri(t.GraphUri) + "> .";
+            return Format(t.Subject, TripleSegment.Subject) + " " + Format(t.Predicate, TripleSegment.Predicate) + " " + Format(t.Object, TripleSegment.Object) + " " + Format(graph) + " .";
         }
     }
 

--- a/Libraries/dotNetRdf/Writing/Formatting/NTriplesFormatter.cs
+++ b/Libraries/dotNetRdf/Writing/Formatting/NTriplesFormatter.cs
@@ -109,6 +109,12 @@ namespace VDS.RDF.Writing.Formatting
         /// </summary>
         public NTriplesSyntax Syntax { get; private set; }
 
+        /// <inheritdoc />
+        public override string Format(Triple t, IRefNode graph)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Formats a URI Node.
         /// </summary>

--- a/Libraries/dotNetRdf/Writing/NQuadsWriter.cs
+++ b/Libraries/dotNetRdf/Writing/NQuadsWriter.cs
@@ -212,20 +212,10 @@ namespace VDS.RDF.Writing
             output.Append(NodeToNTriples(context, t.Predicate, TripleSegment.Predicate));
             output.Append(" ");
             output.Append(NodeToNTriples(context, t.Object, TripleSegment.Object));
-            if (t.GraphName != null || graphName != null)
+            if (graphName != null)
             {
-                // Favour graph name rather than per-triple graph name because we may have a triple with a different graph name than the containing graph
-                if (graphName != null)
-                {
-                    output.Append(" ");
-                    output.Append(context.NodeFormatter.Format(graphName));
-                }
-                else
-                {
-                    output.Append(" <");
-                    output.Append(context.NodeFormatter.Format(t.GraphName));
-                    output.Append(">");
-                }
+                output.Append(" ");
+                output.Append(context.NodeFormatter.Format(graphName));
             }
             output.Append(" .");
 

--- a/Libraries/dotNetRdf/Writing/WriterUtilities.cs
+++ b/Libraries/dotNetRdf/Writing/WriterUtilities.cs
@@ -97,51 +97,75 @@ namespace VDS.RDF.Writing
         /// Error message produced when a User attempts to serialize a Graph containing Graph Literals.
         /// </summary>
         private const string GraphLiteralsUnserializableError = "Graph Literal Nodes are not serializable in {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing Unknown Node Types.
         /// </summary>
         private const string UnknownNodeTypeUnserializableError = "Unknown Node Types cannot be serialized as {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing Triples with Literal Subjects.
         /// </summary>
-        private const string LiteralSubjectsUnserializableError = "Triples with a Literal Subject are not serializable in {0}";
+        private const string LiteralSubjectsUnserializableError =
+            "Triples with a Literal Subject are not serializable in {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing Triples with Literal Predicates.
         /// </summary>
-        private const string LiteralPredicatesUnserializableError = "Triples with a Literal Predicate are not serializable in {0}";
+        private const string LiteralPredicatesUnserializableError =
+            "Triples with a Literal Predicate are not serializable in {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialized a Graph containing Triples with Graph Literal Predicates.
         /// </summary>
-        private const string GraphLiteralPredicatesUnserializableError = "Triples with a Graph Literal Predicate are not serializable in {0}";
+        private const string GraphLiteralPredicatesUnserializableError =
+            "Triples with a Graph Literal Predicate are not serializable in {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing Triples with Blank Node Predicates.
         /// </summary>
-        private const string BlankPredicatesUnserializableError = "Triples with a Blank Node Predicate are not serializable in {0}";
+        private const string BlankPredicatesUnserializableError =
+            "Triples with a Blank Node Predicate are not serializable in {0}";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing URIs which cannot be reduced to a URIRef or QName as required by the serialization.
         /// </summary>
-        public const string UnreducablePropertyURIUnserializable = "Unable to serialize this Graph since a Property has an unreducable URI";
+        public const string UnreducablePropertyURIUnserializable =
+            "Unable to serialize this Graph since a Property has an unreducable URI";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Graph containing collections where a collection item has more than one rdf:first triple.
         /// </summary>
-        public const string MalformedCollectionWithMultipleFirsts = "This RDF Graph contains more than one rdf:first Triple for an Item in a Collection which means the Graph is not serializable";
+        public const string MalformedCollectionWithMultipleFirsts =
+            "This RDF Graph contains more than one rdf:first Triple for an Item in a Collection which means the Graph is not serializable";
+
         /// <summary>
         /// Error messages produced when errors occur in a multi-threaded writing process.
         /// </summary>
-        public const string ThreadedOutputError = "One/more errors occurred while outputting RDF in {0} using a multi-threaded writing process";
+        public const string ThreadedOutputError =
+            "One/more errors occurred while outputting RDF in {0} using a multi-threaded writing process";
+
         /// <summary>
         /// Error message produced when a User attempts to serialize a Variable Node in a format which does not support it.
         /// </summary>
         public const string VariableNodesUnserializableError = "Variable Nodes cannot be serialized as {0}";
+
         /// <summary>
         /// Error message produced when a user attempts to serialize a TripleNode in a format which does not support it.
         /// </summary>
         public const string TripleNodesUnserializableError = "Triple Nodes cannot be serialized as {0}";
+
         /// <summary>
         /// Error message produced when a user attempts to serialize a triple containing a TripleNode predicates.
         /// </summary>
         public const string TripleNodePredicateUnserializableError =
             "Triples with a Triple Node Predicate are not serializable in {0}";
+
+        /// <summary>
+        /// Error message produced when a user attempts to serialize a triple an a non-null graph name via a format that supports only triples.
+        /// </summary>
+        public const string QuadsUnserializableError =
+            "Triples in a graph (quads) are not serializable in {0}";
 
         /// <summary>
         /// Gets an Error message indicating that Graph Literals are not serializable with the appropriate RDF format name inserted in the error.
@@ -241,6 +265,11 @@ namespace VDS.RDF.Writing
         public static string TripleNodePredicateUnserializable(string format)
         {
             return string.Format(TripleNodePredicateUnserializableError, format);
+        }
+
+        public static string QuadsUnserializable(string format)
+        {
+            return string.Format(QuadsUnserializableError, format);
         }
     }
 

--- a/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
+++ b/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
@@ -411,17 +411,18 @@ namespace VDS.RDF.JsonLd
         private static void FixStringLiterals(ITripleStore store)
         {
             var xsdString = new Uri("http://www.w3.org/2001/XMLSchema#string");
-            foreach (Triple t in store.Triples.ToList())
+            foreach (IGraph graphToUpdate in store.Graphs)
             {
-                var literalNode = t.Object as ILiteralNode;
-                if (literalNode != null && String.IsNullOrEmpty(literalNode.Language) && literalNode.DataType == null)
+                foreach (Triple t in graphToUpdate.Triples.ToList())
                 {
-                    IGraph graphToUpdate = t.Graph;
-                    graphToUpdate.Retract(t);
-                    graphToUpdate.Assert(
-                        new Triple(t.Subject, t.Predicate,
-                            graphToUpdate.CreateLiteralNode(literalNode.Value, xsdString),
-                            graphToUpdate.BaseUri));
+                    if (t.Object is ILiteralNode literalNode && string.IsNullOrEmpty(literalNode.Language) &&
+                        literalNode.DataType == null)
+                    {
+                        graphToUpdate.Retract(t);
+                        graphToUpdate.Assert(
+                            new Triple(t.Subject, t.Predicate,
+                                graphToUpdate.CreateLiteralNode(literalNode.Value, xsdString)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Simplify Triple by removing the Graph component. This requires a change to IRdfHandler to support processing quads now that the graph is not carried in the Triple itself but it also removes an ambiguity about the purpose of Triple.Graph.