### PR TITLE
Verify that #634 is fixed.

### DIFF
--- a/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/TriGTests.cs
@@ -23,6 +23,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using FluentAssertions;
 using System;
 using System.IO;
 using System.Linq;
@@ -258,6 +259,19 @@ namespace VDS.RDF.Parsing
             store.LoadFromString(data, new TriGParser(TriGSyntax.Rdf11));
             Assert.Single(store.Graphs);
             Assert.Single(store.Triples);
+        }
+
+        [Fact]
+        public void ParsingPrefixedNameWithColon()
+        {
+            // Reproduce error reported in #634
+            const string input = "@prefix ex: <http://example.org/>. ex:foo { ex:foo:bar:baz ex:value \"a\" . }";
+            var store = new TripleStore();
+            store.LoadFromString(input, new TriGParser(TriGSyntax.Rdf11));
+            Assert.Single(store.Graphs);
+            Assert.Single(store.Triples);
+            store.Triples.First().Subject.Should().BeAssignableTo<IUriNode>().Which.Uri.AbsoluteUri.Should()
+                .Be("http://example.org/foo:bar:baz");
         }
 
         [Fact]

--- a/Testing/dotNetRdf.Tests/Parsing/TurtleTests.cs
+++ b/Testing/dotNetRdf.Tests/Parsing/TurtleTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace VDS.RDF.Parsing
@@ -26,7 +27,19 @@ namespace VDS.RDF.Parsing
             var g = new Graph();
             reader.Load(g, new StringReader(input));
             g.Triples.Count.Should().Be(5);
+        }
 
+        [Fact]
+        public void ItAllowsColonInLocalPartOfPrefixedName()
+        {
+            // Reproduce error reported in #634
+            const string input = "@prefix ex: <http://example.org/>. ex:foo:bar ex:value \"a\" .";
+            var reader = new TurtleParser(TurtleSyntax.W3C, true);
+            var g = new Graph();
+            reader.Load(g, new StringReader(input));
+            g.Triples.Count.Should().Be(1);
+            g.Triples.First().Subject.Should().BeAssignableTo<IUriNode>().Which.Uri.AbsoluteUri.Should()
+                .Be("http://example.org/foo:bar");
         }
     }
 }


### PR DESCRIPTION
This PR just adds a couple of tests of parsing a prefixed name with a colon in the local part in TriG and Turtle syntaxes. It verifies that #634 is fixed.