### PR TITLE
Test and fix for #407

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,11 @@
 ﻿Change Log
 ==========
 
+Latest
+------
+
+FIX: Fixed a bug with handling multiple .GroupBy() calls in the QueryBuilder which was resulting in only the first and last expressions in the GroupBy chain to be added to the built query. Thanks to @jiatao99 for the bug report and proposed fix. (#407)
+
 3.1
 ---
 

--- a/Libraries/dotNetRdf.Core/Query/Builder/QueryBuilder.cs
+++ b/Libraries/dotNetRdf.Core/Query/Builder/QueryBuilder.cs
@@ -343,7 +343,7 @@ namespace VDS.RDF.Query.Builder
                 }
                 else
                 {
-                    lastGroup.Child = buildGroup(Prefixes);
+                    lastGroup = lastGroup.Child = buildGroup(Prefixes);
                 }
             }
 

--- a/Testing/dotNetRdf.Tests/Query/Builder/QueryBuilderTests.cs
+++ b/Testing/dotNetRdf.Tests/Query/Builder/QueryBuilderTests.cs
@@ -805,5 +805,21 @@ namespace VDS.RDF.Query.Builder
             Assert.Equal(2, q1.RootGraphPattern.ChildGraphPatterns.First().ChildGraphPatterns.Count());
             Assert.Contains(q1.RootGraphPattern.ChildGraphPatterns.First().ChildGraphPatterns, p => p.ToString().Contains("p2"));
         }
+
+        [Fact]
+        public void CanBuildQueryWithGroupBySeveralVariables()
+        {
+            SparqlQuery query = QueryBuilder.Select(b => b.Sum("c")).As("sum")
+                .Where(p => p
+                    .Subject("x").PredicateUri(new Uri("http://example.org/a")).Object("a")
+                    .Subject("x").PredicateUri(new Uri("http://example.org/b")).Object("b")
+                    .Subject("x").PredicateUri(new Uri("http://example.org/c")).Object("c"))
+                .GroupBy("x")
+                .GroupBy("a")
+                .GroupBy("b")
+                .BuildQuery();
+            query.GroupBy.Variables.Count().Should().Be(3);
+            query.GroupBy.ToString().Should().Be("?x ?a ?b");
+        }
     }
 }


### PR DESCRIPTION
Fixed QueryBuilder.BuildGroupByClauses to correctly maintain the chain of group by expressions. Thanks to @jiatao99 for the bug report and suggested fix.

Fixes #407