### PR TITLE
Remove .NET 6.0 from CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        framework: ["net6.0", "net8.0", "net472"]
+        framework: ["net8.0", "net472"]
         suite: 
           - "dotNetRdf.Tests"
           - "dotNetRdf.Dynamic.Tests"
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        framework: ["net6.0", "net8.0"]
+        framework: ["net8.0"]
         suite: 
           - "dotNetRdf.Tests"
           - "dotNetRdf.Dynamic.Tests"


### PR DESCRIPTION
Remove .NET 6.0 from CI steps as it is no longer installed on the linux runner and results in longer CI build times.