### PR TITLE
Add line ending normalization for .csproj files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.cs text
+*.csproj text
 Testing/dotNetRdf.Tests/resources/turtle/*   -text
 Testing/dotNetRdf.Tests/resources/turtle11/*   -text
 Testing/dotNetRdf.Tests/resources/turtle11-unofficial/*   -text


### PR DESCRIPTION
Ensure .csproj files are treated as text files.