### PR TITLE
Add support for more lax language tag validation

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,8 @@
 ﻿Change Log
 ==========
 
+ENHANCEMENT: Language tag validation in the `NodeFactory` now supports three modes. `LanguageTagValidationMode.None` disables langauge tag validation. `LanguageTagValidationMode.Turtle` validates language tags against the more relaxed definition in the Turtle 1.1 specification. `LanguageTagValidationMode.WellFormed` validates language tags against the stricter BCP-47 production for well-formed tags. The default validation mode is now set to `LanguageTagValidationMode.Turtle`. The properties `NodeFactory.ValidateLanguageTags` and `NodeFactoryOptions.ValidateLanguageTags` are both deprecated and replaced by `INodeFactory.LanguageTagValidation` and `NodeFactoryOptions.LanguageTagValidation` respectively. Thanks to @IS4Code for their suggestions and input on this. (#565)
+
 3.0.1
 -----
 

--- a/Libraries/dotNetRdf.Core/Core/BaseGraph.cs
+++ b/Libraries/dotNetRdf.Core/Core/BaseGraph.cs
@@ -174,6 +174,12 @@ namespace VDS.RDF
         public virtual bool NormalizeLiteralValues { get; set; } = Options.LiteralValueNormalization;
 #pragma warning restore CS0618 // Type or member is obsolete
 
+        /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => NodeFactory.LanguageTagValidation;
+            set => NodeFactory.LanguageTagValidation = value;
+        }
         #endregion
 
         #region Triple Assertion & Retraction

--- a/Libraries/dotNetRdf.Core/Core/GraphPersistenceWrapper.cs
+++ b/Libraries/dotNetRdf.Core/Core/GraphPersistenceWrapper.cs
@@ -147,6 +147,13 @@ namespace VDS.RDF
             set => _g.UriFactory = value;
         }
 
+        /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => _g.LanguageTagValidation;
+            set => _g.LanguageTagValidation = value;
+        }
+
         /// <inheritdoc/>
         public IEnumerable<INode> Nodes => _g.Nodes;
 

--- a/Libraries/dotNetRdf.Core/Core/INodeFactory.cs
+++ b/Libraries/dotNetRdf.Core/Core/INodeFactory.cs
@@ -144,6 +144,11 @@ namespace VDS.RDF
         bool NormalizeLiteralValues { get; set; }
 
         /// <summary>
+        /// Get or set the type of validation to apply to language tags when creating language-tagged literal nodes.
+        /// </summary>
+        LanguageTagValidationMode LanguageTagValidation { get; set; }
+
+        /// <summary>
         /// Resolve a QName to a URI using this factory's <see cref="NamespaceMap"/> and <see cref="BaseUri"/>.
         /// </summary>
         /// <param name="qName"></param>

--- a/Libraries/dotNetRdf.Core/Core/LanguageTagValidationMode.cs
+++ b/Libraries/dotNetRdf.Core/Core/LanguageTagValidationMode.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 // <copyright>
 // dotNetRDF is free and open source software licensed under the MIT License
 // -------------------------------------------------------------------------
@@ -24,35 +24,28 @@
 // </copyright>
 */
 
-using System;
-
 namespace VDS.RDF
 {
     /// <summary>
-    /// Configuration options that can be passed to the <see cref="NodeFactory"/> constructor.
+    /// Enumeration of the forms of language tag validation supported by the library.
     /// </summary>
-    public class NodeFactoryOptions
+    public enum LanguageTagValidationMode
     {
         /// <summary>
-        /// The initial base URI to use for the resolution of relative URI references. Defaults to null.
+        /// Do not perform any validation on language tags
         /// </summary>
-        public Uri BaseUri { get; set; }
-
+        None = 0,
         /// <summary>
-        /// Whether or not to normalize the value strings of literal nodes.
+        /// Validate language tags against the production defined in the Turtle 1.1 specification
         /// </summary>
-        public bool NormalizeLiteralValues { get; set; }
-
+        /// <remarks>
+        /// <para>The Turtle 1.1 grammar requires a language tag to match the production: <code>'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*</code>.</para>
+        /// <para>NOTE: This validation is more lax than the <see cref="WellFormed"/> validation option.</para>
+        /// </remarks>
+        Turtle = 1,
         /// <summary>
-        /// Whether or not to validate the language specifier of language-tagged literal nodes.
+        /// Validate that language tags are well-formed according to the rules defined by the BCP-47 specification.
         /// </summary>
-        [Obsolete("Replaced by NodeFactoryOptions.LanguageTagValidation")]
-        public bool ValidateLanguageSpecifiers { get; set; } = true;
-
-        /// <summary>
-        /// Set the type of validation applied to the language specified of language tagged literal nodes.
-        /// </summary>
-        public LanguageTagValidationMode LanguageTagValidation { get; set; } = LanguageTagValidationMode.Turtle;
-
+        WellFormed = 2,
     }
 }

--- a/Libraries/dotNetRdf.Core/Core/WrapperGraph.cs
+++ b/Libraries/dotNetRdf.Core/Core/WrapperGraph.cs
@@ -114,6 +114,14 @@ namespace VDS.RDF
         }
 
         /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => _g.LanguageTagValidation;
+            set => _g.LanguageTagValidation = value;
+        }
+
+
+        /// <inheritdoc />
         public virtual IEnumerable<INode> Nodes => _g.Nodes;
 
 

--- a/Libraries/dotNetRdf.Core/Parsing/Handlers/BaseHandler.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/Handlers/BaseHandler.cs
@@ -66,6 +66,13 @@ namespace VDS.RDF.Parsing.Handlers
             set => _factory.NormalizeLiteralValues = value;
         }
 
+        /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => _factory.LanguageTagValidation;
+            set => _factory.LanguageTagValidation = value;
+        }
+
         /// <summary>
         /// Resolve a QName to a URI using the handler's underlying node factory to provide the <see cref="INodeFactory.NamespaceMap"/> and <see cref="INodeFactory.BaseUri"/>.
         /// </summary>

--- a/Libraries/dotNetRdf.Core/Parsing/LanguageTag.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/LanguageTag.cs
@@ -82,8 +82,8 @@ namespace VDS.RDF.Parsing
             IrregularGrandfatheredTags.Concat(RegularGrandfatheredTags)
                 .ToDictionary(k => k.ToLowerInvariant(), v => true);
         
-        private static readonly Regex TestRegex = new Regex("(?<language>([a-zA-Z]{2,3}(-(?<extlang>[a-zA-Z]{3}(-[a-zA-Z]{3}){0,2}))?) | ([a-zA-Z]{4,8}))");
-        private static readonly Regex WellFormedTagRegex = new Regex(
+        private static readonly Regex TurtleTagRegex = new("^[a-zA-Z]+(-[a-zA-Z0-9]+)*$");
+        private static readonly Regex WellFormedTagRegex = new(
             "^(?<language>([a-zA-Z]{2,3}(-(?<extlang>[a-zA-Z]{3}(-[a-zA-Z]{3}){0,2}))?)|([a-zA-Z]{4,8}))" +
             "(-(?<script>[a-zA-Z]{4}))?" +
             "(-(?<region>[a-zA-Z]{2}|[0-9]{3}))?" +
@@ -100,6 +100,16 @@ namespace VDS.RDF.Parsing
         {
             return GrandfatheredTagsLookup.ContainsKey(languageTag.ToLowerInvariant()) ||
                    WellFormedTagRegex.IsMatch(languageTag);
+        }
+
+        /// <summary>
+        /// Determine if a string is valid against the LANGTAG production in the Turtle 1.1 specification
+        /// </summary>
+        /// <param name="languageTag">The string to check.</param>
+        /// <returns>True if <paramref name="languageTag"/> matches the Turtle 1.1 definition of /^[a-zA-Z]+(-[a-zA-Z0-9]+)*$/ .</returns>
+        public static bool IsValidTurtle(string languageTag)
+        {
+            return TurtleTagRegex.IsMatch(languageTag);
         }
     }
 }

--- a/Libraries/dotNetRdf.Core/Parsing/RdfAPatternCopyingHandler.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/RdfAPatternCopyingHandler.cs
@@ -159,6 +159,13 @@ namespace VDS.RDF.Parsing
         }
 
         /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => _innerHandler.LanguageTagValidation;
+            set => _innerHandler.LanguageTagValidation = value;
+        }
+        
+        /// <inheritdoc />
         public Uri ResolveQName(string qName)
         {
             return _innerHandler.ResolveQName(qName);

--- a/Libraries/dotNetRdf.Query.Spin/SpinWrappedGraph.cs
+++ b/Libraries/dotNetRdf.Query.Spin/SpinWrappedGraph.cs
@@ -199,6 +199,13 @@ namespace VDS.RDF.Query.Spin
         }
 
         /// <inheritdoc />
+        public LanguageTagValidationMode LanguageTagValidation
+        {
+            get => LanguageTagValidationMode.None;
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
         public IUriNode CreateUriNode()
         {
             throw new NotImplementedException();

--- a/Testing/dotNetRdf.Tests/Core/LiteralNodeTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/LiteralNodeTests.cs
@@ -197,7 +197,8 @@ namespace VDS.RDF
         public void LanguageTagsAreValidated()
         {
             IGraph g = new Graph();
-            Assert.Throws<ArgumentException>(() => g.CreateLiteralNode("example", ValidTurtleLanguageSpecifier));
+            // By default Turtle validation is used
+            g.CreateLiteralNode("example", ValidTurtleLanguageSpecifier);
             Assert.Throws<ArgumentException>(() => g.CreateLiteralNode("example", InvalidLanguageSpecifier));
         }
 

--- a/Testing/dotNetRdf.Tests/Core/LiteralNodeTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/LiteralNodeTests.cs
@@ -190,20 +190,40 @@ namespace VDS.RDF
             Assert.Single(g.GetTriplesWithObject(ucase));
         }
 
-        const string InvalidLanguageSpecifier = "ab-12";
+        const string ValidTurtleLanguageSpecifier = "ab-12";
+        private const string InvalidLanguageSpecifier = "ab12";
 
         [Fact]
         public void LanguageTagsAreValidated()
         {
             IGraph g = new Graph();
+            Assert.Throws<ArgumentException>(() => g.CreateLiteralNode("example", ValidTurtleLanguageSpecifier));
             Assert.Throws<ArgumentException>(() => g.CreateLiteralNode("example", InvalidLanguageSpecifier));
         }
 
         [Fact]
         public void LanguageTagValidationCanBeDisabled()
         {
-            IGraph g = new Graph(null, new NodeFactory(new NodeFactoryOptions() { ValidateLanguageSpecifiers = false }));
+            IGraph g = new Graph(null, new NodeFactory(new NodeFactoryOptions() { LanguageTagValidation = LanguageTagValidationMode.None }));
+            g.CreateLiteralNode("example", ValidTurtleLanguageSpecifier);
             g.CreateLiteralNode("example", InvalidLanguageSpecifier);
+        }
+
+        [Fact]
+        public void LanguageTagValidationCanBeTurtle()
+        {
+            IGraph g = new Graph(null, new NodeFactory(new NodeFactoryOptions() { LanguageTagValidation = LanguageTagValidationMode.Turtle }));
+            g.CreateLiteralNode("example", ValidTurtleLanguageSpecifier);
+            Assert.Throws<ArgumentException>(() => g.CreateLiteralNode("example", InvalidLanguageSpecifier));
+        }
+
+        [Fact]
+        public void EmptyLanguageTagsAreNotValidated()
+        {
+            IGraph g1 = new Graph(null, new NodeFactory(new NodeFactoryOptions() { LanguageTagValidation = LanguageTagValidationMode.WellFormed }));
+            IGraph g2 = new Graph(null, new NodeFactory(new NodeFactoryOptions() { LanguageTagValidation = LanguageTagValidationMode.Turtle }));
+            g1.CreateLiteralNode("example", "");
+            g2.CreateLiteralNode("example", "");
         }
 
         [Fact]

--- a/Testing/dotNetRdf.Tests/Core/WrapperNodeTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/WrapperNodeTests.cs
@@ -32,6 +32,8 @@ namespace VDS.RDF
 {
     public class WrapperNodeTests
     {
+        private readonly NodeFactory _factory = new(new NodeFactoryOptions());
+
         [Fact]
         public void Requires_underlying_node()
         {
@@ -42,7 +44,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_object()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var nodeObject = node as object;
             var wrapper = new MockWrapperNode(node);
 
@@ -55,7 +57,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_GetHashCode()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.GetHashCode();
@@ -67,7 +69,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_ToString()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.ToString();
@@ -79,11 +81,11 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_NodeType()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
-            var expected = node.NodeType;
-            var actual = wrapper.NodeType;
+            NodeType expected = node.NodeType;
+            NodeType actual = wrapper.NodeType;
 
             Assert.Equal(expected, actual);
         }
@@ -91,7 +93,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_node()
         {
-            var node = new NodeFactory().CreateBlankNode() as INode;
+            var node = _factory.CreateBlankNode() as INode;
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -103,7 +105,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_blank()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -115,7 +117,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_graphLiteral()
         {
-            var node = new NodeFactory().CreateGraphLiteralNode();
+            IGraphLiteralNode node = _factory.CreateGraphLiteralNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -127,7 +129,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_literal()
         {
-            var node = new NodeFactory().CreateLiteralNode(string.Empty);
+            ILiteralNode node = _factory.CreateLiteralNode(string.Empty);
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -139,7 +141,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_uri()
         {
-            var node = new NodeFactory().CreateUriNode(UriFactory.Root.Create("http://example.com/"));
+            IUriNode node = _factory.CreateUriNode(UriFactory.Root.Create("http://example.com/"));
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -151,7 +153,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_CompareTo_variable()
         {
-            var node = new NodeFactory().CreateVariableNode(string.Empty);
+            IVariableNode node = _factory.CreateVariableNode(string.Empty);
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.CompareTo(node);
@@ -163,7 +165,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_node()
         {
-            var node = new NodeFactory().CreateBlankNode() as INode;
+            var node = _factory.CreateBlankNode() as INode;
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -175,7 +177,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_blank()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -187,7 +189,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_graphLiteral()
         {
-            var node = new NodeFactory().CreateGraphLiteralNode();
+            IGraphLiteralNode node = _factory.CreateGraphLiteralNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -199,7 +201,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_literal()
         {
-            var node = new NodeFactory().CreateLiteralNode(string.Empty);
+            ILiteralNode node = _factory.CreateLiteralNode(string.Empty);
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -211,7 +213,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_uri()
         {
-            var node = new NodeFactory().CreateUriNode(UriFactory.Root.Create("http://example.com/"));
+            IUriNode node = _factory.CreateUriNode(UriFactory.Root.Create("http://example.com/"));
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -223,7 +225,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Equals_variable()
         {
-            var node = new NodeFactory().CreateVariableNode(string.Empty);
+            IVariableNode node = _factory.CreateVariableNode(string.Empty);
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.Equals(node);
@@ -235,7 +237,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_ToString_formatter()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             var expected = node.ToString(new CsvFormatter());
@@ -247,7 +249,7 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_ToString_formatter_segment()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
             var formatter = new CsvFormatter();
 
@@ -260,7 +262,7 @@ namespace VDS.RDF
         [Fact]
         public void Fails_invalid_InternalID()
         {
-            var node = new NodeFactory().CreateLiteralNode(string.Empty);
+            ILiteralNode node = _factory.CreateLiteralNode(string.Empty);
             var wrapper = new MockWrapperNode(node);
 
             Assert.Throws<InvalidCastException>(() =>
@@ -271,7 +273,7 @@ namespace VDS.RDF
         public void Delegates_InternalID()
         {
             var expected = new Guid().ToString();
-            var node = new NodeFactory().CreateBlankNode(expected);
+            IBlankNode node = _factory.CreateBlankNode(expected);
             var wrapper = new MockWrapperNode(node);
 
             var actual = ((IBlankNode)wrapper).InternalID;
@@ -282,7 +284,7 @@ namespace VDS.RDF
         [Fact]
         public void Fails_invalid_Uri()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             Assert.Throws<InvalidCastException>(() =>
@@ -292,11 +294,11 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_Uri()
         {
-            var expected = UriFactory.Root.Create("urn:s");
-            var node = new NodeFactory().CreateUriNode(expected);
+            Uri expected = UriFactory.Root.Create("urn:s");
+            IUriNode node = _factory.CreateUriNode(expected);
             var wrapper = new MockWrapperNode(node);
 
-            var actual = ((IUriNode)wrapper).Uri;
+            Uri actual = ((IUriNode)wrapper).Uri;
 
             Assert.Equal(expected, actual);
         }
@@ -304,7 +306,7 @@ namespace VDS.RDF
         [Fact]
         public void Fails_invalid_Value()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             Assert.Throws<InvalidCastException>(() =>
@@ -315,7 +317,7 @@ namespace VDS.RDF
         public void Delegates_Value()
         {
             var expected = string.Empty;
-            var node = new NodeFactory().CreateLiteralNode(expected);
+            ILiteralNode node = _factory.CreateLiteralNode(expected);
             var wrapper = new MockWrapperNode(node);
 
             var actual = ((ILiteralNode)wrapper).Value;
@@ -326,7 +328,7 @@ namespace VDS.RDF
         [Fact]
         public void Fails_invalid_Language()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             Assert.Throws<InvalidCastException>(() =>
@@ -337,7 +339,7 @@ namespace VDS.RDF
         public void Delegates_Language()
         {
             var expected = "en";
-            var node = new NodeFactory().CreateLiteralNode(string.Empty, expected);
+            ILiteralNode node = _factory.CreateLiteralNode(string.Empty, expected);
             var wrapper = new MockWrapperNode(node);
 
             var actual = ((ILiteralNode)wrapper).Language;
@@ -348,7 +350,7 @@ namespace VDS.RDF
         [Fact]
         public void Fails_invalid_DataType()
         {
-            var node = new NodeFactory().CreateBlankNode();
+            IBlankNode node = _factory.CreateBlankNode();
             var wrapper = new MockWrapperNode(node);
 
             Assert.Throws<InvalidCastException>(() =>
@@ -358,11 +360,11 @@ namespace VDS.RDF
         [Fact]
         public void Delegates_DataType()
         {
-            var expected = UriFactory.Root.Create("urn:s");
-            var node = new NodeFactory().CreateLiteralNode(string.Empty, expected);
+            Uri expected = UriFactory.Root.Create("urn:s");
+            ILiteralNode node = _factory.CreateLiteralNode(string.Empty, expected);
             var wrapper = new MockWrapperNode(node);
 
-            var actual = ((ILiteralNode)wrapper).DataType;
+            Uri actual = ((ILiteralNode)wrapper).DataType;
 
             Assert.Equal(expected, actual);
         }

--- a/docs/user_guide/core_concepts.md
+++ b/docs/user_guide/core_concepts.md
@@ -147,7 +147,10 @@ IBlankNode named = g.CreateBlankNode("ID");
 
 ### Literal Nodes
 
-Literal Nodes are used to refer to actual data values. Values may be plain, language specific or typed. A plain literal is simply textual content while a language specific literal is textual content with a language specified in the form of a country code eg. en-GB, en-US, fr. Finally a typed literal is textual content associated with a Data Type URI which indicates the type of the data represented by the literal. Note that a typed literals Data Type does not guarantee that the content of that literal will be of that type.
+Literal Nodes are used to refer to actual data values.
+Values may be plain, language specific or typed. A plain literal is simply textual content while a language specific literal is textual content with a language specified in the form of a country code eg. en-GB, en-US, fr.
+Finally a typed literal is textual content associated with a Data Type URI which indicates the type of the data represented by the literal.
+Note that a typed literal's Data Type does not guarantee that the content of that literal will be of that type.
 
 A [ILiteralNode](xref:VDS.RDF.ILiteralNode) is constructed as follows:
 
@@ -178,6 +181,11 @@ ILiteralNode aurevoir = g.CreateLiteralNode("au revior","fr");
 ILiteralNode two = g.CreateLiteralNode("2", UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeInteger));
 ILiteralNode f = g.CreateLiteralNode("false", UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeBoolean));
 ```
+
+> [!NOTE]
+> When you create a literal node using a `Graph` or `NodeFactory`'s `CreateLiteralNode` method, any langauge tag you provide will be validated according to that factory's langauge tag validation mode.
+> Creating a `LiteralNode` using its public constructor does not provide this additional layer of validation.
+> For more information about the langauge tag validation please refer to [Node Factory](node_factory.md).
 
 ### Triple Nodes
 

--- a/docs/user_guide/node_factory.md
+++ b/docs/user_guide/node_factory.md
@@ -26,6 +26,12 @@ The [`UriFactory`](xref:VDS.RDF.INodeFactory.UriFactory) property can be used to
 The [`NormalizeLiteralValues`](xref:VDS.RDF.INodeFactory.NormalizeLiteralValues) property is a flag that can be set to control whether or not the factory applies Unicode normalization to string literals when creating new literal nodes.
 Unicode normalization can aid in more meaningful string comparison when dealing with strings with composing characters.
 
+The [`LanguageTagValidation`](xref:VDS.RDF.INodeFactory.LanguageTagValidation) property specifies what sort of validation to apply to the language specifier of a literal node. The property currently supports three values:
+
+  * [`LangaugeTagValidationMode.None`](xref:VDS.RDF.LangaugeTagValidationMode.None) - no validation is performed
+  * [`LangaugeTagValidationMode.Turtle`](xref:VDS.RDF.LangaugeTagValidationMode.Turtle) - langauge tags are validated to be conformant with the Turtle 1.1 specification. This allows a language tag to match the regular expression [a-zA-Z]+(-[a-zA-Z0-9]+])*. This is less restrictive than the WellFormed mode which imposes some length constraints and other constraints on individual sub-tags. This is the default mode and is restrictive enough to ensure that other RDF processing tools will handle the langauge tags in your data.
+  * [`LangaugeTagValidationMode.WellFormed](xref:VDS.RDF.LangaugeTagValidationMode.WellFormed) - language tags are validated to be well-formed according to the productions of the BCP-47 specification. This includes allowing the grandfathered regular and irregular tags. Use this mode if you are expecting to process or parse the langauge tags in your data with tools that expect to be dealing with BCP-47 language tags.
+
 ## NodeFactory class
 
 The [`NodeFactory`](xref:VDS.RDF.NodeFactory) class provides the default library implementation of the [`INodeFactory`](xref:VDS.RDF.INodeFactory) interface.


### PR DESCRIPTION
* Add "lax" language tag validation based on the Turtle 1.1 specification in addition to "strict" BCP-47 well-formed tag validation.
* Add a LanguageTagValidation property to INodeFactory and to NodeFactoryOptions to set which type of validation to use.
* Deprecated ValidateLanguageTags property on NodeFactory and NodeFactoryOptions (you now use LanguageTagValidationMode.None to disable validation)
* Update langauge tag validation in the NodeFactory implementation to ignore empty strings (i.e. to always treat these as valid "not present" language tags)

Addresses #565