### PR TITLE
Add RemoveAllFromList methods

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -9,7 +9,8 @@ FIX: Fix for `$PATH` substitution in `SELECT`-based validators in `SPARQL`-based
 FIX: Fixes to the IDisposable implementation of several classes to reduce memory leaks. Thanks to @rorlic for the bug report. (#691)
 NEW: Updated test framework to XUnit 3.x. Thanks to @hellikopter for the PR. (#704)
 NEW: Moved to centrally managed package versions. Thanks to @hellikopter for the PR. (#705, #707)
-FIX: Fixed documentation of RemoveFromList methods to correctly document the limitations of the methods. Thanks to @langsamu for the report (#702, #708)
+FIX: Fixed documentation of RemoveFromList methods to correctly document the limitations of the methods. Thanks to @langsamu for the report. (#702, #708)
+NEW: Added Graph extension methods RemoveAllFromList to remove all instances of a specified node or object (with node mapping function) from an RDF collection. (#709)
 
 3.3.2
 -----

--- a/Libraries/dotNetRdf.Core/Core/Extensions.cs
+++ b/Libraries/dotNetRdf.Core/Core/Extensions.cs
@@ -615,6 +615,45 @@ namespace VDS.RDF
             RemoveFromList(g, listRoot, objects, n => n);
         }
 
+        /// <summary>
+        /// Removes the given items from a list (aka an RDF collection).
+        /// </summary>
+        /// <remarks>If an item occurs multiple times in the list, all instances of that item will be removed.</remarks>
+        /// <param name="g">Graph to retract from.</param>
+        /// <param name="listRoot">Root node of the list to be modified.</param>
+        /// <param name="objects">Objects to remove from the collection.</param>
+        /// <param name="mapFunc">Mapping from object type <typeparamref name="T"/> to <see cref="INode"/>.</param>
+        /// <typeparam name="T">Type of objects to be removed.</typeparam>
+        public static void RemoveAllFromList<T>(this IGraph g, INode listRoot, IEnumerable<T> objects,
+            Func<T, INode> mapFunc)
+        {
+            var removeNodes = objects.Select(mapFunc).ToList();
+            if (!removeNodes.Any())
+            {
+                // Nothing to remove
+                return;
+            }
+            var currObjects = GetListItems(g, listRoot).ToList();
+            var initialCount = currObjects.Count;
+            currObjects.RemoveAll(x=>removeNodes.Contains(x));
+            if (initialCount != currObjects.Count)
+            {
+                RetractList(g, listRoot);
+                AssertList(g, listRoot, currObjects);
+            }
+        }
+
+        /// <summary>
+        /// Removes the given items from a list (aka an RDF collection).
+        /// </summary>
+        /// <remarks>If an item occurs multiple times in the list, all instances of that item will be removed.</remarks>
+        /// <param name="g">Graph to retract from.</param>
+        /// <param name="listRoot">Root node of the list to be modified.</param>
+        /// <param name="objects">Nodes to remove from the collection.</param>
+        public static void RemoveAllFromList(this IGraph g, INode listRoot, IEnumerable<INode> objects)
+        {
+            RemoveAllFromList(g, listRoot, objects, n => n);
+        }
 #endregion
 
 

--- a/Testing/dotNetRdf.Tests/Core/ListTests.cs
+++ b/Testing/dotNetRdf.Tests/Core/ListTests.cs
@@ -23,7 +23,11 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using VDS.RDF.Parsing;
 using Xunit;
 
 namespace VDS.RDF
@@ -121,6 +125,32 @@ namespace VDS.RDF
         {
             var g = new Graph();
             g.AddToList(g.CreateBlankNode(), Enumerable.Empty<INode>());
+        }
+
+        [Fact]
+        public void RemoveFromListRemovesFirstOccurrenceOnly()
+        {
+            var g = new Graph();
+            INode list = g.AssertList([0, 0, 1], x => x.ToLiteral(g));
+            g.RemoveFromList(list, [0], x=>x.ToLiteral(g));
+            g.GetListItems(list).Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void RemoveAllFromListRemovesAllOccurrences()
+        {
+            var g = new Graph();
+            INode list = g.AssertList([0, 0, 1], x => x.ToLiteral(g));
+            g.RemoveAllFromList(list, [0], x=>x.ToLiteral(g));
+            g.GetListItems(list).Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void AnEmptyListCanBeAssertedAndRetrieved()
+        {
+            var g = new Graph();
+            INode list = g.AssertList(new List<INode>());
+            g.GetListItems(list).Should().BeEmpty();
         }
 
         [Fact]


### PR DESCRIPTION
Add methods to remove all instances of a given RDF node (or object with a node mapping function) from an RDF collection. 

In testing this I discovered an issue in the handling of the case where you remove the last item from a list resulting in the list node no longer being readable with the GetListItems method. I will create a separate ticket for that issue.