### PR TITLE
Add Format(Triple) to CsvFormatter

### DIFF
--- a/Libraries/dotNetRdf.Core/Writing/Formatting/CsvFormatter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/Formatting/CsvFormatter.cs
@@ -25,6 +25,7 @@
 */
 
 using System.Linq;
+using System.Text;
 
 namespace VDS.RDF.Writing.Formatting
 {
@@ -39,6 +40,23 @@ namespace VDS.RDF.Writing.Formatting
         /// </summary>
         public CsvFormatter()
             : base("CSV") { }
+
+        /// <summary>
+        /// Formats a Triple for CSV output.
+        /// </summary>
+        /// <param name="t">Triple.</param>
+        /// <returns></returns>
+        public override string Format(Triple t)
+        {
+            var output = new StringBuilder();
+            output.Append(Format(t.Subject));
+            output.Append(',');
+            output.Append(Format(t.Predicate));
+            output.Append(',');
+            output.Append(Format(t.Object));
+            output.Append("\r\n");
+            return output.ToString();
+        }
 
         /// <summary>
         /// Formats URIs for CSV output.


### PR DESCRIPTION
`CsvFormatter` derives from `BaseFormatter` and as such inherits its `Format` method producing Turtle-like strings when triples are formatted. This simply overrides the `Format` method to produce results comparable to `CsvWriter`, in case `CsvFormatter` is used instead (through `WriteThroughHandler` for example).