### PR TITLE
 Turtle / TriG QNames' localname may have leading digits

### DIFF
--- a/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
@@ -24,6 +24,7 @@
 // </copyright>
 */
 
+using AngleSharp.Text;
 using System;
 using System.Text.RegularExpressions;
 using VDS.RDF.Parsing.Tokens;

--- a/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
@@ -853,6 +853,10 @@ namespace VDS.RDF.Parsing
             {
                 return true;
             }
+            else if (c.IsDigit())
+            {
+                return true;
+            }
             else
             {
                 return false;

--- a/Testing/dotNetRdf.Tests/Query/QNameDigitsSupportTests.cs
+++ b/Testing/dotNetRdf.Tests/Query/QNameDigitsSupportTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using System.IO;
+using VDS.RDF.Parsing;
+using Xunit;
+
+namespace VDS.RDF.Query;
+
+public class QNameDigitsSupportTests
+{
+    [Fact]
+    public void QName__ShouldAllow__LeadingDigitInLocalName()
+    {
+        var trigParser = new TriGParser();
+        var tStore = new TripleStore();
+        var loadQnameWithLeadingDigit = Record.Exception(() =>
+            trigParser.Load(
+                tStore, 
+                new StringReader("@prefix exdata: <https://example.com/data/>. exdata:test1 { exdata:1test a <http://example.com/Thing> .}")
+            )
+        );
+
+        loadQnameWithLeadingDigit.Should().BeNull();
+    }
+}
+


### PR DESCRIPTION
According to W3C Trutle / TriG may have leading digits in their local name.
https://www.w3.org/TR/turtle/#h_note_2

I added support to allow for digits as starting characters for Turtle / TriG.

In addition I noted that there is a check that disallows more than one colon in a QName. This should be allowed per the above documentation from W3C, but I did not undertake this fix in this PR.

This fixes #632.

I used the test from the issue above as the base for a unit test.