### PR TITLE
Update implementation of IDisposable for graphs and triple collections

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,7 +6,8 @@ Next release
 
 NEW: Added a new `SafeMode` option for the JSONLD Parser. Setting this option to true will cause additional warnings to be raised when an invalid type, subject, predicate or object is encountered when parsing JSON-LD rather than silently ignoring them. Thanks to @BigBlueHat for the suggestion and @sdml for the initial implementation (#675)
 FIX: Fix for `$PATH` substitution in `SELECT`-based validators in `SPARQL`-based Constraint Components. Thanks to @Ikeragnell for the report and @langsamu for the fix. (#694)
- 
+FIX: Fixes to the IDisposable implementation of several classes to reduce memory leaks. Thanks to @rorlic for the bug report. (#691)
+
 3.3.2
 -----
 

--- a/Libraries/dotNetRdf.Core/Core/BaseTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/BaseTripleCollection.cs
@@ -27,7 +27,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using VDS.RDF.Query.Patterns;
 
 namespace VDS.RDF
 {
@@ -40,6 +39,8 @@ namespace VDS.RDF
     public abstract class BaseTripleCollection
         : IEnumerable<Triple>, IDisposable
     {
+        private bool _isDisposed = false;
+        
         /// <summary>
         /// Adds a Triple to the Collection.
         /// </summary>
@@ -291,7 +292,22 @@ namespace VDS.RDF
         /// <summary>
         /// Disposes of a Triple Collection.
         /// </summary>
-        public abstract void Dispose();
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of a Triple Collection.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+            }
+        }
 
         /// <summary>
         /// Gets the typed Enumerator for the Triple Collection.

--- a/Libraries/dotNetRdf.Core/Core/SubTreeIndexedTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/SubTreeIndexedTripleCollection.cs
@@ -45,17 +45,17 @@ namespace VDS.RDF
     {
         // Indexes
         private readonly MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>
-            _sp = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer()),
-            _po = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer()),
-            _os = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer()),
-            _qsp = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer()),
-            _qpo = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer()),
-            _qos = new MultiDictionary<INode, MultiDictionary<Triple, HashSet<Triple>>>(new FastVirtualNodeComparer());
+            _sp = new(new FastVirtualNodeComparer()),
+            _po = new(new FastVirtualNodeComparer()),
+            _os = new(new FastVirtualNodeComparer()),
+            _qsp = new(new FastVirtualNodeComparer()),
+            _qpo = new(new FastVirtualNodeComparer()),
+            _qos = new(new FastVirtualNodeComparer());
 
         // Placeholder Variables for compound lookups
-        private readonly VariableNode _subjVar = new VariableNode("s"),
-                             _predVar = new VariableNode("p"),
-                             _objVar = new VariableNode("o");
+        private readonly VariableNode _subjVar = new("s"),
+                             _predVar = new("p"),
+                             _objVar = new("o");
 
         // Hash Functions
         private readonly Func<Triple, int> _sHash = t => Tools.CombineHashCodes(t.Subject, t.Predicate),
@@ -318,16 +318,29 @@ namespace VDS.RDF
         /// <inheritdoc/>
         public override IEnumerable<INode> QuotedSubjectNodes => _qsp.Keys;
 
+        private bool _isDisposed;
+
         /// <summary>
         /// Disposes of the collection.
         /// </summary>
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            Triples.Clear();
-            _sp.Clear();
-            _po.Clear();
-            _os.Clear();
-        }
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+                if (disposing)
+                {
+                    Triples.Clear();
+                    _sp.Clear();
+                    _po.Clear();
+                    _os.Clear();
+                    _qos.Clear();
+                    _qpo.Clear();
+                    _qsp.Clear();
+                }
+            }
 
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Libraries/dotNetRdf.Core/Core/ThreadSafeGraph.cs
+++ b/Libraries/dotNetRdf.Core/Core/ThreadSafeGraph.cs
@@ -42,7 +42,7 @@ namespace VDS.RDF
         /// <summary>
         /// Locking Manager for the Graph.
         /// </summary>
-        protected ReaderWriterLockSlim _lockManager = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        protected ReaderWriterLockSlim _lockManager = new(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
         /// Creates a new Thread Safe Graph.
@@ -222,14 +222,24 @@ namespace VDS.RDF
             return id;
         }
 
+        #region IDisposable Members
+        private bool _isDisposed;
         /// <summary>
         /// Disposes of a Graph.
         /// </summary>
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+                if (disposing)
+                {
+                    _lockManager.Dispose();
+                }
+            }
             base.Dispose();
-            _lockManager.Dispose();
         }
+        #endregion
 
         #region Node Selection
 

--- a/Libraries/dotNetRdf.Core/Core/ThreadSafeTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/ThreadSafeTripleCollection.cs
@@ -508,20 +508,29 @@ namespace VDS.RDF
             return triples;
         }
 
+        private bool _isDisposed;
         /// <summary>
         /// Disposes of a Triple Collection.
         /// </summary>
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            try
+            if (!_isDisposed)
             {
-                EnterWriteLock();
-                _triples.Dispose();
+                _isDisposed = true;
+                if (disposing)
+                {
+                    try
+                    {
+                        EnterWriteLock();
+                        _triples.Dispose();
+                    }
+                    finally
+                    {
+                        ExitWriteLock();
+                    }
+                }
             }
-            finally
-            {
-                ExitWriteLock();
-            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/Libraries/dotNetRdf.Core/Core/TreeIndexedTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/TreeIndexedTripleCollection.cs
@@ -646,19 +646,33 @@ namespace VDS.RDF
         }
 
 
-
+        private bool _isDisposed;
         /// <summary>
         /// Disposes of the collection.
         /// </summary>
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            Triples.Clear();
-            _s?.Clear();
-            _p?.Clear();
-            _o?.Clear();
-            _so?.Clear();
-            _sp?.Clear();
-            _po?.Clear();
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+                if (disposing)
+                {
+                    Triples.Clear();
+                    _s?.Clear();
+                    _p?.Clear();
+                    _o?.Clear();
+                    _so?.Clear();
+                    _sp?.Clear();
+                    _po?.Clear();
+                    _qs?.Clear();
+                    _qp?.Clear();
+                    _qo?.Clear();
+                    _qso?.Clear();
+                    _qsp?.Clear();
+                    _qpo?.Clear();
+                }
+            }
+            base.Dispose(disposing);
         }
 
         

--- a/Libraries/dotNetRdf.Core/Core/TripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/TripleCollection.cs
@@ -263,12 +263,20 @@ namespace VDS.RDF
 
         #region IDisposable Members
 
-        /// <summary>
-        /// Disposes of a Triple Collection.
-        /// </summary>
-        public override void Dispose()
+        private bool _isDisposed;
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
         {
-            Triples.Clear();
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+                if (disposing)
+                {
+                    Triples.Clear();
+                }
+            }
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Libraries/dotNetRdf.Core/Core/TripleStoreTripleIndex.cs
+++ b/Libraries/dotNetRdf.Core/Core/TripleStoreTripleIndex.cs
@@ -49,7 +49,7 @@ public class TripleStoreTripleIndex : ITripleIndex
     }
 
     /// <summary>
-    /// Create a triple index over the specified graph of the specified store
+    /// Create a triple index over the specified graph of the specified store.
     /// </summary>
     /// <param name="store">The store to expose as a triple index.</param>
     /// <param name="defaultGraph">The name of the graph to expose in the index.</param>

--- a/Libraries/dotNetRdf.Core/Core/UnionCollections.cs
+++ b/Libraries/dotNetRdf.Core/Core/UnionCollections.cs
@@ -204,17 +204,6 @@ namespace VDS.RDF
         }
 
         /// <summary>
-        /// Disposes of the collection.
-        /// </summary>
-        /// <remarks>
-        /// This does nothing since we don't know where and how the collections we are the union of are being used and therefore to dispose of them could have unwanted/unexpected results.
-        /// </remarks>
-        public override void Dispose()
-        {
-            // Do Nothing
-        }
-
-        /// <summary>
         /// Gets the enumeration of Triples in the union.
         /// </summary>
         /// <returns></returns>

--- a/Libraries/dotNetRdf.Core/Core/WrapperTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Core/WrapperTripleCollection.cs
@@ -40,21 +40,25 @@ namespace VDS.RDF
         /// </summary>
         protected readonly BaseTripleCollection _triples;
 
+        private bool _disposeTriples;
+
         /// <summary>
         /// Creates a new decorator over the default <see cref="TreeIndexedTripleCollection"/>.
         /// </summary>
         public WrapperTripleCollection()
-            : this(new TreeIndexedTripleCollection(true)) { }
+            : this(new TreeIndexedTripleCollection(true), true) { }
 
         /// <summary>
         /// Creates a new decorator around the given triple collection.
         /// </summary>
         /// <param name="tripleCollection">Triple Collection.</param>
-        public WrapperTripleCollection(BaseTripleCollection tripleCollection)
+        /// <param name="disposeTriples">Whether to invoke the Dispose method of <paramref name="tripleCollection"/> when this wrapper collection is disposed.</param>
+        public WrapperTripleCollection(BaseTripleCollection tripleCollection, bool disposeTriples = true)
         {
             _triples = tripleCollection ?? throw new ArgumentNullException(nameof(tripleCollection));
             _triples.TripleAdded += HandleTripleAdded;
             _triples.TripleRemoved += HandleTripleRemoved;
+            _disposeTriples = disposeTriples;
         }
 
         private void HandleTripleAdded(object sender, TripleEventArgs args)
@@ -155,14 +159,6 @@ namespace VDS.RDF
         }
 
         /// <summary>
-        /// Disposes of the collection.
-        /// </summary>
-        public override void Dispose()
-        {
-            _triples.Dispose();
-        }
-
-        /// <summary>
         /// Gets the enumerator for the collection.
         /// </summary>
         /// <returns></returns>
@@ -233,5 +229,28 @@ namespace VDS.RDF
         {
             return _triples.WithSubjectPredicate(subj, pred);
         }
+        
+        #region IDisposable Members
+        private bool _isDisposed;
+        /// <summary>
+        /// Disposes of the collection.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                _isDisposed = true;
+                if (disposing)
+                {
+                    if (_disposeTriples)
+                    {
+                        _triples.Dispose();
+                    }
+                }
+            }
+            base.Dispose(disposing);
+        }
+        
+        #endregion
     }
 }

--- a/Libraries/dotNetRdf.Core/Query/Datasets/QuadDatasetTripleCollection.cs
+++ b/Libraries/dotNetRdf.Core/Query/Datasets/QuadDatasetTripleCollection.cs
@@ -151,12 +151,6 @@ namespace VDS.RDF.Query.Datasets
             _dataset.GetQuoted(_graphName).Select(t => t.Subject).Distinct();
 
         /// <inheritdoc />
-        public override void Dispose()
-        {
-            // No dispose actions needed
-        }
-
-        /// <inheritdoc />
         public override IEnumerator<Triple> GetEnumerator()
         {
             return _dataset.GetQuads(_graphName).GetEnumerator();

--- a/Libraries/dotNetRdf.Ldf/Client/TpfEnumerable.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfEnumerable.cs
@@ -33,18 +33,18 @@ namespace VDS.RDF.LDF.Client;
 
 internal class TpfEnumerable : IEnumerable<Triple>
 {
-    private readonly Uri firstPage;
-    private readonly IRdfReader reader;
-    private readonly Loader loader;
+    private readonly Uri _firstPage;
+    private readonly IRdfReader _reader;
+    private readonly Loader _loader;
 
     internal TpfEnumerable(Uri firstPage, IRdfReader reader = null, Loader loader = null)
     {
-        this.firstPage = firstPage ?? throw new ArgumentNullException(nameof(firstPage));
-        this.reader = reader;
-        this.loader = loader;
+        this._firstPage = firstPage ?? throw new ArgumentNullException(nameof(firstPage));
+        this._reader = reader;
+        this._loader = loader;
     }
 
-    IEnumerator<Triple> IEnumerable<Triple>.GetEnumerator() => new TpfEnumerator(firstPage, reader, loader);
+    IEnumerator<Triple> IEnumerable<Triple>.GetEnumerator() => new TpfEnumerator(_firstPage, _reader, _loader);
 
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<Triple>)this).GetEnumerator();
 }

--- a/Libraries/dotNetRdf.Ldf/Client/TpfLoader.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfLoader.cs
@@ -49,7 +49,16 @@ internal class TpfLoader : IDisposable
 
     public void Dispose()
     {
-        Data.Dispose();
-        Metadata.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Data.Dispose();
+            Metadata.Dispose();
+        }
     }
 }

--- a/Libraries/dotNetRdf.Ldf/Client/TpfMetadataGraph.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfMetadataGraph.cs
@@ -34,24 +34,24 @@ namespace VDS.RDF.LDF.Client;
 
 internal class TpfMetadataGraph : WrapperGraph
 {
-    private readonly ISparqlResult result;
+    private readonly ISparqlResult _result;
 
     internal TpfMetadataGraph(IGraph g) : base(g)
     {
         var sparqlResults = this.ExecuteQuery(Queries.Select) as SparqlResultSet;
-        if (sparqlResults.Count != 1)
+        if (sparqlResults == null || sparqlResults.Count != 1)
         {
             throw new LdfException("Could not interpret metadata in TPF response graph");
         }
 
-        result = sparqlResults.Single();
+        _result = sparqlResults.Single();
     }
 
-    internal IriTemplate Search => new(result["search"], this);
+    internal IriTemplate Search => new(_result["search"], this);
 
     internal Uri NextPageUri => Vocabulary.Hydra.Next.ObjectsOf(Page).Cast<IUriNode>().SingleOrDefault()?.Uri;
 
     internal long? TripleCount => Vocabulary.Void.Triples.ObjectsOf(Page).SingleOrDefault()?.AsValuedNode().AsInteger();
 
-    private GraphWrapperNode Page => new(result["page"], this);
+    private GraphWrapperNode Page => new(_result["page"], this);
 }

--- a/Libraries/dotNetRdf.Ldf/Client/TpfParameters.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfParameters.cs
@@ -34,7 +34,7 @@ namespace VDS.RDF.LDF.Client;
 
 internal class TpfParameters
 {
-    private Uri uri;
+    private Uri _uri;
 
     internal TpfParameters(IriTemplate template, INode subject = null, INode predicate = null, INode @object = null)
     {
@@ -85,8 +85,8 @@ internal class TpfParameters
             variables.Add(template.ObjectVariable, formatter.Format(@object));
         }
 
-        uri = new UriTemplate(template.Template).ResolveUri(variables);
+        _uri = new UriTemplate(template.Template).ResolveUri(variables);
     }
 
-    public static implicit operator Uri(TpfParameters parameters) => parameters.uri;
+    public static implicit operator Uri(TpfParameters parameters) => parameters._uri;
 }

--- a/Libraries/dotNetRdf.Ldf/Client/TpfTripleCollection.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfTripleCollection.cs
@@ -72,8 +72,6 @@ internal class TpfTripleCollection : BaseTripleCollection
 
     public override bool Contains(Triple t) => TpfEnumerable(t.Subject, t.Predicate, t.Object).Any();
 
-    public override void Dispose() { }
-
     public override IEnumerator<Triple> GetEnumerator() => new TpfEnumerator(new TpfParameters(template), reader, loader);
 
     public override IEnumerable<Triple> WithObject(INode o) => TpfEnumerable(o: o);

--- a/Libraries/dotNetRdf.Ldf/Client/TpfTripleCollection.cs
+++ b/Libraries/dotNetRdf.Ldf/Client/TpfTripleCollection.cs
@@ -34,23 +34,23 @@ namespace VDS.RDF.LDF.Client;
 
 internal class TpfTripleCollection : BaseTripleCollection
 {
-    private readonly IriTemplate template;
-    private readonly IRdfReader reader;
-    private readonly Loader loader;
+    private readonly IriTemplate _template;
+    private readonly IRdfReader _reader;
+    private readonly Loader _loader;
 
     internal TpfTripleCollection(IriTemplate template, IRdfReader reader = null, Loader loader = null)
     {
-        this.template = template ?? throw new ArgumentNullException(nameof(template));
-        this.reader = reader;
-        this.loader = loader;
+        this._template = template ?? throw new ArgumentNullException(nameof(template));
+        this._reader = reader;
+        this._loader = loader;
     }
 
-    /// <remarks>Caution: When the LDF response has no triple count statement in the metadata section then every invocation of this property enumerates the collection which potentially involves numerous network requests.</remarks>
+    /// <remarks>Caution: When the LDF response has no triple count statement in the metadata section, then every invocation of this property enumerates the collection which potentially involves numerous network requests.</remarks>
     public override int Count
     {
         get
         {
-            using var fragment = new TpfLoader(new TpfParameters(template), reader, loader);
+            using var fragment = new TpfLoader(new TpfParameters(_template), _reader, _loader);
 
             return fragment.Metadata.TripleCount switch
             {
@@ -72,7 +72,7 @@ internal class TpfTripleCollection : BaseTripleCollection
 
     public override bool Contains(Triple t) => TpfEnumerable(t.Subject, t.Predicate, t.Object).Any();
 
-    public override IEnumerator<Triple> GetEnumerator() => new TpfEnumerator(new TpfParameters(template), reader, loader);
+    public override IEnumerator<Triple> GetEnumerator() => new TpfEnumerator(new TpfParameters(_template), _reader, _loader);
 
     public override IEnumerable<Triple> WithObject(INode o) => TpfEnumerable(o: o);
 
@@ -88,7 +88,7 @@ internal class TpfTripleCollection : BaseTripleCollection
 
     public override IEnumerable<Triple> Asserted => this;
 
-    private IEnumerable<Triple> TpfEnumerable(INode s = null, INode p = null, INode o = null) => new TpfEnumerable(new TpfParameters(template, s, p, o), reader, loader);
+    private IEnumerable<Triple> TpfEnumerable(INode s = null, INode p = null, INode o = null) => new TpfEnumerable(new TpfParameters(_template, s, p, o), _reader, _loader);
 
     #region Mutation methods throw because this triple collection is read-only
 

--- a/Libraries/dotNetRdf.Ldf/Hydra/ExplicitRepresentationFormatter.cs
+++ b/Libraries/dotNetRdf.Ldf/Hydra/ExplicitRepresentationFormatter.cs
@@ -35,8 +35,8 @@ namespace VDS.RDF.LDF.Hydra;
 
 internal class ExplicitRepresentationFormatter : INodeFormatter
 {
-    private readonly static Uri xsdString = UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeString);
-    private readonly static Uri langString = UriFactory.Create(RdfSpecsHelper.RdfLangString);
+    private readonly static Uri XsdString = UriFactory.Create(XmlSpecsHelper.XmlSchemaDataTypeString);
+    private readonly static Uri LangString = UriFactory.Create(RdfSpecsHelper.RdfLangString);
 
     string INodeFormatter.Format(INode node) => node switch
     {
@@ -54,7 +54,7 @@ internal class ExplicitRepresentationFormatter : INodeFormatter
         var builder = new StringBuilder();
         builder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\"", literalNode.Value);
 
-        if (literalNode.DataType is not null && literalNode.DataType != xsdString && literalNode.DataType != langString)
+        if (literalNode.DataType is not null && literalNode.DataType != XsdString && literalNode.DataType != LangString)
         {
             builder.AppendFormat(CultureInfo.InvariantCulture, "^^{0}", literalNode.DataType.AbsoluteUri);
         }

--- a/Libraries/dotNetRdf.Ldf/LdfException.cs
+++ b/Libraries/dotNetRdf.Ldf/LdfException.cs
@@ -27,7 +27,7 @@
 namespace VDS.RDF.LDF;
 
 /// <summary>
-/// This excetion represents errors that occur while working with Linked Data Fragments.
+/// This exception represents errors that occur while working with Linked Data Fragments.
 /// </summary>
 /// <param name="message">The error message.</param>
 public class LdfException(string message) : RdfException(message) { }

--- a/Libraries/dotNetRdf.Ldf/Queries.cs
+++ b/Libraries/dotNetRdf.Ldf/Queries.cs
@@ -32,12 +32,12 @@ namespace VDS.RDF.LDF;
 
 internal static class Queries
 {
-    private static readonly string preamble = """
+    private static readonly string Preamble = """
         PREFIX hydra: <http://www.w3.org/ns/hydra/core#>
         PREFIX void:  <http://rdfs.org/ns/void#>
         """;
 
-    private static readonly string shape = """
+    private static readonly string Shape = """
         ?fragment ^void:subset   ?dataset  .
         ?page     ^void:subset   ?fragment .
         ?search   ^hydra:search  ?dataset  .
@@ -45,16 +45,16 @@ internal static class Queries
         """;
 
     internal static SparqlQuery Select { get; } = new SparqlQueryParser().ParseFromString($$"""
-            {{preamble}}
+            {{Preamble}}
 
             SELECT DISTINCT ?page ?search
             WHERE {
-                {{shape}}
+                {{Shape}}
             }
             """);
 
     internal static SparqlUpdateCommandSet Delete { get; } = new SparqlUpdateParser().ParseFromString($$"""
-            {{preamble}}
+            {{Preamble}}
                         
             DELETE {
             	?datasetContainer ?datasetInverseProperty ?dataset       .
@@ -65,7 +65,7 @@ internal static class Queries
             	?mapping          ?mappingProperty        ?mappingValue  .
             }
             WHERE {
-                {{shape}}
+                {{Shape}}
                         
             	?dataset  ?datasetProperty  ?datasetValue  .
             	?fragment ?fragmentProperty ?fragmentValue .


### PR DESCRIPTION
* Update IDisposable implementation for triple collections and graphs
* Update use of disposable resources in the LDF library to ensure that they are not disposed underlying graphs are still in use
Fixes #691