### PR TITLE
Mark APIs that are now considered 

### DIFF
--- a/Libraries/dotNetRdf.Core/Core/BaseEndpoint.cs
+++ b/Libraries/dotNetRdf.Core/Core/BaseEndpoint.cs
@@ -35,6 +35,7 @@ namespace VDS.RDF
     /// <summary>
     /// Abstract Base class for HTTP endpoints.
     /// </summary>
+    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public abstract class BaseEndpoint
         : IConfigurationSerializable
     {

--- a/Libraries/dotNetRdf.Core/Storage/BaseAsyncHttpConnector.cs
+++ b/Libraries/dotNetRdf.Core/Storage/BaseAsyncHttpConnector.cs
@@ -341,6 +341,7 @@ namespace VDS.RDF.Storage
         /// <param name="g">Graph to save.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release.")]
         protected internal void SaveGraphAsync(HttpWebRequest request, IRdfWriter writer, IGraph g, AsyncStorageCallback callback, object state)
         {
             request.BeginGetRequestStream(r =>
@@ -556,6 +557,7 @@ namespace VDS.RDF.Storage
         /// <param name="graphUri">URI of the Graph to delete.</param>
         /// <param name="callback">Callback.</param>
         /// <param name="state">State to pass to the callback.</param>
+        [Obsolete("This method is obsolete and will be removed in a future release")]
         protected internal void DeleteGraphAsync(HttpWebRequest request, bool allow404, string graphUri, AsyncStorageCallback callback, object state)
         {
             request.BeginGetResponse(r =>

--- a/Libraries/dotNetRdf.Core/Storage/BaseStardogConnector.cs
+++ b/Libraries/dotNetRdf.Core/Storage/BaseStardogConnector.cs
@@ -2078,7 +2078,7 @@ namespace VDS.RDF.Storage
         /// Adds Stardog specific request headers; reasoning needed for &lt; 2.2.
         /// </summary>
         /// <param name="request"></param>
-        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by AddStartdogHeaders(HttpRequestMessage).")]
+        [Obsolete("This method is obsolete and will be removed in a future release. Replaced by AddStardogHeaders(HttpRequestMessage).")]
         protected virtual void AddStardogHeaders(HttpWebRequest request)
         {
 #if !NETCORE


### PR DESCRIPTION
This PR identifies a few remaining places in the dotNetRDF API that make use of the old HttpWebRequest APIs. All of these APIs have newer equivalents that use the .NET HttpClient API instead. These obosleted APIs can be removed in the 4.0 release.

Completes #88 