### PR TITLE
Handle resource with multiple subClassOf/subPropertyOf

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,7 @@ Development
 -----------
 
 FIX: Fix for running the StaticRdfsReasoner against a graph containing circular rdfs:subPropertyOf or rdfs:subClassOf relationships. Thanks to @leifjantzen for the report. (#680)
+FIX: Fix for applying the StaticRdfsReasoner against a graph containing polymorphic rdfs:subPropertyOf or rdfs:subClassOf relationsips. (#682)
 
 3.3.1
 -----

--- a/Testing/dotNetRdf.Inferencing.Tests/Query/Inference/StaticRdfsReasonerTests.cs
+++ b/Testing/dotNetRdf.Inferencing.Tests/Query/Inference/StaticRdfsReasonerTests.cs
@@ -59,4 +59,51 @@ public class StaticRdfsReasonerTests
         }
     }
 
+    [Fact]
+    public void ItHandlesPolymorphicSubClassOf()
+    {
+        var g = new Graph();
+        FileLoader.Load(g, Path.Combine("resources", "polymorphic_subclass.ttl"));
+        var reasoner = new StaticRdfsReasoner();
+        reasoner.Initialise(g);
+        reasoner.Apply(g, g);
+        INode inst = g.GetUriNode(new Uri("http://example.org/test"));
+        INode rdfType = g.CreateUriNode("rdf:type");
+        INode[] expectedClasses = 
+        [
+            g.CreateUriNode(new Uri("http://example.org/ontology/A")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/B")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/C"))
+        ];
+        IList<INode> actualClasses = g.GetTriplesWithSubjectPredicate(inst, rdfType).Select(t => t.Object).ToList();
+        Assert.Equal(expectedClasses.Length, actualClasses.Count);
+        foreach (INode expectedClass in expectedClasses)
+        {
+            Assert.Contains(expectedClass, actualClasses);
+        }
+    }
+
+    [Fact]
+    public void ItHandlesPolymorphicSubPropertyOf()
+    {
+        var g = new Graph();
+        FileLoader.Load(g, Path.Combine("resources", "polymorphic_subproperty.ttl"));
+        var reasoner = new StaticRdfsReasoner();
+        reasoner.Initialise(g);
+        reasoner.Apply(g, g);
+        INode subj = g.GetUriNode(new Uri("http://example.org/s"));
+        INode obj = g.GetUriNode(new Uri("http://example.org/o"));
+        INode[] expectedPredicates = [
+            g.CreateUriNode(new Uri("http://example.org/ontology/a")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/b")),
+            g.CreateUriNode(new Uri("http://example.org/ontology/c")),
+        ];
+        IList<INode> actualPredicates = g.GetTriplesWithSubjectObject(subj, obj).Select(t=>t.Predicate).ToList();
+        Assert.Equal(expectedPredicates.Length, actualPredicates.Count);
+        foreach (INode expectedPredicate in expectedPredicates)
+        {
+            Assert.Contains(expectedPredicate, actualPredicates);
+        }
+    }
+
 }

--- a/Testing/dotNetRdf.Inferencing.Tests/dotNetRdf.Inferencing.Tests.csproj
+++ b/Testing/dotNetRdf.Inferencing.Tests/dotNetRdf.Inferencing.Tests.csproj
@@ -32,6 +32,12 @@
     <None Update="resources\circular_subclass.ttl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="resources\polymorphic_subclass.ttl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="resources\polymorphic_subproperty.ttl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Testing/dotNetRdf.Inferencing.Tests/resources/polymorphic_subclass.ttl
+++ b/Testing/dotNetRdf.Inferencing.Tests/resources/polymorphic_subclass.ttl
@@ -1,0 +1,10 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix : <http://example.org/ontology/> .
+
+:A a rdfs:Class .
+:B a rdfs:Class .
+:C a rdfs:Class .
+:A rdfs:subClassOf :B .
+:A rdfs:subClassOf :C .
+<http://example.org/test> a :A .

--- a/Testing/dotNetRdf.Inferencing.Tests/resources/polymorphic_subproperty.ttl
+++ b/Testing/dotNetRdf.Inferencing.Tests/resources/polymorphic_subproperty.ttl
@@ -1,0 +1,9 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix : <http://example.org/ontology/> .
+
+:a a rdf:Property .
+:b a rdf:Property .
+:c a rdf:Property .
+:c rdfs:subPropertyOf :a, :b .
+<http://example.org/s> :c <http://example.org/o> .


### PR DESCRIPTION
Update StaticRdfsReasoner to allow a one-to-many mapping of property to super-property and class to super-class. Fixes #682