### PR TITLE
Remove redundant test

### DIFF
--- a/Testing/dotNetRdf.Tests/Core/ListTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/ListTests.cs
@@ -124,13 +124,6 @@ namespace VDS.RDF
         }
 
         [Fact]
-        public void GraphLists5()
-        {
-            var g = new Graph();
-            g.AddToList(g.CreateBlankNode(), Enumerable.Empty<INode>());
-        }
-
-        [Fact]
         public void GraphListsError1()
         {
             var g = new Graph();


### PR DESCRIPTION
Removing a test (related to RDF list functionality) that is exactly the same as the one before it.