### PR TITLE
Fixes for WriterHelper.FindCollections

### DIFF
--- a/Libraries/dotNetRdf.Core/Writing/PrettyRdfXmlWriter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/PrettyRdfXmlWriter.cs
@@ -264,7 +264,7 @@ namespace VDS.RDF.Writing
             // Take care of any collections that weren't yet written
             foreach (KeyValuePair<INode, OutputRdfCollection> kvp in context.Collections)
             {
-                if (!kvp.Value.HasBeenWritten)
+                if (!kvp.Value.HasBeenWritten && kvp.Value.Triples.Count > 0)
                 {
                     // Generate a rdf:Description node and then write the collection
                     context.Writer.WriteStartElement("rdf", "Description", NamespaceMapper.RDF);
@@ -657,6 +657,10 @@ namespace VDS.RDF.Writing
 
                 // rdf:rest Node
                 context.Writer.WriteStartElement("rdf", "rest", NamespaceMapper.RDF);
+                if (c.Triples.Count > 0)
+                {
+                    context.Writer.WriteAttributeString("rdf", "parseType", NamespaceMapper.RDF, "Resource");
+                }
             }
             // Terminate the list and close all the open rdf:rest elements
             context.Writer.WriteAttributeString("rdf", "resource", NamespaceMapper.RDF, RdfSpecsHelper.RdfListNil);

--- a/Testing/dotNetRdf.Tests/Writing/WriterHelperTests.cs
+++ b/Testing/dotNetRdf.Tests/Writing/WriterHelperTests.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using VDS.RDF.Parsing;
+using VDS.RDF.Writing.Contexts;
+using Xunit;
+
+namespace VDS.RDF.Writing
+{
+    public class WriterHelperTests
+    {
+        private Dictionary<INode, OutputRdfCollection> FindImplicitCollections(IGraph g)
+        {
+            var sw = new System.IO.StringWriter();
+            var context = new CompressingTurtleWriterContext(g, sw);
+            WriterHelper.FindCollections(context, CollectionSearchMode.ImplicitOnly);
+            return context.Collections;
+        }
+
+        [Fact]
+        public void FindCollectionsIgnoresNodeWithNoRdfFirst()
+        {
+            var g= new Graph();
+            INode rdfFirst = g.CreateUriNode("rdf:first");
+            INode rdfRest = g.CreateUriNode("rdf:rest");
+            INode rdfNil = g.CreateUriNode("rdf:nil");
+            INode listRoot = g.CreateBlankNode();
+            INode listNode = g.CreateBlankNode();
+            g.Assert(listRoot, rdfFirst, g.CreateLiteralNode("first"));
+            g.Assert(listRoot, rdfRest, listNode);
+            g.Assert(listNode, rdfRest, rdfNil);
+
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Empty(collections);
+        }
+
+        [Fact]
+        public void FindCollectionsIgnoresRootWithNoRdfFirst()
+        {
+            var g = new Graph();
+            INode rdfFirst = g.CreateUriNode("rdf:first");
+            INode rdfRest = g.CreateUriNode("rdf:rest");
+            INode rdfNil = g.CreateUriNode("rdf:nil");
+            INode listRoot = g.CreateBlankNode("root");
+            INode listNode = g.CreateBlankNode("node");
+            g.Assert(listRoot, rdfRest, listNode);
+            g.Assert(listNode, rdfFirst, g.CreateLiteralNode("first"));
+            g.Assert(listNode, rdfRest, rdfNil);
+
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Empty(collections);
+        }
+
+        [Fact]
+        public void FindCollectionsIgnoresRootWithMultipleRdfFirst()
+        {
+            var g = new Graph();
+            g.NamespaceMap.AddNamespace("ex", UriFactory.Create("http://example.org/"));
+            INode rdfFirst = g.CreateUriNode("rdf:first");
+            INode rdfRest = g.CreateUriNode("rdf:rest");
+            INode rdfNil = g.CreateUriNode("rdf:nil");
+            INode listRoot = g.CreateBlankNode("root");
+            INode listNode = g.CreateBlankNode("node");
+
+            g.Assert(g.CreateUriNode("ex:s"), g.CreateUriNode("ex:p"), listRoot);
+            g.Assert(listRoot, rdfFirst, g.CreateLiteralNode("first"));
+            g.Assert(listRoot, rdfFirst, g.CreateLiteralNode("another first"));
+            g.Assert(listRoot, rdfRest, listNode);
+            g.Assert(listNode, rdfFirst, g.CreateLiteralNode("second"));
+            g.Assert(listNode, rdfRest, rdfNil);
+
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Empty(collections);
+        }
+
+        [Fact]
+        public void FindCollectionsIgnoresNodeWithMultipleRdfFirst()
+        {
+            var g = new Graph();
+            g.NamespaceMap.AddNamespace("ex", UriFactory.Create("http://example.org/"));
+            INode rdfFirst = g.CreateUriNode("rdf:first");
+            INode rdfRest = g.CreateUriNode("rdf:rest");
+            INode rdfNil = g.CreateUriNode("rdf:nil");
+            INode listRoot = g.CreateBlankNode("root");
+            INode listNode = g.CreateBlankNode("node");
+
+            g.Assert(g.CreateUriNode("ex:s"), g.CreateUriNode("ex:p"), listRoot);
+            g.Assert(listRoot, rdfFirst, g.CreateLiteralNode("first"));
+            g.Assert(listRoot, rdfRest, listNode);
+            g.Assert(listNode, rdfFirst, g.CreateLiteralNode("second"));
+            g.Assert(listNode, rdfFirst, g.CreateLiteralNode("another second"));
+            g.Assert(listNode, rdfRest, rdfNil);
+
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Empty(collections);
+        }
+
+        [Fact]
+        public void FindCollectionsIgnoresUnterminatedList()
+        {
+            var g = new Graph();
+            INode rdfFirst = g.CreateUriNode("rdf:first");
+            INode rdfRest = g.CreateUriNode("rdf:rest");
+            INode l = g.CreateBlankNode();
+            INode m = g.CreateBlankNode();
+            g.Assert(l, rdfFirst, g.CreateLiteralNode("first"));
+            g.Assert(l, rdfRest, m);
+            g.Assert(m, rdfFirst, g.CreateLiteralNode("second"));
+
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Empty(collections);
+        }
+
+        [Fact]
+        public void Issue519ListCompression()
+        {
+            var g = new Graph();
+            g.LoadFromString("""
+                             @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                             @prefix sh: <http://www.w3.org/ns/shacl#> .
+                             _:autos1 rdf:first <urn:a>;
+                               rdf:rest _:autos2.
+                             _:autos2 rdf:first <urn:b>;
+                                rdf:rest _:autos3.
+                             _:autos3 rdf:first <urn:c>;
+                                rdf:rest rdf:nil.
+                             <urn:X> a sh:PropertyShape;
+                                sh:in _:autos1.
+                             """, new TurtleParser(TurtleSyntax.W3C, false));
+            Dictionary<INode, OutputRdfCollection> collections = FindImplicitCollections(g);
+            Assert.Single(collections);
+            OutputRdfCollection collection = collections.Values.First();
+            Assert.False(collection.IsExplicit);
+            Assert.Equal(3, collection.Triples.Count);
+        }
+    }
+}


### PR DESCRIPTION
* Fix to the guard that determines whether an rdf:List collection is compressable (#519)
* Ignore rdf:List collections where list nodes have multiple rdf:first/rdf:rest triples rather than throwing an exception. The lists won't be compressed, but any other collections in the graph will be processed.
* Fix a bug with writing the rdf:rest property in the PrettyRdfXmlWriter