### PR TITLE
Avoid collecting all results when sorting to return a slice.

### DIFF
--- a/Libraries/dotNetRdf.Query.Pull/PullEvaluationContext.cs
+++ b/Libraries/dotNetRdf.Query.Pull/PullEvaluationContext.cs
@@ -18,6 +18,11 @@ internal class PullEvaluationContext : IPatternEvaluationContext
     internal IEnumerable<IRefNode> NamedGraphNames => _namedGraphs.Keys;
     public VariableFactory AutoVarFactory { get; private set; }
     internal ISparqlExpressionProcessor<IValuedNode, PullEvaluationContext, ExpressionContext> ExpressionProcessor { get; }
+
+    /// <summary>
+    /// Get or set the total length of the slice of results that the processor will return (offset + limit).
+    /// </summary>
+    internal int? SliceLength { get; set; } 
     public ITripleStore Data { get; private set; }
     public bool UnionDefaultGraph { get; private set; }
     public INodeFactory NodeFactory { get; private set; }

--- a/Testing/dotNetRdf.TestSuite.W3C/PullEngineEvaluationTestSuite.cs
+++ b/Testing/dotNetRdf.TestSuite.W3C/PullEngineEvaluationTestSuite.cs
@@ -34,7 +34,7 @@ public class PullEngineEvaluationTestSuite : BaseAsyncSparqlEvaluationTestSuite
     [SkippableFact]
     public void RunSingleQueryEvaluation()
     {
-        const string testUrl = "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10";
+        const string testUrl = "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4";
 
         ManifestTestDataProvider provider = testUrl.Contains("data-r2") ? Sparql10QueryEvalTests : Sparql11QueryEvalTests;
         ManifestTestData t = provider.GetTestData(testUrl);


### PR DESCRIPTION
When the query under evaluation specifies a LIMIT, restrict the OrderBy evaluation to collect only the number of results required to satisfy the combination of OFFSET and LIMIT, dropping any results which would sort to be outside of that range.

Fixes #652 