### PR TITLE
Fix generation of distinct blank nodes in a construct query

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -9,6 +9,7 @@ ENHANCEMENT: Update default syntax of the TRiG parser to be RDF 1.1 + RDF Star t
 FIX: Fix parsing of datatyped literals in collections in TRiG 1.1 + RDF Star
 Fix: Fix handling of QNames starting with "prefix" in Turtle tokenizer
 FIX: Fix RdfCanonicalizer so that the line ending in the canonical NQuads output is always `\n` and not `\r\n` on Windows platforms. Thanks to @veikkoeeva for the report. (#631)
+FIX: Fix handling of CONSTRUCT queries so that blank nodes in the CONSTRUCT template are unique for each solution binding. Thanks to @JohanMollevikCap for the report. (#639)
 
 3.2.0
 ------

--- a/Libraries/dotNetRdf.Core/Query/Construct/ConstructContext.cs
+++ b/Libraries/dotNetRdf.Core/Query/Construct/ConstructContext.cs
@@ -142,6 +142,11 @@ namespace VDS.RDF.Query.Construct
         /// </remarks>
         public INode GetNode(INode n)
         {
+            return GetNode(n, false);
+        }
+
+        private INode GetNode(INode n, bool preserveBlankNodes)
+        {
             _nodeMap ??= new MultiDictionary<INode, INode>(new FastVirtualNodeComparer());
 
             if (_nodeMap.TryGetValue(n, out INode node)) return node;
@@ -150,7 +155,7 @@ namespace VDS.RDF.Query.Construct
             switch (n.NodeType)
             {
                 case NodeType.Blank:
-                    temp = GetBlankNode(((IBlankNode)n).InternalID);
+                    temp = preserveBlankNodes ? NodeFactory.CreateBlankNode(((IBlankNode)n).InternalID) :  GetBlankNode(((IBlankNode)n).InternalID);
                     break;
 
                 case NodeType.Variable:
@@ -186,9 +191,9 @@ namespace VDS.RDF.Query.Construct
 
                 case NodeType.Triple:
                     var t = (ITripleNode)n;
-                    INode s = GetNode(t.Triple.Subject);
-                    INode p = GetNode(t.Triple.Predicate);
-                    INode o = GetNode(t.Triple.Object);
+                    INode s = GetNode(t.Triple.Subject, true);
+                    INode p = GetNode(t.Triple.Predicate, true);
+                    INode o = GetNode(t.Triple.Object, true);
                     var triple = new Triple(s, p, o);
                     temp = NodeFactory.CreateTripleNode(triple);
                     break;

--- a/Libraries/dotNetRdf.Core/Query/LeviathanQueryProcessor.cs
+++ b/Libraries/dotNetRdf.Core/Query/LeviathanQueryProcessor.cs
@@ -257,9 +257,9 @@ namespace VDS.RDF.Query
 
                                 // Construct the Triples for each Solution
                                 if (context.OutputMultiset is IdentityMultiset) context.OutputMultiset = new SingletonMultiset();
-                                var constructContext = new ConstructContext(rdfHandler, false);
                                 foreach (ISet s in context.OutputMultiset.Sets)
                                 {
+                                    var constructContext = new ConstructContext(rdfHandler, false);
                                     try
                                     {
                                         constructContext.Set = s;

--- a/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarEvaluationTestSuite.cs
+++ b/Testing/dotNetRdf.TestSuite.RdfStar/SparqlStarEvaluationTestSuite.cs
@@ -136,7 +136,7 @@ namespace VDS.RDF.TestSuite.RdfStar
         {
             ManifestTestData testData =
                 SparqlStarEvalTests.GetTestData(
-                    new Uri("https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-update-1"));
+                    new Uri("https://w3c.github.io/rdf-star/tests/sparql/eval#sparql-star-expr-1"));
             InvokeTestRunner(testData);
         }
     }

--- a/Testing/dotNetRdf.TestSupport/TestTools.cs
+++ b/Testing/dotNetRdf.TestSupport/TestTools.cs
@@ -172,6 +172,16 @@ namespace VDS.RDF
             }
         }
 
+        public static void AssertIsomorphic(IGraph expectGraph, IGraph actualGraph, ITestOutputHelper outputHelper)
+        {
+            GraphDiffReport diffs = expectGraph.Difference(actualGraph);
+            if (!diffs.AreEqual)
+            {
+                ShowDifferences(diffs, "expected", "actual", outputHelper);
+                Assert.Fail("Graphs are not isomorphic.");
+            }
+        }
+
         public static void ShowGraph(IGraph g, ITestOutputHelper _output)
         {
             try


### PR DESCRIPTION
Update the code for executing CONSTRUCT queries so that the ConstructContext is reset for each query solution. This fixes #639