### PR TITLE
Add configuration loader support for pull query processor

### DIFF
--- a/Libraries/dotNetRdf.Core/Configuration/ConfigurationLoader.cs
+++ b/Libraries/dotNetRdf.Core/Configuration/ConfigurationLoader.cs
@@ -1062,7 +1062,39 @@ namespace VDS.RDF.Configuration
         }
 
         /// <summary>
-        /// Gets the 64 bit Integer value or a given default of the first instance of a property for a given Object in the Configuration Graph.
+        /// Gets the unsigned 64-bit Integer value or a given default of the first instance of a property for a given Object in the Configuration Graph.
+        /// </summary>
+        /// <param name="g">Configuration Graph.</param>
+        /// <param name="objNode">Object Node.</param>
+        /// <param name="property">Property Node.</param>
+        /// <param name="defValue">Default Value to return if there is no valid boolean value.</param>
+        /// <returns>
+        /// If there is a valid unsigned integer value for the property then that is returned, in any other case the given <paramref name="defValue">Default Value</paramref> is returned.
+        /// </returns>
+        public static ulong GetConfigurationUInt64(IGraph g, INode objNode, INode property, ulong defValue)
+        {
+            INode n = g.GetTriplesWithSubjectPredicate(objNode, property).Select(t => t.Object).FirstOrDefault();
+            if(n == null) return defValue;
+            // Resolve AppSettings
+            if (n.NodeType != NodeType.Literal)
+            {
+                n = ResolveAppSetting(g, n);
+                if (n == null) return defValue;
+            }
+
+            if (n.NodeType == NodeType.Literal)
+            {
+                if (ulong.TryParse(((ILiteralNode)n).Value, out var temp))
+                {
+                    return temp;
+                }
+                return defValue;
+            }
+            return defValue;
+        }
+
+        /// <summary>
+        /// Gets the 64-bit Integer value or a given default of the first instance of a property for a given Object in the Configuration Graph.
         /// </summary>
         /// <param name="g">Configuration Graph.</param>
         /// <param name="objNode">Object Node.</param>
@@ -1095,7 +1127,7 @@ namespace VDS.RDF.Configuration
         }
 
         /// <summary>
-        /// Gets the 64 bit Integer value or a given default of the first instance of the first property for a given Object in the Configuration Graph.
+        /// Gets the 64-bit Integer value or a given default of the first instance of the first property for a given Object in the Configuration Graph.
         /// </summary>
         /// <param name="g">Configuration Graph.</param>
         /// <param name="objNode">Object Node.</param>
@@ -1130,7 +1162,7 @@ namespace VDS.RDF.Configuration
         }
 
         /// <summary>
-        /// Gets the 64 bit Integer value or a given default of the first instance of a property for a given Object in the Configuration Graph.
+        /// Gets the 32-bit Integer value or a given default of the first instance of a property for a given Object in the Configuration Graph.
         /// </summary>
         /// <param name="g">Configuration Graph.</param>
         /// <param name="objNode">Object Node.</param>
@@ -1163,7 +1195,7 @@ namespace VDS.RDF.Configuration
         }
 
         /// <summary>
-        /// Gets the 64 bit Integer value or a given default of the first instance of the first property for a given Object in the Configuration Graph.
+        /// Gets the 32-bit Integer value or a given default of the first instance of the first property for a given Object in the Configuration Graph.
         /// </summary>
         /// <param name="g">Configuration Graph.</param>
         /// <param name="objNode">Object Node.</param>

--- a/Libraries/dotNetRdf.Query.Pull/Configuration/PullQueryProcessorConfigurationFactory.cs
+++ b/Libraries/dotNetRdf.Query.Pull/Configuration/PullQueryProcessorConfigurationFactory.cs
@@ -1,0 +1,68 @@
+using VDS.RDF.Configuration;
+
+namespace VDS.RDF.Query.Pull.Configuration;
+
+/// <summary>
+/// Factory class for producing a <see cref="PullQueryProcessor"/> from a configuration graph.
+/// </summary>
+public class PullQueryProcessorConfigurationFactory : IObjectFactory
+{
+    private const string PullQueryProcessor = "VDS.RDF.Query.Pull.PullQueryProcessor";
+    
+
+    /// <inheritdoc />
+    public bool TryLoadObject(IGraph g, INode objNode, Type targetType, out object? obj)
+    {
+        obj = null;
+        ISparqlQueryProcessor? queryProcessor = null;
+
+        // Get the property nodes we will use to load the configuration
+        INode usingStore = g.CreateUriNode(UriFactory.Create(ConfigurationLoader.PropertyUsingStore));
+        switch (targetType.FullName)
+        {
+            case PullQueryProcessor:
+                INode storeObj = ConfigurationLoader.GetConfigurationNode(g, objNode, usingStore);
+                if (storeObj == null) return false;
+                var store = ConfigurationLoader.LoadObject(g, storeObj);
+                if (store is ITripleStore tripletStoreObj)
+                {
+                    queryProcessor = new PullQueryProcessor(tripletStoreObj, options =>
+                    {
+                        ApplyConfigurationOptions(options, g, objNode);
+                    });
+                }
+                break;
+        }
+        obj = queryProcessor;
+        return queryProcessor != null;
+    }
+
+    private void ApplyConfigurationOptions(PullQueryOptions options, IGraph g, INode objNode)
+    {
+        INode? timeoutNode = g.GetUriNode(UriFactory.Create(ConfigurationLoader.PropertyTimeout));
+        if (timeoutNode != null)
+        {
+            var timeout = ConfigurationLoader.GetConfigurationUInt64(g, objNode, timeoutNode, PullQueryOptions.DefaultQueryExecutionTimeout);
+            options.QueryExecutionTimeout = timeout;
+        }
+        
+        INode? unionDefaultGraphNode = g.GetUriNode(UriFactory.Create(ConfigurationLoader.PropertyUnionDefaultGraph));
+        if (unionDefaultGraphNode != null)
+        {
+            var unionDefaultGraph = ConfigurationLoader.GetConfigurationBoolean(g, objNode, unionDefaultGraphNode, false);
+            options.UnionDefaultGraph = unionDefaultGraph;
+        }
+    }
+    
+    /// <inheritdoc />
+    public bool CanLoadObject(Type t)
+    {
+        switch (t.FullName)
+        {
+            case PullQueryProcessor:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/Libraries/dotNetRdf.Query.Pull/PullQueryOptions.cs
+++ b/Libraries/dotNetRdf.Query.Pull/PullQueryOptions.cs
@@ -37,6 +37,11 @@ namespace VDS.RDF.Query.Pull;
 public class PullQueryOptions
 {
     /// <summary>
+    /// The default query timeout in milliseconds.
+    /// </summary>
+    public static ulong DefaultQueryExecutionTimeout = 180000;
+    
+    /// <summary>
     /// Get or set the node comparer to use in evaluation. 
     /// </summary>
     public ISparqlNodeComparer NodeComparer = new SparqlNodeComparer(
@@ -45,8 +50,8 @@ public class PullQueryOptions
     /// <summary>
     /// Get or set the hard timeout limit for SPARQL query execution (in milliseconds).
     /// </summary>
-    /// <remarks>Defaults to 180 000 (3 minutes). When set to 0, no timeout limit is applied to query evaluation.</remarks>
-    public ulong QueryExecutionTimeout { get; set; } 
+    /// <remarks>Defaults to <see cref="DefaultQueryExecutionTimeout"/>. When set to 0, no timeout limit is applied to query evaluation.</remarks>
+    public ulong QueryExecutionTimeout { get; set; } = DefaultQueryExecutionTimeout;
 
     /// <summary>
     /// Get or set the optimisers to be applied to a query algebra prior to evaluation.

--- a/Libraries/dotNetRdf.Query.Pull/PullQueryProcessor.cs
+++ b/Libraries/dotNetRdf.Query.Pull/PullQueryProcessor.cs
@@ -13,6 +13,16 @@ public class PullQueryProcessor : ISparqlQueryProcessor
     private readonly PullQueryOptions _options = new();
 
     /// <summary>
+    /// Gets the query execution timeout (in ms) configured for this processor.
+    /// </summary>
+    public ulong QueryExecutionTimeout { get { return _options.QueryExecutionTimeout; } }
+    
+    /// <summary>
+    /// Gets the union default graph setting configured for this processor.
+    /// </summary>
+    public bool UnionDefaultGraph {get {return _options.UnionDefaultGraph;}}
+    
+    /// <summary>
     /// Construct a new query processor instance.
     /// </summary>
     /// <param name="tripleStore">The store to query against</param>

--- a/Testing/dotNetRdf.Query.Pull.Tests/ConfigurationTests.cs
+++ b/Testing/dotNetRdf.Query.Pull.Tests/ConfigurationTests.cs
@@ -1,0 +1,80 @@
+using VDS.RDF;
+using VDS.RDF.Configuration;
+using VDS.RDF.Query.Pull;
+using VDS.RDF.Query.Pull.Configuration;
+
+namespace dotNetRdf.Query.Pull.Tests;
+
+public class ConfigurationTests
+{
+    public ConfigurationTests()
+    {
+        ConfigurationLoader.AddObjectFactory(new PullQueryProcessorConfigurationFactory());
+    }
+
+    [Fact]
+    public void ItLoadsConfigurationWithNoOptions()
+    {
+        var configGraph = new Graph();
+        configGraph.LoadFromString(
+            """
+            @prefix : <http://example.org/> .
+            @prefix dnr: <http://www.dotnetrdf.org/configuration#> .
+            :queryProcessor dnr:type "VDS.RDF.Query.Pull.PullQueryProcessor" ;
+              dnr:usingStore [
+                dnr:type "VDS.RDF.TripleStore" ;
+              ] ;
+            .
+            """);
+        INode? configNode = configGraph.GetUriNode(UriFactory.Create("http://example.org/queryProcessor"));
+        Assert.NotNull(configNode);
+        var loadedObject = ConfigurationLoader.LoadObject(configGraph, configNode);
+        Assert.NotNull(loadedObject);
+        Assert.IsType<PullQueryProcessor>(loadedObject);
+    }
+
+    [Fact]
+    public void ItLoadsConfigurationWithOptions()
+    {
+        var configGraph = new Graph();
+        configGraph.LoadFromString(
+            """
+            @prefix : <http://example.org/> .
+            @prefix dnr: <http://www.dotnetrdf.org/configuration#> .
+            :queryProcessor a dnr:SparqlQueryProcessor ;
+              dnr:type "VDS.RDF.Query.Pull.PullQueryProcessor" ;
+              dnr:usingStore [
+                dnr:type "VDS.RDF.TripleStore" ;
+              ] ;
+              dnr:timeout 60000 ;
+              dnr:unionDefaultGraph true ;
+            .
+            """);
+        INode? configNode = configGraph.GetUriNode(UriFactory.Create("http://example.org/queryProcessor"));
+        Assert.NotNull(configNode);
+        var loadedObject = ConfigurationLoader.LoadObject(configGraph, configNode);
+        Assert.NotNull(loadedObject);
+        PullQueryProcessor processor = Assert.IsType<PullQueryProcessor>(loadedObject);
+        Assert.True(processor.UnionDefaultGraph);
+        Assert.Equal(60000ul, processor.QueryExecutionTimeout);
+    }
+
+    [Fact]
+    public void ItFailsToLoadIfThereIsNoConfiguredStoreOption()
+    {
+        var configGraph = new Graph();
+        configGraph.LoadFromString(
+            """
+            @prefix : <http://example.org/> .
+            @prefix dnr: <http://www.dotnetrdf.org/configuration#> .
+            :queryProcessor a dnr:SparqlQueryProcessor ;
+              dnr:type "VDS.RDF.Query.Pull.PullQueryProcessor" ;
+              dnr:timeout 60000 ;
+              dnr:unionDefaultGraph true ;
+            .
+            """);
+        INode? configNode = configGraph.GetUriNode(UriFactory.Create("http://example.org/queryProcessor"));
+        Assert.NotNull(configNode);
+        Assert.Throws<DotNetRdfConfigurationException>(() => ConfigurationLoader.LoadObject(configGraph, configNode));
+    }
+}

--- a/docs/user_guide/configuration/query_processors.md
+++ b/docs/user_guide/configuration/query_processors.md
@@ -94,19 +94,28 @@ _:endpoint a dnr:SparqlQueryClient ;
 
 The above configures a Remote Query Processor which passes queries to the endpoint at `http://example.org/sparql`
 
-## Pellet Query Processor 
+## Pull Query Processor
 
-The Pellet Query Processor is used to pass queries to the SPARQL service provided by a knowledge base on some remote Pellet Server.
-It is configured by adding the `dnr:server` and `dnr:storeID` properties to the basic configuration like so:
+The Pull Query Processor is an alternate in-memory SPARQL query engine implementation which aims to minimize the size
+of intermediate results sets during processing by using a streaming approach to query evaluation.
+
+The Pull Query Processor must be configured with a [Triple Store](triple_stores.md) instance to query against and accepts
+options for setting the default query execution timeout and whether the default graph is the union of all graphs.
 
 ```turtle
 
 @prefix dnr: <http://www.dotnetrdf.org/configuration#> .
 
-_:proc a dnr:SparqlQueryProcessor ;
-  dnr:type "VDS.RDF.Query.PelletQueryProcessor" ;
-  dnr:server "http://ps.clarkparsia.com" ;
-  dnr:storeID "wine" .
+_:proc a dnr:SparqlQueryProcessor
+  dnr:type "VDS.RDF.Query.Pull.PullQueryProcessor" ;
+  dnr:usingStore _:store ;
+  dnr:timeout 60000 ;
+  dnr:unionDefaultGraph true ;
+.
+
+_:store a dnr:TripleStore ;
+  dnr:type "VDS.RDF.TripleStore" .
 ```
 
-This would configure a Pellet Query Processor which sends queries to the SPARQL service of the `wine` knowledge base on the Pellet Server at `http://ps.clarkparsia.com`
+The example above configures a Pull Query Processor to query over an (initially empty) in-memory triple store using
+the union of all graphs as the default graph and with a query execution timeout set to 1 minute (60 000ms).


### PR DESCRIPTION
* Add a configuration factory for the PullQueryProcessor
* Currently supports a small subset of processor configuration options (query execution timeout and default union graph).
* Add documentation and remove documentation of the configuration of the PelletQueryProcessor which is no longer part of dotNetRDF.