### PR TITLE
Add ] and ) to characters allowed after an empty string

### DIFF
--- a/Libraries/dotNetRdf/Parsing/Tokens/TurtleTokeniser.cs
+++ b/Libraries/dotNetRdf/Parsing/Tokens/TurtleTokeniser.cs
@@ -423,7 +423,7 @@ namespace VDS.RDF.Parsing.Tokens
                                                 quotemarksallowed = true;
                                                 longliteral = true;
                                             }
-                                            else if (char.IsWhiteSpace(next) || next == '.' || next == ';' || next == ',' || next == '^' || next == '@')
+                                            else if (char.IsWhiteSpace(next) || next is '.' or ';' or ',' or '^' or '@' or ']' or ')')
                                             {
                                                 // Empty String
                                                 LastTokenType = Token.LITERAL;
@@ -511,7 +511,7 @@ namespace VDS.RDF.Parsing.Tokens
                                                     altquotemarksallowed = true;
                                                     altlongliteral = true;
                                                 }
-                                                else if (char.IsWhiteSpace(next) || next == '.' || next == ';' || next == ',' || next == '^' || next == '@')
+                                                else if (char.IsWhiteSpace(next) || next is '.' or ';' or ',' or '^' or '@' or ']' or ')')
                                                 {
                                                     // Empty String
                                                     LastTokenType = Token.LITERAL;


### PR DESCRIPTION
At the moment, `TurtleParser` fails with this input:
```ttl
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
_:x rdf:value [rdf:value ""].
```
The reason is that the tokenizer does not understand `]` after `""`, since it is not in the list of the characters that may be directly after `""` (or `''`). This adds `]`, and `)` too, for lists.