### PR TITLE
Fix more build workflow warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,12 +38,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Tests
-        run: dotnet test -c Release --filter "Category!=explicit&Category!=performance" --framework ${{ matrix.framework }} --collect:"XPlat Code Coverage" Testing/${{matrix.suite}}
-      - name: Upload Code Coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-ubuntu ${{matrix.suite}} ${{matrix.framework}}
-          path: Testing\${{matrix.suite}}\TestResults\**\coverage.cobertura.xml
+        run: dotnet test -c Release --filter "Category!=explicit&Category!=performance" --framework ${{ matrix.framework }} Testing/${{matrix.suite}}
 
   fusekiTests:
     runs-on: ubuntu-latest
@@ -95,9 +90,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Generate coverage report
-      uses: danielpalme/ReportGenerator-GitHub-Action@4.5.8
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.10
       with:
         reports: '*\*\*.xml'
         targetdir: 'coveragereport'


### PR DESCRIPTION
* Remove coverage generation and upload from linux tests
* Update download-artifact@v2 to @v3
* Update ReportGenerator-GitHub-Action@4.5.8 to @5.1.0