### PR TITLE
Update NuGet package metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,21 +2,32 @@
 
   <PropertyGroup>
     <!-- Default Assembly metadata -->
-    <Copyright>Copyright © dotNetRDF Project 2009-2021</Copyright>
-
+    <Copyright>Copyright © dotNetRDF Project 2009-2022</Copyright>
+    <!-- Default Build Options -->
+    <CodeAnalysisRuleSet>../../dotnetrdf.ruleset</CodeAnalysisRuleSet>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <PropertyGroup>
 	  <!-- Default NuGet Package metadata -->
     <PackageTags>RDF;Semantic;Web;SPARQL;RDF/XML;Turtle;Notation3</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>http://www.dotnetrdf.org</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequiresLicenseAcceptance>false</RequiresLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnetrdf/dotnetrdf</RepositoryUrl>
     <Authors>RobVesse;tpluscode;kal_ahmed;ronmichael;dotnetrdf</Authors>
+    <PackageIcon>icon.png</PackageIcon>
+    <!--
+      NB: Ideally this section would contain a common PackageReadmeFile property.
+      However the current version of NuGet fails to properly pack the file/resolve the packed file.
+      As a result the README is included separately in each .csproj file -->
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="/"/>
+    <None Include="../../icon.png" pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/Libraries/dotNetRdf.AspNet/dotNetRdf.AspNet.csproj
+++ b/Libraries/dotNetRdf.AspNet/dotNetRdf.AspNet.csproj
@@ -3,13 +3,22 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.AspNet</AssemblyName>
     <AssemblyTitle>dotNetRDF ASP.NET Support</AssemblyTitle>
-    <Description>Provides a framework for building RDF-powered ASP.NET web applications and web APIs.</Description>
-    <PackageId>dotNetRdf.AspNet</PackageId>
-    <PackageTags>RDF;Semantic;Web;SPARQL;Web API</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <RootNamespace>VDS.RDF</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.AspNet</PackageId>
+    <Title>dotNetRDF ASP.NET Support</Title>
+    <Description>Provides a framework for building RDF-powered ASP.NET web applications and web APIs.</Description>
+    <PackageTags>RDF;Semantic;Web;SPARQL;Web API</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Update\Protocol\" />

--- a/Libraries/dotNetRdf.Client/dotNetRdf.Client.csproj
+++ b/Libraries/dotNetRdf.Client/dotNetRdf.Client.csproj
@@ -1,16 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Client</AssemblyName>
     <AssemblyTitle>dotNetRDF Triple Store Client Library</AssemblyTitle>
-    <Description>Provides a framework for interacting with a variety of open-source and commercial triple-stores.</Description>
-    <PackageId>dotNetRdf.Client</PackageId>
-    <PackageTags>RDF;Client;Allegrograph;Sesame;4Store;Fuseki;Jena</PackageTags>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <RootNamespace>VDS.RDF</RootNamespace>
-    <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Client</PackageId>
+    <Title>dotNetRDF Triple Store Client Library</Title>
+    <Description>Provides a framework for interacting with a variety of open-source and commercial triple-stores.</Description>
+    <PackageTags>RDF;Client;Allegrograph;Sesame;4Store;Fuseki;Jena</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Configuration\" />

--- a/Libraries/dotNetRdf.Data.DataTables/dotNetRdf.Data.DataTables.csproj
+++ b/Libraries/dotNetRdf.Data.DataTables/dotNetRdf.Data.DataTables.csproj
@@ -3,18 +3,28 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Data.DataTables</AssemblyName>
     <AssemblyTitle>dotNetRDF DataTables</AssemblyTitle>
-    <Description>Package which allow integrating dotNetRDF with System.Data.DataTable</Description>
-    <PackageId>dotNetRdf.Data.DataTables</PackageId>
-    <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <RootNamespace>VDS.RDF.Data.DataTables</RootNamespace>
-    <VersionPrefix>$(Version)</VersionPrefix>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Data.DataTables</PackageId>
+    <Title>dotNetRDF DataTables</Title>
+    <Description>Package which allow integrating dotNetRDF with System.Data.DataTable</Description>
+    <PackageTags>RDF;Semantic;Web;DataTables</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />
   </ItemGroup>
 

--- a/Libraries/dotNetRdf.Data.Virtuoso/dotNetRdf.Data.Virtuoso.csproj
+++ b/Libraries/dotNetRdf.Data.Virtuoso/dotNetRdf.Data.Virtuoso.csproj
@@ -3,17 +3,22 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Data.Virtuoso</AssemblyName>
     <AssemblyTitle>dotNetRDF Virtuoso connector</AssemblyTitle>
-    <Description>Provides support for using OpenLink Virtuoso as a backend triplestore with dotNetRDF</Description>
-    <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>net472</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>dotNetRdf.Data.Virtuoso</PackageId>
-    <PackageTags>RDF;Semantic;Web;SPARQL;Virtuoso;OpenLink</PackageTags>
-    <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
     <RootNamespace>VDS.RDF.Storage</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Data.Virtuoso</PackageId>
+    <Title>dotNetRDF Virtuoso connector</Title>
+    <Description>Provides support for using OpenLink Virtuoso as a backend triplestore with dotNetRDF</Description>
+    <PackageTags>RDF;Semantic;Web;SPARQL;Virtuoso;OpenLink</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />

--- a/Libraries/dotNetRdf.Dynamic/dotNetRdf.Dynamic.csproj
+++ b/Libraries/dotNetRdf.Dynamic/dotNetRdf.Dynamic.csproj
@@ -1,14 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Dynamic</AssemblyName>
     <AssemblyTitle>dotNetRDF Dynamic API</AssemblyTitle>
-    <Description>Provides an API for manipulating RDF graphs using .NET dynamic objects.</Description>
-    <PackageId>dotNetRdf.Dynamic</PackageId>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <RootNamespace>VDS.RDF.Dynamic</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Dynamic</PackageId>
+    <Title>dotNetRDF Dynamic Objects API</Title>
+    <Description>Provides an API for manipulating RDF graphs using .NET dynamic objects.</Description>
+    <PackageTags>RDF;dynamic;objects</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleToSuffix Include=".Tests"/>

--- a/Libraries/dotNetRdf.Inferencing/dotNetRdf.Inferencing.csproj
+++ b/Libraries/dotNetRdf.Inferencing/dotNetRdf.Inferencing.csproj
@@ -3,12 +3,22 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Inferencing</AssemblyName>
     <AssemblyTitle>dotNetRDF Inferencing Support</AssemblyTitle>
-    <Description>Adds support for basic inferencing from an RDF Schema/Ontology</Description>
-    <PackageId>dotNetRdf.Inferencing</PackageId>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <RootNamespace>VDS.RDF</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Inferencing</PackageId>
+    <Title>dotNetRDF Inferencing Support</Title>
+    <Description>Adds support for basic inferencing from an RDF Schema/Ontology</Description>
+    <PackageTags>RDF;RDFSchema;OWL;Inference</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Ontology\" />

--- a/Libraries/dotNetRdf.Ontology/dotNetRdf.Ontology.csproj
+++ b/Libraries/dotNetRdf.Ontology/dotNetRdf.Ontology.csproj
@@ -1,16 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Ontology</AssemblyName>
     <AssemblyTitle>dotNetRDF Ontology API</AssemblyTitle>
-    <Description>Provides a convenience API for creating RDF graphs that contain RDF Schema/Ontology data.</Description>
-    <PackageId>dotNetRdf.Ontology</PackageId>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Ontology</PackageId>
+    <Title>dotNetRDF Ontology API</Title>
+    <Description>Provides a convenience API for creating RDF graphs that contain RDF Schema/Ontology data.</Description>
+    <PackageTags>RDF;Semantic;Web;RDF Schema;OWL</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Writing\**" />

--- a/Libraries/dotNetRdf.Query.FullText/dotNetRdf.Query.FullText.csproj
+++ b/Libraries/dotNetRdf.Query.FullText/dotNetRdf.Query.FullText.csproj
@@ -3,17 +3,22 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Query.FullText</AssemblyName>
     <AssemblyTitle>dotNetRDF Full Text Query Support</AssemblyTitle>
-    <Description>Provides Full Text SPARQL support as a plugin for the dotNetRDF Leviathan SPARQL Engine using Lucene.Net</Description>
-    <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>dotNetRdf.Query.FullText</PackageId>
-    <PackageTags>RDF;Semantic;Web;SPARQL;Query;Full;Text;Lucene</PackageTags>
-    <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
     <RootNamespace>VDS.RDF.Query</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Query.FullText</PackageId>
+    <Title>dotNetRDF Full Text Query Support</Title>
+    <Description>Provides Full Text SPARQL support as a plugin for the dotNetRDF Leviathan SPARQL Engine using Lucene.Net</Description>
+    <PackageTags>RDF;Semantic;Web;SPARQL;Query;Full;Text;Lucene</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="FullText.ttl" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />

--- a/Libraries/dotNetRdf.Query.Spin/dotNetRdf.Query.Spin.csproj
+++ b/Libraries/dotNetRdf.Query.Spin/dotNetRdf.Query.Spin.csproj
@@ -3,17 +3,22 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Query.Spin</AssemblyName>
     <AssemblyTitle>dotNetRDF SPIN Support</AssemblyTitle>
-    <Description>A library which provides a full SPIN implementation using dotNetRDF's Leviathan SPARQL engine</Description>
-    <VersionPrefix>$(Version)</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>dotNetRdf.Query.Spin</PackageId>
-    <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
     <RootNamespace>VDS.RDF.Query.Spin</RootNamespace>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Query.Spin</PackageId>
+    <Title>dotNetRDF SPIN Support</Title>
+    <Description>A library which provides a full SPIN implementation using dotNetRDF's Leviathan SPARQL engine</Description>
+    <PackageTags>RDF;Semantic;Web;SPARQL;Inference;SPIN</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Constraints\SPINConstraints.cs;Core\ContainsVarChecker.cs;Core\ObjectPropertiesGetter.cs;Core\SPINUtil.cs;Util\DatasetUtil.cs" />

--- a/Libraries/dotNetRdf.Shacl/dotNetRdf.Shacl.csproj
+++ b/Libraries/dotNetRdf.Shacl/dotNetRdf.Shacl.csproj
@@ -1,14 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Shacl</AssemblyName>
     <AssemblyTitle>dotNetRdf SHACL Support</AssemblyTitle>
-    <Description>Provides support for validating RDF graphs with the W3C Shape Constraint Language.</Description>
-    <PackageId>dotNetRdf.Shacl</PackageId>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <RootNamespace>VDS.RDF.Shacl</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Shacl</PackageId>
+    <Title>dotNetRdf SHACL Support</Title>
+    <Description>Provides support for validating RDF graphs with the W3C Shape Constraint Language.</Description>
+    <PackageTags>RDF;Validation;Shapes;Constraint;SHACL</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />

--- a/Libraries/dotNetRdf.Skos/dotNetRdf.Skos.csproj
+++ b/Libraries/dotNetRdf.Skos/dotNetRdf.Skos.csproj
@@ -2,14 +2,23 @@
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Skos</AssemblyName>
-    <AssemblyTitle>dotNetRdf SKOS API</AssemblyTitle>
-    <Description>Provides a convience API for working the RDF graphs that contain SKOS Concept Schemes.</Description>
+    <AssemblyTitle>dotNetRDF SKOS API</AssemblyTitle>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <RootNamespace>VDS.RDF.Skos</RootNamespace>
-    <PackageId>dotNetRdf.Skos</PackageId>
-    <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Skos</PackageId>
+    <AssemblyTitle>dotNetRDF SKOS API</AssemblyTitle>
+    <Description>Provides a convience API for working the RDF graphs that contain SKOS Concept Schemes.</Description>
+    <PackageTags>RDF;SKOS;Taxonomy</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dotNetRdf\dotNetRdf.csproj" />

--- a/Libraries/dotNetRdf.Writing.HtmlSchema/dotNetRdf.Writing.HtmlSchema.csproj
+++ b/Libraries/dotNetRdf.Writing.HtmlSchema/dotNetRdf.Writing.HtmlSchema.csproj
@@ -1,13 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>dotNetRdf.Writing.HtmlSchema</AssemblyName>
     <AssemblyTitle>dotNetRDF HTML Schema Writer</AssemblyTitle>
-    <Description>Provides an RDF writer that exports the RDF Schema/Ontology information in a graph as an HTML documentation page</Description>
-    <PackageId>dotNetRdf.Writing.HtmlSchema</PackageId>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>VDS.RDF</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf.Writing.HtmlSchema</PackageId>
+    <Title>dotNetRDF HTML Schema Writer</Title>
+    <Description>Provides an RDF writer that exports the RDF Schema/Ontology information in a graph as an HTML documentation page</Description>
+    <PackageTags>RDF;Schema;Documentation;HTML</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Writing\" />

--- a/Libraries/dotNetRdf/dotNetRdf.csproj
+++ b/Libraries/dotNetRdf/dotNetRdf.csproj
@@ -3,18 +3,23 @@
   <PropertyGroup>
     <AssemblyName>dotNetRdf</AssemblyName>
     <AssemblyTitle>dotNetRDF</AssemblyTitle>
-    <VersionPrefix>$(Version)</VersionPrefix>
-    <Description>dotNetRDF is a RDF, SPARQL and Semantic Web API for .Net.  It provides simple but powerfully extensible APIs for this and integrates with a variety of popular triple stores.</Description>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>dotNetRdf</PackageId>
-    <CodeAnalysisRuleSet>..\..\dotnetrdf.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>VDS.RDF</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <LangVersion>latest</LangVersion>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>   
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet Package Metadata. Additional values are inherited from ../Directory.Build.props -->
+    <PackageId>dotNetRdf</PackageId>
+    <Title>dotNetRDF Core Library</Title>
+    <Description>dotNetRDF is an RDF, SPARQL and Linked Datat API for .Net.  It provides simple but powerfully extensible APIs for this and integrates with a variety of popular triple stores.</Description>
+    <PackageTags>RDF;Semantic;Web;Linked Data;SPARQL;RDF/XML;Turtle;Notation3;JSON-LD;RDFStar</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="dotNetRdf.Test" />

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ![Build status](https://github.com/dotnetrdf/dotnetrdf/actions/workflows/build.yaml/badge.svg)
 
-
----
-
-**WARNING** You are currently looking at the branch for development of the upcoming dotNetRDF 3.0 release.
-If you are looking for the code for the current dotNetRDF 2.x release [please check out the `maintenance/2.x` branch](https://github.com/dotnetrdf/dotnetrdf/tree/maintenance/2.x)
-
 ---
 
 dotNetRDF is a powerful and flexible API for working with RDF and SPARQL in .NET environments.
@@ -15,6 +9,7 @@ dotNetRDF is a powerful and flexible API for working with RDF and SPARQL in .NET
 dotNetRDF is licensed under the MIT License, see the LICENSE.txt file in this repository
 
 The `main` branch of this repository is now used for development of dotNetRDF 3.0. This major update is currently a work in progress and introduces a number of breaking API changes, new features including support for [RDF-Star and SPARQL-Star](https://w3c.github.io/rdf-star/cg-spec), and it also restructures the packaging of the code to minimize dependencies and better separate out core functionality from higher-level APIs.
+If you are looking for the code for the dotNetRDF 2.x release series [please check out the `maintenance/2.x` branch](https://github.com/dotnetrdf/dotnetrdf/tree/maintenance/2.x)
 
 The restructured NuGet packages for dotNetRDF 3.0 are:
 

--- a/dotNetRdf.sln
+++ b/dotNetRdf.sln
@@ -24,11 +24,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake
+		.github\workflows\build.yaml = .github\workflows\build.yaml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		dotnetrdf.ruleset = dotnetrdf.ruleset
 		.github\workflows\publish.yaml = .github\workflows\publish.yaml
-		.github\workflows\build.yaml = .github\workflows\build.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SparqlAnalyzer", "Testing\SparqlAnalyzer\SparqlAnalyzer.csproj", "{B19AD698-11F5-486E-B534-00262F751700}"


### PR DESCRIPTION
* Extract common properties do Directory.Build.props
* Update other properties (title, description and tags) for each packaged project separately.
* Add a reference to the top-level README.md of the repo in each NuGet package
* Remove the warning about this being the 3.0 development branch from the README
* Move the reference to the 2.x maintenance branch into the body of the README text.

NOTE: The `dotnet pack` command fails when the `PackageReadmeFile` property is made a common property in `Directory.Build.props` so it is instead specified in each packaged project.

Closes #469 