### PR TITLE
Line endings for canonicalized nquads should always be `\n`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ Testing/dotNetRdf.Tests/resources/turtle11/*   -text
 Testing/dotNetRdf.Tests/resources/turtle11-unofficial/*   -text
 Testing/dotNetRdf.Tests/resources/trig11/* -text
 Testing/dotNetRdf.TestSuite.Rdfa/resources/** -text
+Testing/dotNetRdf.TestSuite.RdfCanon/resources/rdfc10/* -text

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,6 +7,7 @@ Next Release (3.2.1)
 ENHANCEMENT: Update default syntax of the TRiG parser to be RDF 1.1 + RDF Star to be consistent with the defaults of the NTriples, NQuads and Turtle parsers. Thanks to @markus-ap for the report. (#640)
 FIX: Fix parsing of datatyped literals in collections in TRiG 1.1 + RDF Star
 Fix: Fix handling of QNames starting with "prefix" in Turtle tokenizer
+FIX: Fix RdfCanonicalizer so that the line ending in the canonical NQuads output is always `\n` and not `\r\n` on Windows platforms. Thanks to @veikkoeeva for the report. (#631)
 
 3.2.0
 ------

--- a/Libraries/dotNetRdf.Core/Core/RdfCanonicalizer.cs
+++ b/Libraries/dotNetRdf.Core/Core/RdfCanonicalizer.cs
@@ -388,7 +388,22 @@ public class RdfCanonicalizer(string hashAlgorithm = "SHA256")
         /// <summary>
         /// The dataset, serialized in canonical n-quads form.
         /// </summary>
-        public readonly string SerializedNQuads = new NQuads11Formatter().Format(outputDataset);
+        public string SerializedNQuads
+        {
+            get
+            {
+                var sb = new StringBuilder();
+                var formatter = new NQuads11Formatter();
+                outputDataset.Graphs
+                    .SelectMany(graph => graph.Triples.Select(triple => formatter.Format(triple, graph.Name)))
+                    .OrderBy(p => p, StringComparer.Ordinal).ToList().ForEach(s =>
+                    {
+                        sb.Append(s);
+                        sb.Append("\n");
+                    });
+                return sb.ToString();
+            }
+        }
 
         /// <summary>
         /// The input dataset.
@@ -405,4 +420,5 @@ public class RdfCanonicalizer(string hashAlgorithm = "SHA256")
         /// </summary>
         public readonly IDictionary<string, string> IssuedIdentifiersMap = issuedIdentifiersMap;
     }
+    
 }

--- a/Libraries/dotNetRdf.Core/Writing/Formatting/NQuadsFormatter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/Formatting/NQuadsFormatter.cs
@@ -88,20 +88,6 @@ namespace VDS.RDF.Writing.Formatting
             }
             return Format(t.Subject, TripleSegment.Subject) + " " + Format(t.Predicate, TripleSegment.Predicate) + " " + Format(t.Object, TripleSegment.Object) + " " + Format(graph) + " .";
         }
-
-        /// <summary>
-        /// Formats a TripleStore as a String. Especially useful for canonicalized graphs.
-        /// </summary>
-        /// <param name="store"></param>
-        /// <returns></returns>
-        public string Format(ITripleStore store)
-        {
-            var sb = new StringBuilder();
-            store.Graphs
-                .SelectMany(graph => graph.Triples.Select(triple => this.Format(triple, graph.Name)))
-                .OrderBy(p => p, StringComparer.Ordinal).ToList().ForEach(s => sb.AppendLine(s));
-            return sb.ToString();
-        }
     }
 
     /// <summary>

--- a/Testing/dotNetRdf.TestSuite.RdfCanon/RdfCanonTestSuite.cs
+++ b/Testing/dotNetRdf.TestSuite.RdfCanon/RdfCanonTestSuite.cs
@@ -29,8 +29,11 @@ public class RdfCanonTestSuite(ITestOutputHelper output) : RdfTestSuite
     internal void EvalTest(ManifestTestData t)
     {
         var resultInputPath = t.Manifest.ResolveResourcePath(t.Result);
-        var expectedResult = File.ReadAllText(resultInputPath);
-
+        string expectedResult;
+        using (var sr = new StreamReader(new FileStream(resultInputPath, FileMode.Open), Encoding.UTF8))
+        {
+            expectedResult = sr.ReadToEnd();
+        }
         RdfCanonicalizer.CanonicalizedRdfDataset result = RunCanonicalize(t);
 
         result.SerializedNQuads.Should().BeEquivalentTo(expectedResult);


### PR DESCRIPTION
* Move the logic for producing the canoncalized nquads output from NQuads11Formatter to RdfCanonicalizer
* Ensure that the line ending character is always `\n` rather than using `AppendLine` which varies line-ending by platform.
* Update gitattrbutes for RDF Canonicalization test suite to ensure line-endings are not modified on Windows platforms.
Fixes #631 