### PR TITLE
Proper `∀` for `$PATH` substitution in `sh:select`

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,7 @@ Next release
 ------------
 
 NEW: Added a new `SafeMode` option for the JSONLD Parser. Setting this option to true will cause additional warnings to be raised when an invalid type, subject, predicate or object is encountered when parsing JSON-LD rather than silently ignoring them. Thanks to @BigBlueHat for the suggestion and @sdml for the initial implementation (#675)
+FIX: Fix for `$PATH` substitution in `SELECT`-based validators in `SPARQL`-based Constraint Components. Thanks to @Ikeragnell for the report and @langsamu for the fix. (#694)
  
 3.3.2
 -----

--- a/Libraries/dotNetRdf.Shacl/Constraints/Select.cs
+++ b/Libraries/dotNetRdf.Shacl/Constraints/Select.cs
@@ -131,11 +131,12 @@ namespace VDS.RDF.Shacl.Constraints
         {
             for (var i = 0; i < pattern.TriplePatterns.Count(); i++)
             {
-                if (pattern.TriplePatterns[i] is TriplePattern triplePattern && triplePattern.Predicate.Variables.All(x=>x.Equals("PATH")))
-                {
-                    pattern.TriplePatterns.RemoveAt(i);
-                    pattern.TriplePatterns.Insert(i, new PropertyPathPattern(triplePattern.Subject, path, triplePattern.Object));
-                }
+                if (pattern.TriplePatterns[i] is not TriplePattern triplePattern) { continue; }
+                if (triplePattern.Predicate is not VariablePattern variablePattern) { continue; }
+                if (variablePattern.VariableName != "PATH") { continue; }
+
+                pattern.TriplePatterns.RemoveAt(i);
+                pattern.TriplePatterns.Insert(i, new PropertyPathPattern(triplePattern.Subject, path, triplePattern.Object));
             }
 
             foreach (GraphPattern subPattern in pattern.ChildGraphPatterns)


### PR DESCRIPTION
# What

Fixes #692, which identified a mistake in the implementation of `SELECT`-based validators in `SPARQL`-based Constraint Components.

# Why

The SHACL spec says this in its usual poetic brevity:
> [...] prior to execution substitute the variable PATH where it appears in the predicate position of a triple pattern with a valid SPARQL surface syntax string of the SHACL property path specified via sh:path at the property shape. [...]

-- [6.3 Validation with SPARQL-based Constraint Components](https://www.w3.org/TR/shacl/#constraint-components-validation)

We need `$PATH` in `sh:select` so we can refer to the predicate our constraint was anchored on.

# How

This change [fixes](https://github.com/dotnetrdf/dotnetrdf/pull/694/files#diff-ce49e2948c178ea4525a643a75d67742b7e43e391edc45a54a8b97d928cacbcfL134-R139) the implementation of the algorithm specified in the quote above.
The mistake (thx @Ikeragnell) is a well-known one about universal quantification over empty sets, summarized nicely in [my favourite quote from the W3C website](https://www.w3.org/TR/owl2-primer/#Property_Restrictions:~:text=There%20is%20one%20particular%20misconception%20concerning%20the%20universal%20role%20restriction).