### PR TITLE
Fix for execution of a SERVICE clause in an update

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@
 Next Release (3.2.1)
 ------------
 
+FIX: Fix SERVICE query timeout calculation in update commands which was causing SPARQL updates with a SERVICE clause to abort prematurely. Thanks to @rdstn for the report. (#641)
 ENHANCEMENT: Update default syntax of the TRiG parser to be RDF 1.1 + RDF Star to be consistent with the defaults of the NTriples, NQuads and Turtle parsers. Thanks to @markus-ap for the report. (#640)
 FIX: Fix parsing of datatyped literals in collections in TRiG 1.1 + RDF Star
 Fix: Fix handling of QNames starting with "prefix" in Turtle tokenizer

--- a/Libraries/dotNetRdf.Core/Query/LeviathanQueryProcessor.cs
+++ b/Libraries/dotNetRdf.Core/Query/LeviathanQueryProcessor.cs
@@ -2118,9 +2118,14 @@ namespace VDS.RDF.Query
                 {
                     // Try and get a Result Set from the Service
                     var cts = new CancellationTokenSource();
-                    cts.CancelAfter(TimeSpan.FromMilliseconds(context.RemainingTimeout));
-                    var task = Task.Run(() => endpoint.QueryWithResultSetAsync(query.ToString(), cts.Token));
-                    task.Wait();
+                    var remainingTimeMillis = context.RemainingTimeout;
+                    if (remainingTimeMillis > 0)
+                    {
+                        cts.CancelAfter(TimeSpan.FromMilliseconds(remainingTimeMillis));
+                    }
+
+                    Task<SparqlResultSet> task = endpoint.QueryWithResultSetAsync(query.ToString(), cts.Token);
+                    task.Wait(cts.Token);
                     context.CheckTimeout();
 
                     // Transform this Result Set back into a Multiset

--- a/Libraries/dotNetRdf.Core/Update/LeviathanUpdateOptions.cs
+++ b/Libraries/dotNetRdf.Core/Update/LeviathanUpdateOptions.cs
@@ -53,7 +53,11 @@ namespace VDS.RDF.Update
         public long UpdateExecutionTimeout
         {
             get => _updateExecutionTimeout;
-            set => _updateExecutionTimeout = Math.Max(0, value);
+            set
+            {
+                _updateExecutionTimeout = Math.Max(0, value);
+                QueryExecutionTimeout = _updateExecutionTimeout;
+            }
         }
     }
 }

--- a/Libraries/dotNetRdf.Core/Update/LeviathanUpdateProcessor.cs
+++ b/Libraries/dotNetRdf.Core/Update/LeviathanUpdateProcessor.cs
@@ -973,7 +973,9 @@ namespace VDS.RDF.Update
                     context.Data.SetActiveGraph(cmd.UsingUris.Select<Uri, IRefNode>(u => new UriNode(u)).ToList());
                     datasetOk = true;
                 }
+                queryContext.StartExecution(context.RemainingTimeout);
                 BaseMultiset results = queryContext.Evaluate(where);
+                queryContext.EndExecution();
                 if (results is IdentityMultiset) results = new SingletonMultiset(results.Variables);
                 if (cmd.UsingUris.Any())
                 {

--- a/Testing/dotNetRdf.Tests/Query/ServiceTests.cs
+++ b/Testing/dotNetRdf.Tests/Query/ServiceTests.cs
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using Xunit;
 using VDS.RDF.Parsing;
+using VDS.RDF.Update;
 
 namespace VDS.RDF.Query
 {
@@ -38,7 +39,7 @@ namespace VDS.RDF.Query
         }
 
         [Fact]
-        public void SparqlService()
+        public void SparqlServiceQuery()
         {
             _serverFixture.RegisterSelectQueryGetHandler("SELECT * WHERE { ?s ?p ?o . } LIMIT 10 ");
             var query = $"SELECT * WHERE {{ SERVICE <{_serverFixture.Server.Urls[0] + "/sparql"}> {{ ?s ?p ?o }} }} LIMIT 10";
@@ -52,6 +53,20 @@ namespace VDS.RDF.Query
             Assert.NotEmpty(resultSet.Results);
         }
 
+        [Fact]
+        public void SparqlServiceUpdate()
+        {
+            _serverFixture.RegisterSelectQueryGetHandler("SELECT * WHERE \r\n{ ?s ?p ?o . }\r\n");
+            // _serverFixture.RegisterSelectQueryPostHandler();
+            var query = $"INSERT {{ ?s ?p ?o }} WHERE {{ SERVICE <{_serverFixture.Server.Urls[0] + "/sparql"}> {{ ?s ?p ?o . }} }}";
+            var parser = new SparqlUpdateParser();
+            SparqlUpdateCommandSet q = parser.ParseFromString(query);
+
+            var processor =
+                new LeviathanUpdateProcessor(new TripleStore(), options => options.UpdateExecutionTimeout = 15000);
+            processor.ProcessCommandSet(q);
+        }
+        
         [Fact]
         [Trait("Category", "explicit")]
         public void SparqlServiceUsingBindings()


### PR DESCRIPTION
* Fix the setup of the query context used in an update command so that the remaining processing time is properly used to set the query timeout.
* Fix the use of the remaining processing time when making federated query calls to handle the case where there is explicitly no timeout set.

Fixes #641 