### PR TITLE
Run tests on net8 instead of net7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        framework: ["net6.0", "net7.0", "net472"]
+        framework: ["net6.0", "net8.0", "net472"]
         suite: ["dotNetRdf.Tests", "dotNetRdf.Dynamic.Tests", "dotNetRdf.Inferencing.Tests", "dotNetRdf.Ontology.Tests", "dotNetRdf.Shacl.Tests", "dotNetRdf.Skos.Tests", "dotNetRdf.Query.FullText.Tests", "dotNetRdf.Writing.HtmlSchema.Tests", "dotNetRdf.TestSuite.RdfStar", "dotNetRdf.TestSuite.Rdfa", "dotNetRdf.TestSuite.RdfCanon", "dotNetRdf.Data.DataTables.Tests", "dotNetRdf.Ldf.Tests"]
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        framework: ["net6.0", "net7.0"]
+        framework: ["net6.0", "net8.0"]
         suite: ["dotNetRdf.Tests", "dotNetRdf.Dynamic.Tests", "dotNetRdf.Inferencing.Tests", "dotNetRdf.Ontology.Tests", "dotNetRdf.Shacl.Tests", "dotNetRdf.Skos.Tests", "dotNetRdf.Query.FullText.Tests", "dotNetRdf.Writing.HtmlSchema.Tests", "dotNetRdf.TestSuite.RdfStar", "dotNetRdf.TestSuite.Rdfa", "dotNetRdf.TestSuite.RdfCanon", "dotNetRdf.Data.DataTables.Tests", "dotNetRdf.Ldf.Tests"]
     steps:
       - name: Checkout
@@ -48,13 +48,13 @@ jobs:
     - name: Start Fuseki
       run: docker run --rm -d -p 3030:3030 --name fuseki atomgraph/fuseki --mem /ds
     - name: Test Fuskei Connector
-      run: dotnet test -c Release --framework net6.0 --collect:"XPlat Code Coverage" Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
+      run: dotnet test -c Release --framework net8.0 --collect:"XPlat Code Coverage" Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
     - name: Stop Fuseki
       run: docker stop fuseki
     - name: Upload Code Coverage
       uses: actions/upload-artifact@v3
       with:
-        name: code-coverage dotNetRdf.Connectors.Fuseki.Tests net6.0
+        name: code-coverage dotNetRdf.Connectors.Fuseki.Tests net8.0
         path: Testing/dotNetRdf.Connectors.Fuseki.Tests/TestResults/*/coverage.cobertura.xml
         
   report:

--- a/Testing/Directory.Build.props
+++ b/Testing/Directory.Build.props
@@ -6,7 +6,7 @@
     <!-- Default Build Options -->
     <CodeAnalysisRuleSet>../../dotnetrdf.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net472</TargetFrameworks>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
* Update CI test matrix to drop net7 and add net8
* Update test build properties to drop net7 from the list of target frameworks
Fixes #620 