### PR TITLE
Ensure output stream is closed

### DIFF
--- a/Testing/dotNetRdf.Tests/Writing/GraphVizTests.cs
+++ b/Testing/dotNetRdf.Tests/Writing/GraphVizTests.cs
@@ -30,12 +30,9 @@ namespace VDS.RDF.Writing
 
     public class GraphVizTests
     {
-        [SkippableFact]
+        [Fact]
         public void WritingGraphViz1()
         {
-            Skip.IfNot(TestConfigManager.GetSettingAsBoolean(TestConfigManager.UseGraphViz),
-                "Test Config marks GraphViz as unavailable, test cannot be run");
-
             var g = new Graph();
             g.LoadFromEmbeddedResource("VDS.RDF.Configuration.configuration.ttl");
 


### PR DESCRIPTION
* Update Save(IGraph, string) to dispose of the locally created output stream.
* Use UTF-8 encoding as preferred by DOT
* Run the GraphVizTests methods that don't rely on a local installation of dot.exe
* Do a little bit of code tidying

Fixes #585 