### PR TITLE
Fix package build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
         echo "NuGetPreReleaseTag: ${{ steps.gitversion.outputs.NuGetPreReleaseTag }}"
         
     - name: Build solution
-      run: dotnet pack -o nugets --configuration=Release -p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}
+      run: dotnet pack --configuration=Release -p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }} -p:PackageOutputPath=../../nugets
       
     - name: Upload NuGet Packages
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Modify pack command to use PackageOutputPath property rather than -o flag.

Fixes #547 