### PR TITLE
Basic Quads API

### DIFF
--- a/Libraries/dotNetRdf.Core/Core/BaseTripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/BaseTripleStore.cs
@@ -121,7 +121,39 @@ namespace VDS.RDF
         public abstract IUriFactory UriFactory { get; }
         #endregion
 
+        #region Assert/Retract Quads
+
+        /// <inheritdoc />
+        public void Assert(Quad quad)
+        {
+            if (!HasGraph(quad.Graph))
+            {
+                Add(quad.Graph);
+            }
+            Graphs[quad.Graph].Assert(quad.AsTriple());
+        }
+
+        /// <inheritdoc />
+        public void Retract(Quad quad)
+        {
+            if (HasGraph(quad.Graph))
+            {
+                Graphs[quad.Graph].Retract(quad.AsTriple());
+            }
+        }
+        #endregion
+
         #region Loading & Unloading
+
+        /// <summary>
+        /// Add a new empty graph with the specified name to the triple store
+        /// </summary>
+        /// <param name="graphName">The name of the graph to add.</param>
+        /// <returns>True if the execution resulted in a new graph being added to the triplestore, false otherwise.</returns>
+        public virtual bool Add(IRefNode graphName)
+        {
+            return !HasGraph(graphName) && Graphs.Add(new Graph(graphName), false);
+        }
 
         /// <summary>
         /// Adds a Graph into the Triple Store.

--- a/Libraries/dotNetRdf.Core/Core/BaseTripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/BaseTripleStore.cs
@@ -104,6 +104,17 @@ namespace VDS.RDF
             }
         }
 
+        /// <inheritdoc />
+        public IEnumerable<Quad> Quads
+        {
+            get
+            {
+                return from g in _graphs
+                    from t in g.Triples
+                    select new Quad(t, g.Name);
+            }
+        }
+
         /// <summary>
         /// Get the preferred URI factory to use when creating URIs in this store.
         /// </summary>

--- a/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
@@ -63,6 +63,12 @@ namespace VDS.RDF
         {
             get;
         }
+        
+        /// <summary>
+        /// Gets all the Quads in the Triple Store which are currently loaded in memory.
+        /// </summary>
+        /// <remarks>Since a Triple Store object may represent only a snapshot of the underlying Store evaluating this enumerator may only return some of the Quads in the Store and may depending on specific Triple Store return nothing.</remarks>
+        IEnumerable<Quad> Quads { get; }
 
         /// <summary>
         /// Get the preferred URI factory to use when creating URIs in this store.

--- a/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
@@ -24,6 +24,8 @@
 // </copyright>
 */
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using VDS.RDF.Parsing;
@@ -100,7 +102,7 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="graphName"></param>
         /// <returns>True if a new graph was added, false otherwise.</returns>
-        bool Add(IRefNode graphName);
+        bool Add(IRefNode? graphName);
 
         /// <summary>
         /// Adds a Graph into the Triple Store.
@@ -141,14 +143,14 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="graphUri">Graph Uri of the Graph to remove.</param>
         [Obsolete("Replaced by Remove(IRefNode)")]
-        bool Remove(Uri graphUri);
+        bool Remove(Uri? graphUri);
 
         /// <summary>
         /// Removes a graph from the triple store.
         /// </summary>
         /// <param name="graphName">The name of the graph to remove.</param>
         /// <returns>True if the operation removed a graph, false if no matching graph was found to remove.</returns>
-        bool Remove(IRefNode graphName);
+        bool Remove(IRefNode? graphName);
 
         #endregion
 
@@ -168,7 +170,7 @@ namespace VDS.RDF
         /// <param name="graphName">The name of the graph to check for.</param>
         /// <returns>True if this store contains a graph with the specified name, false otherwise.</returns>
         /// <remarks>Pass null for<paramref name="graphName"/> to check for the default (unnamed) graph.</remarks>
-        bool HasGraph(IRefNode graphName);
+        bool HasGraph(IRefNode? graphName);
 
         /// <summary>
         /// Gets a Graph from the Triple Store;.
@@ -186,8 +188,22 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="graphName">The name of the graph to be retrieved. May be null to retrieve the default (unnamed) graph.</param>
         /// <returns></returns>
-        IGraph this[IRefNode graphName] { get; }
+        IGraph this[IRefNode? graphName] { get; }
 
+        #endregion
+        
+        #region Quad Retrieval
+
+        /// <summary>
+        /// Return an enumeration of all quads in the store that match the specified subject, predicate, object and/or graph.
+        /// </summary>
+        /// <param name="s">The subject node to match. Null matches all subject nodes.</param>
+        /// <param name="p">The predicate node to match. Null matches all predicate nodes.</param>
+        /// <param name="o">The object node to match. Null matches all object nodes.</param>
+        /// <param name="g">The graph to match. Null matches all graphs if <paramref name="allGraphs"/> is true, or only the unnamed graph is <paramref name="allGraphs"/> is false.</param>
+        /// <param name="allGraphs"></param>
+        /// <returns></returns>
+        IEnumerable<Quad> GetQuads(INode? s = null, INode? p = null, INode? o = null, IRefNode? g = null, bool allGraphs = true);
         #endregion
 
         #region Events
@@ -195,27 +211,27 @@ namespace VDS.RDF
         /// <summary>
         /// Event which is raised when a Graph is added
         /// </summary>
-        event TripleStoreEventHandler GraphAdded;
+        event TripleStoreEventHandler? GraphAdded;
 
         /// <summary>
         /// Event which is raised when a Graph is removed
         /// </summary>
-        event TripleStoreEventHandler GraphRemoved;
+        event TripleStoreEventHandler? GraphRemoved;
 
         /// <summary>
         /// Event which is raised when a Graphs contents changes
         /// </summary>
-        event TripleStoreEventHandler GraphChanged;
+        event TripleStoreEventHandler? GraphChanged;
 
         /// <summary>
         /// Event which is raised when a Graph is cleared
         /// </summary>
-        event TripleStoreEventHandler GraphCleared;
+        event TripleStoreEventHandler? GraphCleared;
 
         /// <summary>
         /// Event which is raised when a Graph has a merge operation performed on it
         /// </summary>
-        event TripleStoreEventHandler GraphMerged;
+        event TripleStoreEventHandler? GraphMerged;
 
         #endregion
 

--- a/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/ITripleStore.cs
@@ -76,7 +76,31 @@ namespace VDS.RDF
         IUriFactory UriFactory { get; }
         #endregion
 
+        #region Assert & Retract Quads
+
+        /// <summary>
+        /// Assert a quad in the triple store.
+        /// </summary>
+        /// <param name="quad">The quad to be added.</param>
+        /// <remarks>If the quad's graph is not currently in the triple store, a new graph will be added.</remarks>
+        public void Assert(Quad quad);
+
+        /// <summary>
+        /// Remove a quad from the triple store.
+        /// </summary>
+        /// <param name="quad">The quad to be removed.</param>
+        /// <remarks>If the quad's graph is not currently in the triple store, this operation will make no modification to the triple store. Otherwise it will invoke the Retract method on the graph.</remarks>
+        public void Retract(Quad quad);
+
+        #endregion
         #region Loading & Unloading Graphs
+
+        /// <summary>
+        /// Adds an empty graph with the specified name to the triple store.
+        /// </summary>
+        /// <param name="graphName"></param>
+        /// <returns>True if a new graph was added, false otherwise.</returns>
+        bool Add(IRefNode graphName);
 
         /// <summary>
         /// Adds a Graph into the Triple Store.

--- a/Libraries/dotNetRdf.Core/Core/MIMETypesHelper.cs
+++ b/Libraries/dotNetRdf.Core/Core/MIMETypesHelper.cs
@@ -100,7 +100,7 @@ namespace VDS.RDF
         /// <summary>
         /// MIME Types for TriG.
         /// </summary>
-        public static readonly string[] TriG = { "application/x-trig" };
+        public static readonly string[] TriG = { "application/trig", "application/x-trig" };
 
         /// <summary>
         /// MIME Types for TriX.

--- a/Libraries/dotNetRdf.Core/Core/MIMETypesHelper.cs
+++ b/Libraries/dotNetRdf.Core/Core/MIMETypesHelper.cs
@@ -749,8 +749,7 @@ namespace VDS.RDF
             {
                 if (!_init) Init();
 
-                var header = new HttpRequestMessage().Headers.Accept;
-
+                HashSet<MediaTypeWithQualityHeaderValue> accept = [];
                 foreach (MimeTypeDefinition definition in Definitions)
                 {
                     if (definition.CanParseRdf)
@@ -759,20 +758,26 @@ namespace VDS.RDF
                         {
                             foreach (var mimeType in definition.MimeTypes)
                             {
-                                header.Add(new MediaTypeWithQualityHeaderValue(mimeType, Convert.ToDouble(definition.Preference)));
+                                accept.Add(new MediaTypeWithQualityHeaderValue(mimeType, Convert.ToDouble(definition.Preference)));
                             }
                         }
                         else
                         {
                             foreach (var mimeType in definition.MimeTypes)
                             {
-                                header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
+                                accept.Add(new MediaTypeWithQualityHeaderValue(mimeType));
                             }
                         }
                     }
                 }
 
-                header.Add(new MediaTypeWithQualityHeaderValue("*/*", .5));
+                accept.Add(new MediaTypeWithQualityHeaderValue("*/*", .5));
+
+                HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> header = new HttpRequestMessage().Headers.Accept;
+                foreach (MediaTypeWithQualityHeaderValue headerValue in accept)
+                {
+                    header.Add(headerValue);
+                }
 
                 return header.ToString();
             }
@@ -788,8 +793,7 @@ namespace VDS.RDF
             {
                 if (!_init) Init();
 
-                var header = new HttpRequestMessage().Headers.Accept;
-
+                HashSet<MediaTypeWithQualityHeaderValue> accept = [];
                 foreach (MimeTypeDefinition definition in Definitions)
                 {
                     if (definition.CanParseSparqlResults)
@@ -798,19 +802,23 @@ namespace VDS.RDF
                         {
                             foreach (var mimeType in definition.MimeTypes)
                             {
-                                header.Add(new MediaTypeWithQualityHeaderValue(mimeType, Convert.ToDouble(definition.Preference)));
+                                accept.Add(new MediaTypeWithQualityHeaderValue(mimeType, Convert.ToDouble(definition.Preference)));
                             }
                         }
                         else
                         {
                             foreach (var mimeType in definition.MimeTypes)
                             {
-                                header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
+                                accept.Add(new MediaTypeWithQualityHeaderValue(mimeType));
                             }
                         }
                     }
                 }
-
+                HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> header = new HttpRequestMessage().Headers.Accept;
+                foreach (MediaTypeWithQualityHeaderValue headerValue in accept)
+                {
+                    header.Add(headerValue);
+                }
                 return header.ToString();
             }
         }
@@ -825,7 +833,7 @@ namespace VDS.RDF
             {
                 if (!_init) Init();
 
-                var header = new HttpRequestMessage().Headers.Accept;
+                HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> header = new HttpRequestMessage().Headers.Accept;
 
                 foreach (MimeTypeDefinition definition in Definitions)
                 {
@@ -863,19 +871,13 @@ namespace VDS.RDF
             {
                 if (!_init) Init();
 
-                var header = new HttpRequestMessage().Headers.Accept;
-
-                foreach (MimeTypeDefinition definition in Definitions)
+                HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> header = new HttpRequestMessage().Headers.Accept;
+                var mimeTypes =
+                    new HashSet<string>(Definitions.Where(d => d.CanParseRdfDatasets).SelectMany(d => d.MimeTypes));
+                foreach (var mimeType in mimeTypes)
                 {
-                    if (definition.CanParseRdfDatasets)
-                    {
-                        foreach (var mimeType in definition.MimeTypes)
-                        {
-                            header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
-                        }
-                    }
+                    header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
                 }
-
                 return header.ToString();
             }
         }
@@ -889,17 +891,12 @@ namespace VDS.RDF
             {
                 if (!_init) Init();
 
-                var header = new HttpRequestMessage().Headers.Accept;
-
-                foreach (MimeTypeDefinition definition in Definitions)
+                HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> header = new HttpRequestMessage().Headers.Accept;
+                var mimeTypes =
+                    new HashSet<string>(Definitions.Where(d => d.CanParseRdf || d.CanParseRdfDatasets).SelectMany(d => d.MimeTypes));
+                foreach (var mimeType in mimeTypes)
                 {
-                    if (definition.CanParseRdf || definition.CanParseRdfDatasets)
-                    {
-                        foreach (var mimeType in definition.MimeTypes)
-                        {
-                            header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
-                        }
-                    }
+                    header.Add(new MediaTypeWithQualityHeaderValue(mimeType));
                 }
                 header.Add(new MediaTypeWithQualityHeaderValue("*/*", .5));
 

--- a/Libraries/dotNetRdf.Core/Core/Quad.cs
+++ b/Libraries/dotNetRdf.Core/Core/Quad.cs
@@ -1,0 +1,120 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+//
+// Copyright (c) 2009-2024 dotNetRDF Project (http://dotnetrdf.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System;
+
+namespace VDS.RDF;
+
+/**
+ * Class for representing quads in memory.
+ */
+public sealed class Quad: IComparable<Quad>, IEquatable<Quad>
+{
+    /// <summary>
+    /// Get the subject node of the quad.
+    /// </summary>
+    public INode Subject { get; }
+
+    /// <summary>
+    /// Get the predicate node of the quad.
+    /// </summary>
+    public INode Predicate { get; }
+
+    /// <summary>
+    /// Get the object node of the quad.
+    /// </summary>
+    public INode Object { get; }
+    
+    /// <summary>
+    /// Get the graph node of the quad.
+    /// </summary>
+    public IRefNode Graph { get; }
+    
+    private readonly int _hashCode;
+
+    public Quad(INode subject, INode predicate, INode @object, IRefNode graphName)
+    {
+        Subject = subject;
+        Predicate = predicate;
+        Object = @object;
+        Graph = @graphName;
+        _hashCode = Tools.CombineHashCodes(
+            Subject.GetHashCode(),
+            Predicate.GetHashCode(),
+            Object.GetHashCode(),
+            Graph.GetHashCode());
+    }
+    
+    public Quad(Triple t, IRefNode graph) : this(t.Subject, t.Predicate, t.Object, graph) {}
+    
+    /// <inheritdoc />
+    public int CompareTo(Quad other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return 0;
+        }
+        if (ReferenceEquals(Subject, other.Subject) &&
+            ReferenceEquals(Predicate, other.Predicate) &&
+            ReferenceEquals(Object, other.Object) &&
+            ReferenceEquals(Graph, other.Graph))
+        {
+            return 0;
+        }
+        var result = Subject.CompareTo(other.Subject);
+        if (result == 0)
+        {
+            result = Predicate.CompareTo(other.Predicate);
+            if (result == 0)
+            {
+                result = Object.CompareTo(other.Object);
+                if (result == 0)
+                {
+                    result = Graph.CompareTo(other.Graph);
+                }
+            }
+        }
+        return result;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(Quad other)
+    {
+        return this.CompareTo(other) == 0;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return _hashCode;
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"{Subject}, {Predicate}, {Object}, {Graph}";
+    }
+}

--- a/Libraries/dotNetRdf.Core/Core/Quad.cs
+++ b/Libraries/dotNetRdf.Core/Core/Quad.cs
@@ -31,6 +31,8 @@ namespace VDS.RDF;
 /**
  * Class for representing quads in memory.
  */
+
+#nullable enable
 public sealed class Quad: IComparable<Quad>, IEquatable<Quad>
 {
     /// <summary>
@@ -51,11 +53,18 @@ public sealed class Quad: IComparable<Quad>, IEquatable<Quad>
     /// <summary>
     /// Get the graph node of the quad.
     /// </summary>
-    public IRefNode Graph { get; }
+    public IRefNode? Graph { get; }
     
     private readonly int _hashCode;
 
-    public Quad(INode subject, INode predicate, INode @object, IRefNode graphName)
+    /// <summary>
+    /// Construct a new Quad with the specified subject, predicate, object, and optionally graph.
+    /// </summary>
+    /// <param name="subject">The subject node of the quad.</param>
+    /// <param name="predicate">The predicate node of the quad.</param>
+    /// <param name="object">The object node of the quad.</param>
+    /// <param name="graphName">The graph that the statement is in. A null value indicates the unnamed graph.</param>
+    public Quad(INode subject, INode predicate, INode @object, IRefNode? graphName)
     {
         Subject = subject;
         Predicate = predicate;
@@ -65,10 +74,24 @@ public sealed class Quad: IComparable<Quad>, IEquatable<Quad>
             Subject.GetHashCode(),
             Predicate.GetHashCode(),
             Object.GetHashCode(),
-            Graph.GetHashCode());
+            Graph?.GetHashCode() ?? -1);
     }
     
-    public Quad(Triple t, IRefNode graph) : this(t.Subject, t.Predicate, t.Object, graph) {}
+    /// <summary>
+    /// Construct a new Quad with the specified triple contained in the specified graph.
+    /// </summary>
+    /// <param name="t">The subject, predicate and object of the quad as a <see cref="Triple"/>.</param>
+    /// <param name="graph">The graph that the statement is in. A null value indicates the unnamed graph.</param>
+    public Quad(Triple t, IRefNode? graph) : this(t.Subject, t.Predicate, t.Object, graph) {}
+
+    /// <summary>
+    /// Create and return a new <see cref="Triple"/> instance created with the <see cref="Subject"/>, <see cref="Predicate"/>, and <see cref="Object"/> of this quad.
+    /// </summary>
+    /// <returns>A new <see cref="Triple"/> instance.</returns>
+    public Triple AsTriple()
+    {
+        return new Triple(Subject, Predicate, Object);
+    }
     
     /// <inheritdoc />
     public int CompareTo(Quad other)
@@ -93,7 +116,14 @@ public sealed class Quad: IComparable<Quad>, IEquatable<Quad>
                 result = Object.CompareTo(other.Object);
                 if (result == 0)
                 {
-                    result = Graph.CompareTo(other.Graph);
+                    if (Graph == null)
+                    {
+                        result = other.Graph == null ? 0 : 1;
+                    }
+                    else
+                    {
+                        result = Graph.CompareTo(other.Graph);
+                    }
                 }
             }
         }

--- a/Libraries/dotNetRdf.Core/Core/TripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/TripleStore.cs
@@ -429,8 +429,7 @@ namespace VDS.RDF
 
 
         #endregion
-
-
+        
         #region IDisposable Members
 
         /// <summary>

--- a/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
@@ -100,6 +100,15 @@ namespace VDS.RDF
             }
         }
 
+        /// <inheritdoc />
+        public virtual IEnumerable<Quad> Quads
+        {
+            get
+            {
+                return _store.Quads;
+            }
+        }
+
         /// <summary>
         /// Get the preferred URI factory to use when creating URIs in this store.
         /// </summary>

--- a/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
@@ -114,6 +114,24 @@ namespace VDS.RDF
         /// </summary>
         public virtual IUriFactory UriFactory => _store.UriFactory;
 
+        /// <inheritdoc />
+        public virtual void Assert(Quad quad)
+        {
+            _store.Assert(quad);
+        }
+
+        /// <inheritdoc />
+        public virtual void Retract(Quad quad)
+        {
+            _store.Retract(quad);
+        }
+
+        /// <inheritdoc />
+        public virtual bool Add(IRefNode graphName)
+        {
+            return _store.Add(graphName);
+        }
+
         /// <summary>
         /// Adds a Graph to the store.
         /// </summary>

--- a/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
+++ b/Libraries/dotNetRdf.Core/Core/WrapperTripleStore.cs
@@ -24,6 +24,7 @@
 // </copyright>
 */
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using VDS.RDF.Parsing;
@@ -127,7 +128,7 @@ namespace VDS.RDF
         }
 
         /// <inheritdoc />
-        public virtual bool Add(IRefNode graphName)
+        public virtual bool Add(IRefNode? graphName)
         {
             return _store.Add(graphName);
         }
@@ -192,7 +193,7 @@ namespace VDS.RDF
         /// <param name="graphUri">Graph URI.</param>
         /// <returns></returns>
         [Obsolete("Replaced by Remove(IRefNode)")]
-        public virtual bool Remove(Uri graphUri)
+        public virtual bool Remove(Uri? graphUri)
         {
             return _store.Remove(graphUri);
         }
@@ -202,7 +203,7 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="graphName">The name of the graph to remove.</param>
         /// <returns>True if the operation removed a graph, false if no matching graph was found to remove.</returns>
-        public virtual bool Remove(IRefNode graphName)
+        public virtual bool Remove(IRefNode? graphName)
         {
             return _store.Remove(graphName);
         }
@@ -224,7 +225,7 @@ namespace VDS.RDF
         /// <param name="graphName">The name of the graph to check for.</param>
         /// <returns>True if this store contains a graph with the specified name, false otherwise.</returns>
         /// <remarks>Pass null for<paramref name="graphName"/> to check for the default (unnamed) graph.</remarks>
-        public virtual bool HasGraph(IRefNode graphName)
+        public virtual bool HasGraph(IRefNode? graphName)
         {
             return _store.HasGraph(graphName);
         }
@@ -248,32 +249,38 @@ namespace VDS.RDF
         /// </summary>
         /// <param name="graphName">The name of the graph to be retrieved. May be null to retrieve the default (unnamed) graph.</param>
         /// <returns></returns>
-        public virtual IGraph this[IRefNode graphName] => _store[graphName];
+        public virtual IGraph this[IRefNode? graphName] => _store[graphName];
+
+        /// <inheritdoc />
+        public IEnumerable<Quad> GetQuads(INode? s = null, INode? p = null, INode? o = null, IRefNode? g = null, bool allGraphs = true)
+        {
+            return _store.GetQuads(s, p, o, g, allGraphs);
+        }
 
         /// <summary>
         /// Event which is raised when a graph is added
         /// </summary>
-        public event TripleStoreEventHandler GraphAdded;
+        public event TripleStoreEventHandler? GraphAdded;
 
         /// <summary>
         /// Events which is raised when a graph is removed
         /// </summary>
-        public event TripleStoreEventHandler GraphRemoved;
+        public event TripleStoreEventHandler? GraphRemoved;
 
         /// <summary>
         /// Event which is raised when a graph is changed
         /// </summary>
-        public event TripleStoreEventHandler GraphChanged;
+        public event TripleStoreEventHandler? GraphChanged;
 
         /// <summary>
         /// Event which is raised when a graph is cleared
         /// </summary>
-        public event TripleStoreEventHandler GraphCleared;
+        public event TripleStoreEventHandler? GraphCleared;
 
         /// <summary>
         /// Event which is raised when a graph is merged
         /// </summary>
-        public event TripleStoreEventHandler GraphMerged;
+        public event TripleStoreEventHandler? GraphMerged;
 
         /// <summary>
         /// Helper method for raising the <see cref="GraphAdded">Graph Added</see> event manually.

--- a/Testing/dotNetRdf.Tests/Core/AbstractTripleStoreTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/AbstractTripleStoreTests.cs
@@ -339,6 +339,71 @@ namespace VDS.RDF
             Assert.False(store.HasGraph(unnamed));
         }
 
+        [Fact]
+        public void MatchQuadsInNamedGraph()
+        {
+            ITripleStore store = GetInstance();
+            INode s = new UriNode(store.UriFactory.Create("https://example.org/s"));
+            INode p = new UriNode(store.UriFactory.Create("https://example.org/p"));
+            INode o = new UriNode(store.UriFactory.Create("https://example.org/o"));
+            IRefNode g = new UriNode(store.UriFactory.Create("https://example.org/g1"));
+            IRefNode g2 = new UriNode(store.UriFactory.Create("https://example.org/g2"));
+            store.Assert(new Quad(s, p, o, g));
+            store.Assert(new Quad(s, p, o, g2));
+            Assert.Single(store.GetQuads(s: s, g: g));
+            Assert.Single(store.GetQuads(p: p, g: g));
+            Assert.Single(store.GetQuads(o: o, g: g));
+            Assert.Single(store.GetQuads(g: g));
+            Assert.Single(store.GetQuads(s, p, g:g));
+            Assert.Single(store.GetQuads(s, o: o, g:g));
+            Assert.Single(store.GetQuads(p: p, o: o, g: g));
+            Assert.Single(store.GetQuads(s, p, o, g));
+        }
+
+        [Fact]
+        public void MatchQuadsInUnnamedGraph()
+        {
+            ITripleStore store = GetInstance();
+            INode s = new UriNode(store.UriFactory.Create("https://example.org/s"));
+            INode p = new UriNode(store.UriFactory.Create("https://example.org/p"));
+            INode o = new UriNode(store.UriFactory.Create("https://example.org/o"));
+            IRefNode? unnamed = null;
+            IRefNode g = new UriNode(store.UriFactory.Create("https://example.org/g1"));
+            store.Assert(new Quad(s, p, o, unnamed));
+            store.Assert(new Quad(s, p, o, g));
+            Assert.Single(store.GetQuads(s: s, allGraphs:false));
+            Assert.Single(store.GetQuads(p: p, allGraphs:false));
+            Assert.Single(store.GetQuads(o: o, allGraphs:false));
+            Assert.Single(store.GetQuads(allGraphs:false));
+            Assert.Single(store.GetQuads(s, p, allGraphs:false));
+            Assert.Single(store.GetQuads(s, o: o, allGraphs:false));
+            Assert.Single(store.GetQuads(p: p, o: o, allGraphs:false));
+            Assert.Single(store.GetQuads(s, p, o, unnamed, allGraphs:false));
+        }
+
+        [Fact]
+        public void MatchQuadsInAllGraphs()
+        {
+            ITripleStore store = GetInstance();
+            INode s = new UriNode(store.UriFactory.Create("https://example.org/s"));
+            INode p = new UriNode(store.UriFactory.Create("https://example.org/p"));
+            INode o = new UriNode(store.UriFactory.Create("https://example.org/o"));
+            IRefNode g = new UriNode(store.UriFactory.Create("https://example.org/g1"));
+            IRefNode g2 = new UriNode(store.UriFactory.Create("https://example.org/g2"));
+            IRefNode? unnamed = null; 
+            store.Assert(new Quad(s, p, o, g));
+            store.Assert(new Quad(s, p, o, g2));
+            store.Assert(new Quad(s, p, o, unnamed));
+            Assert.Equal(3, store.GetQuads(s: s).Count());
+            Assert.Equal(3,store.GetQuads(p: p).Count());
+            Assert.Equal(3,store.GetQuads(o: o).Count());
+            Assert.Equal(3,store.GetQuads().Count());
+            Assert.Equal(3,store.GetQuads(s, p).Count());
+            Assert.Equal(3,store.GetQuads(s, o: o).Count());
+            Assert.Equal(3,store.GetQuads(p: p, o: o).Count());
+            Assert.Equal(3,store.GetQuads(s, p, o).Count());
+        }
+
     }
 
 

--- a/Testing/dotNetRdf.Tests/Core/AbstractTripleStoreTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/AbstractTripleStoreTests.cs
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using System;
+using System.Linq;
 using Xunit;
 
 namespace VDS.RDF
@@ -110,6 +111,72 @@ namespace VDS.RDF
 
             Assert.True(store.HasGraph(g.Name));
         }
+
+        [Fact]
+        public void EnumerateQuads01()
+        {
+            ITripleStore store = GetInstance();
+            IGraph g = new Graph(new UriNode(new Uri("http://example.org/g1")));
+            INode s1 = g.CreateUriNode(new Uri("http://example.org/s1"));
+            IUriNode p = g.CreateUriNode(new Uri("http://example.org/p"));
+            IUriNode o = g.CreateUriNode(new Uri("http://example.org/o"));
+            IUriNode s2 = g.CreateUriNode(new Uri("http://example.org/s2"));
+            g.Assert(new Triple(s1, p, o));
+            g.Assert(new Triple(s2, p, o));
+            
+            // No quads until graph is added
+            var quads = store.Quads.ToList();
+            Assert.Empty(quads);
+            
+            store.Add(g);
+            
+            quads = store.Quads.ToList();
+            Assert.Equal(2, quads.Count);
+            Assert.Contains(new Quad(s1, p, o, g.Name), quads);
+            Assert.Contains(new Quad(s2, p, o, g.Name), quads);
+        }
+        
+        [Fact]
+        public void EnumerateQuads02()
+        {
+            ITripleStore store = GetInstance();
+            IGraph g1 = new Graph(new UriNode(new Uri("http://example.org/g1")));
+            INode s1 = g1.CreateUriNode(new Uri("http://example.org/s1"));
+            IUriNode p = g1.CreateUriNode(new Uri("http://example.org/p"));
+            IUriNode o = g1.CreateUriNode(new Uri("http://example.org/o"));
+            IUriNode s2 = g1.CreateUriNode(new Uri("http://example.org/s2"));
+            g1.Assert(new Triple(s1, p, o));
+            g1.Assert(new Triple(s2, p, o));
+
+            IGraph g2 = new Graph(new UriNode(new Uri("http://example.org/g2")));
+            INode s12 = g2.CreateUriNode(new Uri("http://example.org/s1"));
+            IUriNode p2 = g2.CreateUriNode(new Uri("http://example.org/p"));
+            IUriNode o2 = g2.CreateUriNode(new Uri("http://example.org/o"));
+            IUriNode s22 = g2.CreateUriNode(new Uri("http://example.org/s2"));
+            g2.Assert(new Triple(s12, p2, o2));
+            g2.Assert(new Triple(s22, p2, o2));
+
+            // No quads until graph is added
+            var quads = store.Quads.ToList();
+            Assert.Empty(quads);
+            
+            store.Add(g1);
+            
+            quads = store.Quads.ToList();
+            Assert.Equal(2, quads.Count);
+            Assert.Contains(new Quad(s1, p, o, g1.Name), quads);
+            Assert.Contains(new Quad(s2, p, o, g1.Name), quads);
+
+            store.Add(g2);
+
+            quads = store.Quads.ToList();
+            Assert.Equal(4, quads.Count);
+            Assert.Contains(new Quad(s1, p, o, g1.Name), quads);
+            Assert.Contains(new Quad(s2, p, o, g1.Name), quads);
+            Assert.Contains(new Quad(s12, p2, o2, g2.Name), quads);
+            Assert.Contains(new Quad(s22, p2, o2, g2.Name), quads);
+        }
+
     }
 
 

--- a/Testing/dotNetRdf.Tests/Core/MimeTypesTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/MimeTypesTests.cs
@@ -2685,7 +2685,7 @@ namespace VDS.RDF
         {
             var request = new HttpRequestMessage();
             request.Headers.Add(HeaderNames.Accept, MimeTypesHelper.HttpSparqlAcceptHeader);
-            Assert.Equal(17, request.Headers.Accept.Count);
+            Assert.Equal(12, request.Headers.Accept.Count);
         }
 
         [Fact]
@@ -2693,7 +2693,7 @@ namespace VDS.RDF
         {
             var request = new HttpRequestMessage();
             request.Headers.Add(HeaderNames.Accept, MimeTypesHelper.HttpAcceptHeader);
-            Assert.Equal(41, request.Headers.Accept.Count);
+            Assert.Equal(21, request.Headers.Accept.Count);
         }
 
         [Fact]
@@ -2701,7 +2701,7 @@ namespace VDS.RDF
         {
             var request = new HttpRequestMessage();
             request.Headers.Add(HeaderNames.Accept, MimeTypesHelper.HttpRdfDatasetAcceptHeader);
-            Assert.Equal(10, request.Headers.Accept.Count);
+            Assert.Equal(6, request.Headers.Accept.Count);
         }
     }
 }

--- a/Testing/dotNetRdf.Tests/Core/QuadTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/QuadTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace VDS.RDF;
+
+public class QuadTests
+{
+    [Fact]
+    public void ConstructQuadFromFourNodes()
+    {
+        var nf = new NodeFactory();
+        INode s = nf.CreateUriNode(UriFactory.Create("http://example.org/s"));
+        INode p = nf.CreateUriNode(UriFactory.Create("http://example.org/p"));
+        INode o = nf.CreateUriNode(UriFactory.Create("http://example.org/o"));
+        IRefNode g = nf.CreateUriNode(UriFactory.Create("http://example.org/g"));
+        var q = new Quad(s, p, o, g);
+        Assert.Equal("http://example.org/s, http://example.org/p, http://example.org/o, http://example.org/g", q.ToString());
+    }
+    
+    [Fact]
+    public void ConstructQuadFromTripleAndGraph()
+    {
+        var nf = new NodeFactory();
+        INode s = nf.CreateUriNode(UriFactory.Create("http://example.org/s"));
+        INode p = nf.CreateUriNode(UriFactory.Create("http://example.org/p"));
+        INode o = nf.CreateUriNode(UriFactory.Create("http://example.org/o"));
+        var t = new Triple(s, p, o);
+        IRefNode g = nf.CreateUriNode(UriFactory.Create("http://example.org/g"));
+        var q = new Quad(t, g);
+        Assert.Equal("http://example.org/s, http://example.org/p, http://example.org/o, http://example.org/g", q.ToString());
+    }
+
+    [Fact]
+    public void QuadsEquality()
+    {
+        var nf = new NodeFactory();
+        INode s = nf.CreateUriNode(UriFactory.Create("http://example.org/s"));
+        INode p = nf.CreateUriNode(UriFactory.Create("http://example.org/p"));
+        INode o = nf.CreateUriNode(UriFactory.Create("http://example.org/o"));
+        var t = new Triple(s, p, o);
+        IRefNode g = nf.CreateUriNode(UriFactory.Create("http://example.org/g"));
+        var q1 = new Quad(t, g);
+        var q2 = new Quad(t.Subject, t.Predicate, t.Object, g);
+        var nf2 = new NodeFactory();
+        INode s2 = nf2.CreateUriNode(UriFactory.Create("http://example.org/s"));
+        INode p2 = nf2.CreateUriNode(UriFactory.Create("http://example.org/p"));
+        INode o2 = nf2.CreateUriNode(UriFactory.Create("http://example.org/o"));
+        IRefNode g2 = nf2.CreateUriNode(UriFactory.Create("http://example.org/g"));
+        var q3 = new Quad(s2, p2, o2, g2);
+        Assert.True(q1.Equals(q2));
+        Assert.True(q1.Equals(q3));
+        Assert.True(q2.Equals(q3));
+    }
+
+    [Fact]
+    public void QuadsComparability()
+    {
+        var nf = new NodeFactory();
+        INode s = nf.CreateUriNode(UriFactory.Create("http://example.org/s"));
+        INode p = nf.CreateUriNode(UriFactory.Create("http://example.org/p"));
+        INode o = nf.CreateLiteralNode("1");
+        IRefNode g = nf.CreateUriNode(UriFactory.Create("http://example.org/g"));   
+        INode s2 = nf.CreateUriNode(UriFactory.Create("http://example.org/s2"));
+        INode p2 = nf.CreateUriNode(UriFactory.Create("http://example.org/p2"));
+        INode o2 = nf.CreateLiteralNode("2");
+        IRefNode g2 = nf.CreateUriNode(UriFactory.Create("http://example.org/g2"));
+        var q1 = new Quad(s, p, o, g);
+        var q2 = new Quad(s2, p, o, g);
+        var q3 = new Quad(s, p2, o, g);
+        var q4 = new Quad(s, p, o2, g);
+        var q5 = new Quad(s, p, o, g2);
+        var l = new List<Quad>
+        {
+            q1,
+            q2,
+            q3,
+            q4,
+            q5
+        };
+        l.Sort();
+        var expectSort = new List<Quad>
+        {
+            q1,
+            q5,
+            q4,
+            q3,
+            q2
+        };
+        Assert.Equal(expectSort, l);
+    }
+}


### PR DESCRIPTION
* Add `Quad` type to represent a statement in a graph.
* Add  `IEnumerable<Quad> Quads` property to `ITripleStore` to iterate all quads in the loaded graphs of the store.
* Add `Assert(Quad)` and `Retract(Quad)` to `ITripleStore` to add / remove quads in the store.
* Add `GetQuads()` to `ITripleStore` to get a filtered enumeration of quads in the loaded graphs of the store.

There is a basic implementation of all of these properties/methods in `BaseTripleStore`