### PR TITLE
DeepClone input JArray on JSON-LD Canonicalize

### DIFF
--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
@@ -465,7 +465,7 @@ namespace VDS.RDF.JsonLd
         public static string Canonicalize(JArray input)
         {
             var store = new TripleStore();
-            new JsonLdParser().Load(store, input);
+            new JsonLdParser().Load(store, input.DeepClone() as JArray);
 
             return new RdfCanonicalizer().Canonicalize(store).SerializedNQuads;
         }


### PR DESCRIPTION
If we don't do this, the JsonLdParser.Load() method will mess with the original object, which is likely not desirable.

(I just noticed this during testing, apologies for missing it in the initial PR)