### PR TITLE
Confirm #542 is fixed

### DIFF
--- a/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
@@ -249,5 +249,15 @@ namespace VDS.RDF.Parsing
             Assert.Single(store.Graphs);
             Assert.Single(store.Triples);
         }
+
+        [Fact]
+        public void ParsingPrefixWithDot()
+        {
+            const string data = "@prefix exdata: <https://example.com/data/>. exdata:test1 { exdata:test.1 a <http://example.com/Thing> .}";
+            var store = new TripleStore();
+            store.LoadFromString(data, new TriGParser(TriGSyntax.Rdf11));
+            Assert.Single(store.Graphs);
+            Assert.Single(store.Triples);
+        }
     }
 }


### PR DESCRIPTION
Add unit test to confirm that the updated TriG parser handles a dot in the reference part of a CURIE