### PR TITLE
Fix for circular subPropertyOf and subClassOf

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,11 @@
 ﻿Change Log
 ==========
 
+Development
+-----------
+
+FIX: Fix for running the StaticRdfsReasoner against a graph containing circular rdfs:subPropertyOf or rdfs:subClassOf relationships. Thanks to @leifjantzen for the report. (#680)
+
 3.3.1
 -----
 

--- a/Testing/dotNetRdf.Inferencing.Tests/Ontology/OntologyReasoningTests.cs
+++ b/Testing/dotNetRdf.Inferencing.Tests/Ontology/OntologyReasoningTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query.Inference;
 using Xunit;
@@ -61,5 +63,6 @@ namespace VDS.RDF.Ontology
                 _output.WriteLine(t.ToString());
             }
         }
+
     }
 }

--- a/Testing/dotNetRdf.Inferencing.Tests/Query/Inference/StaticRdfsReasonerTests.cs
+++ b/Testing/dotNetRdf.Inferencing.Tests/Query/Inference/StaticRdfsReasonerTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using VDS.RDF.Ontology;
+using VDS.RDF.Parsing;
+using Xunit;
+
+namespace VDS.RDF.Query.Inference;
+
+public class StaticRdfsReasonerTests
+{
+    [Fact]
+    public void ItHandlesCircularSubpropertyOf()
+    {
+        var g = new Graph();
+        FileLoader.Load(g, Path.Combine("resources", "circular_subproperty.ttl"));
+        var reasoner = new StaticRdfsReasoner();
+        reasoner.Initialise(g);
+        reasoner.Apply(g, g);
+        INode obj= g.GetUriNode(new Uri("http://example.com/o"));
+        INode subj = g.GetUriNode(new Uri("http://example.com/s"));
+        Assert.NotNull(subj);
+        Assert.NotNull(obj);
+        INode[] expectedNodes =
+        [
+            g.CreateUriNode(new Uri("http://example.com/ontology/predicate#a")),
+            g.CreateUriNode(new Uri("http://example.com/ontology/predicate#b")),
+            g.CreateUriNode(new Uri("http://example.com/source/predicate#c")),
+            g.CreateUriNode(new Uri("http://example.com/ontology/predicate#test"))
+        ];
+        IList<INode> predicates = g.GetTriplesWithSubjectObject(subj, obj).Select(t => t.Predicate).ToList();
+        foreach (INode expectedNode in expectedNodes)
+        {
+            Assert.Contains(expectedNode, predicates);
+        }
+    }
+
+    [Fact]
+    public void ItHandlesCircularSubClassOf()
+    {
+        var g = new Graph();
+        FileLoader.Load(g, Path.Combine("resources", "circular_subclass.ttl"));
+        var reasoner = new StaticRdfsReasoner();
+        reasoner.Initialise(g);
+        reasoner.Apply(g, g);
+        INode inst = g.GetUriNode(new Uri("http://example.org/test"));
+        INode rdfType = g.CreateUriNode("rdf:type");
+        INode[] expectedClasses =
+        [
+            g.CreateUriNode(new Uri("http://example.org/ontology/A")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/B")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/C"))
+        ];
+        IList<INode> actualClasses = g.GetTriplesWithSubjectPredicate(inst, rdfType).Select(t => t.Object).ToList();
+        foreach (INode expectedClass in expectedClasses)
+        {
+            Assert.Contains(expectedClass, actualClasses);
+        }
+    }
+
+}

--- a/Testing/dotNetRdf.Inferencing.Tests/dotNetRdf.Inferencing.Tests.csproj
+++ b/Testing/dotNetRdf.Inferencing.Tests/dotNetRdf.Inferencing.Tests.csproj
@@ -26,6 +26,12 @@
     <None Update="resources\InferenceTest.ttl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="resources\circular_subproperty.ttl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="resources\circular_subclass.ttl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Testing/dotNetRdf.Inferencing.Tests/resources/circular_subclass.ttl
+++ b/Testing/dotNetRdf.Inferencing.Tests/resources/circular_subclass.ttl
@@ -1,0 +1,11 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix : <http://example.org/ontology/> .
+
+:A a rdfs:Class .
+:B a rdfs:Class .
+:C a rdfs:Class .
+:A rdfs:subClassOf :B .
+:B rdfs:subClassOf :A .
+:C rdfs:subClassOf :B .
+<http://example.org/test> a :C .

--- a/Testing/dotNetRdf.Inferencing.Tests/resources/circular_subproperty.ttl
+++ b/Testing/dotNetRdf.Inferencing.Tests/resources/circular_subproperty.ttl
@@ -1,0 +1,16 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.com/ontology/predicate#a> a rdf:Property .
+<http://example.com/ontology/predicate#b> a rdf:Property .
+
+<http://example.com/ontology/predicate#b> rdfs:subPropertyOf <http://example.com/ontology/predicate#a> .
+<http://example.com/ontology/predicate#a> rdfs:subPropertyOf <http://example.com/ontology/predicate#b> .
+
+<http://example.com/source/predicate#c> a rdf:Property .
+<http://example.com/source/predicate#d> a rdf:Property .
+
+<http://example.com/source/predicate#c> rdfs:subPropertyOf <http://example.com/ontology/predicate#a> .
+
+<http://example.com/ontology/predicate#test> rdfs:subPropertyOf <http://example.com/source/predicate#c> .
+<http://example.com/s> <http://example.com/ontology/predicate#test> <http://example.com/o> .


### PR DESCRIPTION
Fix the StaticRdfsReasoner to avoid an infinite loop when processing ontologies with a circular rdfs:subPropertyOf or rdfs:subClassOf property chain. Fixes #680