### PR TITLE
Fix handling of class URIs in HtmlSchemaWriter

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,7 +10,7 @@ FIX: Fix parsing of datatyped literals in collections in TRiG 1.1 + RDF Star
 Fix: Fix handling of QNames starting with "prefix" in Turtle tokenizer
 FIX: Fix RdfCanonicalizer so that the line ending in the canonical NQuads output is always `\n` and not `\r\n` on Windows platforms. Thanks to @veikkoeeva for the report. (#631)
 FIX: Fix handling of CONSTRUCT queries so that blank nodes in the CONSTRUCT template are unique for each solution binding. Thanks to @JohanMollevikCap for the report. (#639)
-
+FIX: Fix HtmlSchemaWriter to handle writing classes whose IRI is not successfully compressed to a QName. Thanks to @sixdiamants for the report. (#629)
 3.2.0
 ------
 NEW: Implementation of the November 2023 draft of the W3C [RDF Dataset Canonicalization](https://www.w3.org/TR/2023/CRD-rdf-canon-20231130/) specification. Thanks to @zotanmew and @deviant for this contribution. (#615)

--- a/Libraries/dotNetRdf.Writing.HtmlSchema/Writing/HtmlSchemaWriter.cs
+++ b/Libraries/dotNetRdf.Writing.HtmlSchema/Writing/HtmlSchemaWriter.cs
@@ -490,7 +490,8 @@ namespace VDS.RDF.Writing
                         }
                         else
                         {
-                            var temp = new Uri(qname, UriKind.RelativeOrAbsolute);
+                            var iri = qname.Trim('<','>');
+                            var temp = new Uri(iri, UriKind.RelativeOrAbsolute);
                             if (!temp.Fragment.Equals(string.Empty))
                             {
                                 context.HtmlWriter.WriteEncodedText(temp.Fragment);

--- a/Testing/dotNetRdf.Writing.HtmlSchema.Tests/WriterTests.cs
+++ b/Testing/dotNetRdf.Writing.HtmlSchema.Tests/WriterTests.cs
@@ -6,6 +6,7 @@ using VDS.RDF.Parsing;
 using VDS.RDF.Writing;
 using Xunit;
 using Xunit.Abstractions;
+using StringWriter = VDS.RDF.Writing.StringWriter;
 
 namespace VDS.RDF
 {
@@ -91,6 +92,15 @@ namespace VDS.RDF
 
             Assert.True(strWriter.ToString().Contains("ex:one"), "Should have documented ex:one as a range");
             Assert.True(strWriter.ToString().Contains("ex:two"), "Should have documented ex:two as a range");
+        }
+        
+        [Fact]
+        public void ItCanWriteNodesWithNoFragment()
+        {
+            var graph = new Graph();
+            graph.LoadFromString("<http://example.org/MyClass> a <http://www.w3.org/2002/07/owl#Class> .", new TurtleParser());
+            var html = StringWriter.Write(graph, new HtmlSchemaWriter());
+            Assert.True(html.Contains("MyClass"), "Should have documented MyClass as a class");
         }
     }
 


### PR DESCRIPTION
Fix to properly handle classes with an IRI that cannot be compressed to a QName.

Fixes #629 