### PR TITLE
Add ISparqlResultFactory and a default implementation

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,7 @@ Latest
 ------
 
 FIX: Fixed a bug with handling multiple .GroupBy() calls in the QueryBuilder which was resulting in only the first and last expressions in the GroupBy chain to be added to the built query. Thanks to @jiatao99 for the bug report and proposed fix. (#407)
+ENHANCEMENT: Added `VDS.RDF.Query.ISparqlResultFactory` to allow implementers to specify how an `ISet` of variable bindings are converted to an `ISparqlResult` instance before being passed to the client's `ISparqlResultHandler`. The factory instance to be used can now be set via the `LeviathanQueryOptions.SparqlResultFactory` property. The default implementation creates instances of the `VDS.RDF.SparqlResult` class. Thanks to @jiatao99 for the suggestion. (#478)
 
 3.1
 ---

--- a/Libraries/dotNetRdf.Core/Query/Algebra/SetExtensions.cs
+++ b/Libraries/dotNetRdf.Core/Query/Algebra/SetExtensions.cs
@@ -24,6 +24,7 @@
 // </copyright>
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,6 +40,7 @@ namespace VDS.RDF.Query.Algebra
         /// </summary>
         /// <param name="set"></param>
         /// <returns></returns>
+        [Obsolete("Replaced by the ISparqlResultFactory interface and its implementation.")]
         public static SparqlResult AsSparqlResult(this ISet set)
         {
             return new SparqlResult(set.Variables.Select(var => new KeyValuePair<string, INode>(var, set[var])));

--- a/Libraries/dotNetRdf.Core/Query/ISparqlResultFactory.cs
+++ b/Libraries/dotNetRdf.Core/Query/ISparqlResultFactory.cs
@@ -1,0 +1,52 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+//
+// Copyright (c) 2009-2023 dotNetRDF Project (http://dotnetrdf.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Collections.Generic;
+using VDS.RDF.Query.Algebra;
+
+namespace VDS.RDF.Query;
+
+/**
+ * Defines an interface for creating the <see cref="ISparqlResult"/> instances that are passed from a
+ * query processor to a <see cref="ISparqlResultsHandler"/>.
+ */
+public interface ISparqlResultFactory
+{
+    /// <summary>
+    /// Create a SPARQL result row from a single set of variable bindings.
+    /// </summary>
+    /// <param name="bindings">The variable bindings to be converted / wrapped as a <see cref="ISparqlResult"/>.</param>
+    /// <returns>The <see cref="ISparqlResult"/> instance that represents the row.</returns>
+    public ISparqlResult MakeResult(ISet bindings);
+
+    /// <summary>
+    /// Create a SPARQL result row from a subset of variable bindings.
+    /// </summary>
+    /// <param name="bindings">The variable bindings.</param>
+    /// <param name="variables">The variables to be included in the generated <see cref="ISparqlResult"/>.</param>
+    /// <returns>The &lt;see cref="ISparqlResult"/&gt; instance that represents the row.</returns>
+    public ISparqlResult MakeResult(ISet bindings, IEnumerable<string> variables);
+}

--- a/Libraries/dotNetRdf.Core/Query/LeviathanQueryOptions.cs
+++ b/Libraries/dotNetRdf.Core/Query/LeviathanQueryOptions.cs
@@ -139,6 +139,10 @@ namespace VDS.RDF.Query
             set => _describer = value;
         }
 
-
+        /// <summary>
+        /// Gets/Sets the <see cref="ISparqlResultFactory"/> which creates the <see cref="ISparqlResult"/> instances
+        /// that are passed to a <see cref="ISparqlResultsHandler"/>.
+        /// </summary>
+        public ISparqlResultFactory SparqlResultFactory { get; set; } = new SparqlResultFactory();
     }
 }

--- a/Libraries/dotNetRdf.Core/Query/ResultsHandlerExtensions.cs
+++ b/Libraries/dotNetRdf.Core/Query/ResultsHandlerExtensions.cs
@@ -77,7 +77,7 @@ namespace VDS.RDF.Query
                     }
                     foreach (ISet s in context.OutputMultiset.Sets)
                     {
-                        if (!handler.HandleResult(s.AsSparqlResult())) ParserHelper.Stop();
+                        if (!handler.HandleResult(context.Options.SparqlResultFactory.MakeResult(s))) ParserHelper.Stop();
                     }
 
                     // The VirtualCount property on SparqlQuery has been marked obsolete

--- a/Libraries/dotNetRdf.Core/Query/SparqlResultFactory.cs
+++ b/Libraries/dotNetRdf.Core/Query/SparqlResultFactory.cs
@@ -1,0 +1,51 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+//
+// Copyright (c) 2009-2023 dotNetRDF Project (http://dotnetrdf.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using VDS.RDF.Query.Algebra;
+
+namespace VDS.RDF.Query;
+
+/**
+ * Default implementation of <see cref="ISparqlResultFactory"/> that builds a <see cref="SparqlResult"/> instance
+ * from an <see cref="ISet"/> that represents a SPARQL query solution.
+ */
+public class SparqlResultFactory : ISparqlResultFactory
+{
+    /// <inheritdoc />
+    public ISparqlResult MakeResult(ISet bindings)
+    {
+        return new SparqlResult(bindings.Variables.Select(var => new KeyValuePair<string, INode>(var, bindings[var])));
+    }
+
+    /// <inheritdoc />
+    public ISparqlResult MakeResult(ISet bindings, IEnumerable<string> variables)
+    {
+        return new SparqlResult(variables.Where(bindings.ContainsVariable)
+            .Select(x => new KeyValuePair<string, INode>(x, bindings[x])));
+    }
+}


### PR DESCRIPTION
* Add `VDS.RDF.Query.ISparqlResultFactory` and a default implentation `VDS.RDF.Query.SparqlResultFactory`
* Add `VDS.RDF.Query.LeviathanQueryOptions.SparqlResultFactory` property to allow the factory instance to be configured for a Leviathan query processor.
* Update `LeviathanQueryProcessor` to use the factory instance when constructing results to pass to the query result handler.

Fixes #478 