### PR TITLE
Add SparqlQuery optimisation to QueryBuilder

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,6 +12,7 @@ NEW: A new SPARQL query processor that works on an asynchronous enumeration appr
 ENHANCEMENT: The DefaultDocumentLoader static class now exposes properties to configure the maximum allowed response size
     and maximum number of redirects to follow when loading JSON-LD documents from the web. Under the hood the implementation
     has been updated to use the more modern HttpClient stack in .NET. Thanks to @zotanmew for the report. (#650)
+ENHANCEMENT: The QueryBuilder now optimises the generated `SparqlQuery` by default. Whether or not to optimize the generated query, and which optimisers to apply can be controlled through arguments to the `Build` method. Thanks to @RetYn for the report. (#658)
 
 3.2.1
 -----

--- a/Libraries/dotNetRdf.Core/Query/Builder/IQueryBuilder.cs
+++ b/Libraries/dotNetRdf.Core/Query/Builder/IQueryBuilder.cs
@@ -26,6 +26,7 @@
 
 using System;
 using VDS.RDF.Query.Builder.Expressions;
+using VDS.RDF.Query.Optimisation;
 
 namespace VDS.RDF.Query.Builder
 {
@@ -103,7 +104,9 @@ namespace VDS.RDF.Query.Builder
         /// <summary>
         /// Builds and returns a <see cref="SparqlQuery"/>.
         /// </summary>
-        SparqlQuery BuildQuery();
+        /// <param name="applyOptimisation">Whether to apply query optimisation to the generated <see cref="SparqlQuery"/> before returning it.</param>
+        /// <param name="queryOptimiser">The optimiser to apply to the query if <paramref name="applyOptimisation"/> is set to true. If not specified, defaults to the globally scoped SPARQL query optimiser.</param>
+        SparqlQuery BuildQuery(bool applyOptimisation = true, IQueryOptimiser queryOptimiser = null);
         /// <summary>
         /// Adds a BIND variable assignment to the root graph pattern.
         /// </summary>

--- a/Libraries/dotNetRdf.Core/Query/Builder/QueryBuilder.cs
+++ b/Libraries/dotNetRdf.Core/Query/Builder/QueryBuilder.cs
@@ -31,6 +31,7 @@ using VDS.RDF.Query.Builder.Expressions;
 using VDS.RDF.Query.Expressions;
 using VDS.RDF.Query.Filters;
 using VDS.RDF.Query.Grouping;
+using VDS.RDF.Query.Optimisation;
 using VDS.RDF.Query.Ordering;
 using VDS.RDF.Query.Patterns;
 
@@ -294,7 +295,7 @@ namespace VDS.RDF.Query.Builder
         }
 
         /// <inheritdoc />
-        public SparqlQuery BuildQuery()
+        public SparqlQuery BuildQuery(bool applyOptimisation = true, IQueryOptimiser queryOptimiser = null)
         {
             var query = new SparqlQuery
             {
@@ -303,7 +304,20 @@ namespace VDS.RDF.Query.Builder
                 Offset = _queryOffset,
             };
 
-            return BuildQuery(query);
+            SparqlQuery ret = BuildQuery(query);
+            if (applyOptimisation)
+            {
+                if (queryOptimiser != null)
+                {
+                    ret.Optimise(queryOptimiser);
+                }
+                else
+                {
+                    ret.Optimise();
+                }
+            }
+
+            return ret;
         }
 
         /// <summary>

--- a/Testing/dotNetRdf.Tests/Query/Builder/QueryBuilderWikiTests.cs
+++ b/Testing/dotNetRdf.Tests/Query/Builder/QueryBuilderWikiTests.cs
@@ -199,7 +199,7 @@ namespace VDS.RDF.Query.Builder
             b.Prefixes.AddNamespace("dc", new Uri("http://purl.org/dc/elements/1.1/"));
 
             // when
-            var q = b.BuildQuery();
+            var q = b.BuildQuery(false);
 
             // then
             Assert.NotNull(q.RootGraphPattern.Filter);
@@ -224,7 +224,7 @@ namespace VDS.RDF.Query.Builder
             b.Prefixes.AddNamespace("ns", new Uri("http://example.org/ns#"));
 
             // when
-            var q = b.BuildQuery();
+            var q = b.BuildQuery(false);
 
             // then
             Assert.Single(q.RootGraphPattern.ChildGraphPatterns);
@@ -334,7 +334,7 @@ namespace VDS.RDF.Query.Builder
             b.Prefixes.AddNamespace("ns", new Uri("http://example.com/ns#"));
 
             // when
-            var q = b.BuildQuery();
+            var q = b.BuildQuery(false);
 
             // then
             Assert.False(q.RootGraphPattern.HasChildGraphPatterns);


### PR DESCRIPTION
By default the QueryBuilder will now apply optimisation to the SparqlQuery instance before returning it. Optional arguments to BuildQuery can be used to disable optimisation and to specify which query optimiser to apply. Default is to apply the globally configured query optimiser.

Fixes #658 