### PR TITLE
Fix the ToString for LeftJoin so parentheses are balanced

### DIFF
--- a/Libraries/dotNetRdf.Core/Query/Algebra/LeftJoin.cs
+++ b/Libraries/dotNetRdf.Core/Query/Algebra/LeftJoin.cs
@@ -125,7 +125,7 @@ namespace VDS.RDF.Query.Algebra
         /// <returns></returns>
         public override string ToString()
         {
-            var filter = Filter.ToString();
+            var filter = Filter.ToString().TrimEnd();
             filter = filter.Substring(7, filter.Length - 8);
             return "LeftJoin(" + Lhs + ", " + Rhs + ", " + filter + ")";
         }


### PR DESCRIPTION
Because `Filter.ToString()` contained a trailing space, `LeftJoin.ToString()` translated `Filter(true) ` to `true)` causing unbalanced parentheses in the `ISparqlAlgebra` instances containing `LeftJoin`s. This makes it more difficult debugging `ISparqlAlgebra`s.

By first trimming the end of the `Filter.ToString()` this unwanted behaviour is prevented.