### PR TITLE
Trig fixes and update

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,13 @@
 ﻿Change Log
 ==========
 
+Next Release (3.2.1)
+------------
+
+ENHANCEMENT: Update default syntax of the TRiG parser to be RDF 1.1 + RDF Star to be consistent with the defaults of the NTriples, NQuads and Turtle parsers. Thanks to @markus-ap for the report. (#640)
+FIX: Fix parsing of datatyped literals in collections in TRiG 1.1 + RDF Star
+Fix: Fix handling of QNames starting with "prefix" in Turtle tokenizer
+
 3.2.0
 ------
 NEW: Implementation of the November 2023 draft of the W3C [RDF Dataset Canonicalization](https://www.w3.org/TR/2023/CRD-rdf-canon-20231130/) specification. Thanks to @zotanmew and @deviant for this contribution. (#615)

--- a/Libraries/dotNetRdf.Core/Parsing/Tokens/TurtleTokeniser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/Tokens/TurtleTokeniser.cs
@@ -987,7 +987,9 @@ namespace VDS.RDF.Parsing.Tokens
                         if (!Value.Equals("prefix".Substring(0, Length), StringComparison.OrdinalIgnoreCase)) break;
                     }
 
-                    if (Value.Equals("prefix", StringComparison.OrdinalIgnoreCase))
+                    var afterPrefix = Peek();
+
+                    if (Value.Equals("prefix", StringComparison.OrdinalIgnoreCase) && char.IsWhiteSpace(afterPrefix))
                     {
                         LastTokenType = Token.PREFIXDIRECTIVE;
                         return new PrefixDirectiveToken(CurrentLine, StartPosition);

--- a/Testing/dotNetRdf.Ldf.Tests/dotNetRdf.Ldf.Tests.csproj
+++ b/Testing/dotNetRdf.Ldf.Tests/dotNetRdf.Ldf.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>dotNetRdf.LDF.Tests</RootNamespace>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Testing/dotNetRdf.Tests/Parsing/Suites/TriG.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/Suites/TriG.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF.Parsing.Suites
         private readonly ITestOutputHelper _testOutputHelper;
 
         public TriG(ITestOutputHelper testOutputHelper)
-            : base(new TriGParser(), new NQuadsParser(), "trig")
+            : base(new TriGParser(TriGSyntax.MemberSubmission), new NQuadsParser(), "trig")
         {
             _testOutputHelper = testOutputHelper;
             CheckResults = false;

--- a/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
@@ -259,5 +259,16 @@ namespace VDS.RDF.Parsing
             Assert.Single(store.Graphs);
             Assert.Single(store.Triples);
         }
+
+        [Fact]
+        public void ParsingPrefixCalledPrefix()
+        {
+            const string data = @"@prefix prefix1: <http://example.com/>.
+<http://example.org/cyrillic> {
+    prefix1:test1 prefix1:pred1 ""литерал"".
+    prefix1:test2 prefix1:pred1 ""EnglishTest"".
+}";
+            TestParsing(data, TriGSyntax.Rdf11Star, true);
+        }
     }
 }

--- a/Testing/dotNetRdf.Tests/Query/SparqlParsingComplex.cs
+++ b/Testing/dotNetRdf.Tests/Query/SparqlParsingComplex.cs
@@ -224,7 +224,7 @@ namespace VDS.RDF.Query
         public void SparqlEvaluationMultipleOptionals()
         {
             var store = new TripleStore();
-            store.LoadFromFile(Path.Combine("resources", "multiple-options.trig"));
+            store.LoadFromFile(Path.Combine("resources", "multiple-options.trig"), new TriGParser(TriGSyntax.MemberSubmission));
 
             var parser = new SparqlQueryParser();
             SparqlQuery query = parser.ParseFromFile(Path.Combine("resources", "multiple-optionals.rq"));
@@ -245,7 +245,7 @@ namespace VDS.RDF.Query
         public void SparqlEvaluationMultipleOptionals2()
         {
             var store = new TripleStore();
-            store.LoadFromFile(Path.Combine("resources", "multiple-options.trig"));
+            store.LoadFromFile(Path.Combine("resources", "multiple-options.trig"), new TriGParser(TriGSyntax.MemberSubmission));
 
             var parser = new SparqlQueryParser();
             SparqlQuery query = parser.ParseFromFile(Path.Combine("resources", "multiple-optionals-alternate.rq"));


### PR DESCRIPTION
* Update the default syntax of the TriG parser to be RDF 1.1 + RDF-Star (which matches the default used by TriGWriter and by the Turtle, NTriples and NQuads parsers). Resolves #640 
* Fix handling of datatyped literals in collections in the TriG parser
* Fix tokenization of QNames that start with the string "prefix" (case-insensitive) which were being incorrectly identified as a prefix directive even if the string is followed by other non-whitespace characters.