### PR TITLE
Fix constructor param validation for SPARQL Update commands

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,7 @@
 -----
 
 ENHANCEMENT: Update the asynchronous pull query engine to use indexed lookups for joins.
+FIX: Constructors for SPARQL update commands now validate inputs to guard against null values for required parameters. Documentation has been updated for the affected classes.
 
 3.4
 ---

--- a/Libraries/dotNetRdf.Core/Update/Commands/AddCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/AddCommand.cs
@@ -37,10 +37,11 @@ public class AddCommand
     /// <summary>
     /// Creates a command which merges the data from the source graph into the destination graph.
     /// </summary>
-    /// <param name="sourceGraphName">Name of the source graph.</param>
-    /// <param name="destinationGraphName">Name of the destination graph.</param>
-    /// <param name="silent">Whether errors should be suppressed.</param>
-    public AddCommand(IRefNode sourceGraphName, IRefNode destinationGraphName, bool silent = false):base(SparqlUpdateCommandType.Add, sourceGraphName, destinationGraphName, silent){}
+    /// <param name="sourceGraphName">Name of the source graph. If null, the source graph is the default graph.</param>
+    /// <param name="destinationGraphName">Name of the destination graph. If null, the destination graph is the default graph.</param>
+    /// <param name="silent">Whether errors should be suppressed. Defaults to `false`.</param>
+    public AddCommand(IRefNode sourceGraphName, IRefNode destinationGraphName, bool silent = false)
+        :base(SparqlUpdateCommandType.Add, sourceGraphName, destinationGraphName, silent){}
 
     /// <summary>
     /// Creates a Command which merges the data from the Source Graph into the Destination Graph.

--- a/Libraries/dotNetRdf.Core/Update/Commands/ClearCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/ClearCommand.cs
@@ -64,13 +64,20 @@ public class ClearCommand : SparqlUpdateCommand
     /// <param name="graphName">Graph URI.</param>
     /// <param name="mode">Clear Mode.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
+    /// <remarks>
+    /// <paramref name="graphName"/> is only relevant when <paramref name="mode"/> is <see cref="ClearMode.Graph"/>.
+    /// If <paramref name="graphName"/> is null and the <paramref name="mode"/> is <see cref="ClearMode.Graph"/>,
+    /// the <paramref name="mode"/> will be changed to <see cref="ClearMode.Default"/>.
+    /// </remarks>
     public ClearCommand(IRefNode graphName, ClearMode mode, bool silent)
         : base(SparqlUpdateCommandType.Clear)
     {
         TargetGraphName = graphName;
         Mode = mode;
         if (TargetGraphName == null && Mode == ClearMode.Graph) Mode = ClearMode.Default;
-        if (Mode == ClearMode.Default) TargetGraphName = null;
+        if (Mode == ClearMode.Default) {
+            TargetGraphName = null;
+        }
         Silent = silent;
     }
 
@@ -81,10 +88,8 @@ public class ClearCommand : SparqlUpdateCommand
     /// <param name="mode">Clear Mode.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
     [Obsolete("Replaced by ClearCommand(IRefNode, ClearMode, bool)")]
-    public ClearCommand(Uri graphName, ClearMode mode, bool silent) : this(graphName == null ? null : new UriNode(graphName), mode, silent)
-    {
-
-    }
+    public ClearCommand(Uri graphName, ClearMode mode, bool silent) 
+        : this(graphName == null ? null : new UriNode(graphName), mode, silent) { }
 
     /// <summary>
     /// Creates a Command which clears the given Graph.
@@ -100,9 +105,7 @@ public class ClearCommand : SparqlUpdateCommand
     /// <param name="graphUri">URI of the Graph to clear.</param>
     [Obsolete("Replaced by ClearCommand(IRefNode)")]
     public ClearCommand(Uri graphUri)
-        : this(graphUri == null ? null : new UriNode(graphUri), ClearMode.Graph, false)
-    {
-    }
+        : this(graphUri == null ? null : new UriNode(graphUri), ClearMode.Graph, false) { }
 
 
     /// <summary>
@@ -116,6 +119,9 @@ public class ClearCommand : SparqlUpdateCommand
     /// </summary>
     /// <param name="mode">Clear Mode.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
+    /// <remarks>
+    /// If <paramref name="mode"/> is <see cref="ClearMode.Graph"/>, the Command will operate on the Default Graph.
+    /// </remarks>
     public ClearCommand(ClearMode mode, bool silent)
         : this((IRefNode)null, mode, silent) { }
 
@@ -123,6 +129,9 @@ public class ClearCommand : SparqlUpdateCommand
     /// Creates a Command which performs the specified type of clear.
     /// </summary>
     /// <param name="mode">Clear Mode.</param>
+    /// <remarks>
+    /// If <paramref name="mode"/> is <see cref="ClearMode.Graph"/>, the Command will operate on the Default Graph.
+    /// </remarks>
     public ClearCommand(ClearMode mode)
         : this(mode, false) { }
 

--- a/Libraries/dotNetRdf.Core/Update/Commands/CopyCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/CopyCommand.cs
@@ -56,8 +56,8 @@ public class CopyCommand
     /// <summary>
     /// Creates a Command which Copies the contents of one Graph to another overwriting the destination Graph.
     /// </summary>
-    /// <param name="sourceName">Source Graph name.</param>
-    /// <param name="destName">Destination Graph name.</param>
+    /// <param name="sourceName">Source Graph name, or null if the source graph is the default graph.</param>
+    /// <param name="destName">Destination Graph name, or null if the destination graph is the default graph.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
     public CopyCommand(IRefNode sourceName, IRefNode destName, bool silent = false)
         : base(SparqlUpdateCommandType.Copy, sourceName, destName, silent) { }

--- a/Libraries/dotNetRdf.Core/Update/Commands/CreateCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/CreateCommand.cs
@@ -57,6 +57,7 @@ public class CreateCommand : SparqlUpdateCommand
     /// </summary>
     /// <param name="graphName">Name of the graph to create.</param>
     /// <param name="silent">Whether the create should be done silently.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="graphName"/> is null.</exception>
     public CreateCommand(IRefNode graphName, bool silent = false) : base(SparqlUpdateCommandType.Create)
     {
         TargetGraphName = graphName ?? throw new ArgumentNullException(nameof(graphName));

--- a/Libraries/dotNetRdf.Core/Update/Commands/CreateCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/CreateCommand.cs
@@ -40,15 +40,15 @@ public class CreateCommand : SparqlUpdateCommand
     /// </summary>
     /// <param name="graphUri">URI of the Graph to create.</param>
     /// <param name="silent">Whether the create should be done silently.</param>
+    [Obsolete("Replaced by CreateCommand(IRefNode, bool)")]
     public CreateCommand(Uri graphUri, bool silent)
-        : this(graphUri == null ? null : new UriNode(graphUri), silent) 
-    {
-    }
+        : this(graphUri == null ? null : new UriNode(graphUri), silent) { }
 
     /// <summary>
     /// Creates a new CREATE command.
     /// </summary>
     /// <param name="graphUri">URI of the Graph to create.</param>
+    [Obsolete("Replaced by CreateCommand(IRefNode, bool)")]
     public CreateCommand(Uri graphUri)
         : this(graphUri == null ? null : new UriNode(graphUri), false) { }
 

--- a/Libraries/dotNetRdf.Core/Update/Commands/DeleteCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/DeleteCommand.cs
@@ -54,9 +54,10 @@ public class DeleteCommand : BaseModificationCommand
     /// <summary>
     /// Creates a new DELETE command.
     /// </summary>
-    /// <param name="deletions">REQUIRED: Pattern to construct Triples to delete.</param>
-    /// <param name="where">REQUIRED: Pattern to select data which is then used in evaluating the deletions pattern.</param>
-    /// <param name="graphName">OPTIONAL: Name of the affected Graph. If null, the operations is applied to the default graph.</param>
+    /// <param name="deletions">Pattern to construct Triples to delete.</param>
+    /// <param name="where">Pattern to select data which is then used in evaluating the deletions pattern.</param>
+    /// <param name="graphName">Name of the affected Graph. If null, the operations is applied to the default graph.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="deletions"/> or <paramref name="where"/> is null.</exception>
     public DeleteCommand(GraphPattern deletions, GraphPattern where, IRefNode graphName)
         : base(SparqlUpdateCommandType.Delete)
     {

--- a/Libraries/dotNetRdf.Core/Update/Commands/DeleteCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/DeleteCommand.cs
@@ -47,25 +47,26 @@ public class DeleteCommand : BaseModificationCommand
     /// <param name="graphUri">URI of the affected Graph.</param>
     [Obsolete("Replaced by DeleteCommand(GraphPatten, GraphPattern, IRefNode")]
     public DeleteCommand(GraphPattern deletions, GraphPattern where, Uri graphUri)
-        : base(SparqlUpdateCommandType.Delete)
+        : this(deletions, where, graphUri == null ? null : new UriNode(graphUri))
     {
-        if (!IsValidDeletePattern(deletions, true)) throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
-
-        DeletePattern = deletions;
-        WherePattern = where;
-        WithGraphName = graphUri == null ? null : new UriNode(graphUri);
     }
 
     /// <summary>
     /// Creates a new DELETE command.
     /// </summary>
-    /// <param name="deletions">Pattern to construct Triples to delete.</param>
-    /// <param name="where">Pattern to select data which is then used in evaluating the deletions pattern.</param>
-    /// <param name="graphName">Name of the affected Graph.</param>
+    /// <param name="deletions">REQUIRED: Pattern to construct Triples to delete.</param>
+    /// <param name="where">REQUIRED: Pattern to select data which is then used in evaluating the deletions pattern.</param>
+    /// <param name="graphName">OPTIONAL: Name of the affected Graph. If null, the operations is applied to the default graph.</param>
     public DeleteCommand(GraphPattern deletions, GraphPattern where, IRefNode graphName)
         : base(SparqlUpdateCommandType.Delete)
     {
-        if (!IsValidDeletePattern(deletions, true)) throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
+        if (deletions == null) throw new ArgumentNullException(nameof(deletions));
+        if (where == null) throw new ArgumentNullException(nameof(where));
+
+        if (!IsValidDeletePattern(deletions, true))
+        {
+            throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
+        }
 
         DeletePattern = deletions;
         WherePattern = where;
@@ -77,13 +78,7 @@ public class DeleteCommand : BaseModificationCommand
     /// <param name="deletions">Pattern to construct Triples to delete.</param>
     /// <param name="where">Pattern to select data which is then used in evaluating the deletions pattern.</param>
     public DeleteCommand(GraphPattern deletions, GraphPattern where)
-        : base(SparqlUpdateCommandType.Delete)
-    {
-        if (!IsValidDeletePattern(deletions, true)) throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
-
-        DeletePattern = deletions;
-        WherePattern = where;
-    }
+        : this(deletions, where, (IRefNode)null) { }
 
     /// <summary>
     /// Creates a new DELETE command. 
@@ -100,12 +95,10 @@ public class DeleteCommand : BaseModificationCommand
     /// <param name="where">Pattern to construct Triples to delete.</param>
     /// <param name="graphName">Name of the affected Graph.</param>
     public DeleteCommand(GraphPattern where, IRefNode graphName)
-        : this(where, where, graphName)
-    {
-    }
+        : this(where, where, graphName) { }
 
     /// <summary>
-    /// Createa a new DELETE command which operates on the Default Graph.
+    /// Creates a new DELETE command which operates on the Default Graph.
     /// </summary>
     /// <param name="where">Pattern to construct Triples to delete.</param>
     public DeleteCommand(GraphPattern where)

--- a/Libraries/dotNetRdf.Core/Update/Commands/DeleteDataCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/DeleteDataCommand.cs
@@ -42,11 +42,20 @@ public class DeleteDataCommand : SparqlUpdateCommand
     /// <summary>
     /// Creates a new DELETE DATA command.
     /// </summary>
-    /// <param name="pattern">Pattern composed of concrete Triples to delete.</param>
+    /// <param name="pattern">Pattern composed of concrete Triples to delete. Must not be null.</param>
+    /// <throws cref="ArgumentNullException">Thrown if the given pattern is null.</throws>
+    /// <throws cref="SparqlUpdateException">Thrown if the given pattern is not valid for use in a DELETE DATA command.</throws>
     public DeleteDataCommand(GraphPattern pattern)
         : base(SparqlUpdateCommandType.DeleteData) 
     {
-        if (!IsValidDataPattern(pattern, true)) throw new SparqlUpdateException("Cannot create a DELETE DATA command where any of the Triple Patterns are not concrete triples (Variables/Blank Nodes are not permitted) or a GRAPH clause has nested Graph Patterns");
+        if (pattern == null)
+        {
+            throw new ArgumentNullException(nameof(pattern));
+        }
+        if (!IsValidDataPattern(pattern, true))
+        {
+            throw new SparqlUpdateException("Cannot create a DELETE DATA command where any of the Triple Patterns are not concrete triples (Variables/Blank Nodes are not permitted) or a GRAPH clause has nested Graph Patterns");
+        }
         _pattern = pattern;
     }
 

--- a/Libraries/dotNetRdf.Core/Update/Commands/DropCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/DropCommand.cs
@@ -41,12 +41,23 @@ public class DropCommand : SparqlUpdateCommand
     /// <param name="graphName">Name of the Graph to DROP.</param>
     /// <param name="mode">DROP Mode to use.</param>
     /// <param name="silent">Whether the DROP should be done silently.</param>
-    public DropCommand(IRefNode graphName = null, ClearMode mode = ClearMode.Graph, bool silent = false) : base(SparqlUpdateCommandType.Drop)
+    /// <remarks>
+    /// If <paramref name="graphName"/> is null and <paramref name="mode"/> is <see cref="ClearMode.Graph"/>, the Command will operate on the Default Graph.
+    /// If <paramref name="mode"/> is <see cref="ClearMode.Default"/>, <paramref name="graphName"/> is ignored and <see cref="TargetGraphName"/> will be set to null.
+    /// </remarks>
+    public DropCommand(IRefNode graphName = null, ClearMode mode = ClearMode.Graph, bool silent = false) 
+        : base(SparqlUpdateCommandType.Drop)
     {
         TargetGraphName = graphName;
         Mode = mode;
-        if (TargetGraphName == null && Mode == ClearMode.Graph) Mode = ClearMode.Default;
-        if (Mode == ClearMode.Default) TargetGraphName = null;
+        if (TargetGraphName == null && Mode == ClearMode.Graph)
+        {
+            Mode = ClearMode.Default;
+        }
+        if (Mode == ClearMode.Default)
+            {
+                TargetGraphName = null;
+            }
         Silent = silent;
     }
 
@@ -99,6 +110,9 @@ public class DropCommand : SparqlUpdateCommand
     /// </summary>
     /// <param name="mode">Clear Mode.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
+    /// <remarks>
+    /// If <paramref name="mode"/> is <see cref="ClearMode.Graph"/>, the Command will operate on the Default Graph.
+    /// </remarks>
     public DropCommand(ClearMode mode, bool silent)
         : this((IRefNode)null, mode, silent) { }
 

--- a/Libraries/dotNetRdf.Core/Update/Commands/InsertCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/InsertCommand.cs
@@ -46,6 +46,7 @@ public class InsertCommand
     /// <param name="insertions">Pattern to construct Triples to insert.</param>
     /// <param name="where">Pattern to select data which is then used in evaluating the insertions.</param>
     /// <param name="graphName">Name of the affected Graph.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="insertions"/> or <paramref name="where"/> is null.</exception>
     public InsertCommand(GraphPattern insertions, GraphPattern where, IRefNode graphName) : base(
         SparqlUpdateCommandType.Insert)
     {

--- a/Libraries/dotNetRdf.Core/Update/Commands/InsertCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/InsertCommand.cs
@@ -49,6 +49,8 @@ public class InsertCommand
     public InsertCommand(GraphPattern insertions, GraphPattern where, IRefNode graphName) : base(
         SparqlUpdateCommandType.Insert)
     {
+        if (insertions == null) throw new ArgumentNullException(nameof(insertions));
+        if (where == null) throw new ArgumentNullException(nameof(where));
         InsertPattern = insertions;
         WherePattern = where;
         WithGraphName = graphName;
@@ -62,9 +64,7 @@ public class InsertCommand
     /// <param name="graphUri">URI of the affected Graph.</param>
     [Obsolete("Replaced by InsertCommand(GraphPattern, GraphPattern, IRefNode)")]
     public InsertCommand(GraphPattern insertions, GraphPattern where, Uri graphUri)
-        : this(insertions, where, graphUri == null ? null : new UriNode(graphUri))
-    {
-    }
+        : this(insertions, where, graphUri == null ? null : new UriNode(graphUri)) { }
 
     /// <summary>
     /// Creates a new INSERT command which operates on the Default Graph.

--- a/Libraries/dotNetRdf.Core/Update/Commands/InsertDataCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/InsertDataCommand.cs
@@ -42,10 +42,19 @@ public class InsertDataCommand
     /// Creates a new INSERT DATA command.
     /// </summary>
     /// <param name="pattern">Pattern containing concrete Triples to insert.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the pattern is null.</exception>
+    /// <exception cref="SparqlUpdateException">Thrown when the pattern is not valid for use in an INSERT DATA command.</exception>
     public InsertDataCommand(GraphPattern pattern)
         : base(SparqlUpdateCommandType.InsertData) 
     {
-        if (!IsValidDataPattern(pattern, true)) throw new SparqlUpdateException("Cannot create a INSERT DATA command where any of the Triple Patterns are not concrete triples (variables are not permitted) or a GRAPH clause has nested Graph Patterns");
+        if (pattern == null)
+        {
+            throw new ArgumentNullException(nameof(pattern));
+        }
+        if (!IsValidDataPattern(pattern, true))
+        {
+            throw new SparqlUpdateException("Cannot create a INSERT DATA command where any of the Triple Patterns are not concrete triples (variables are not permitted) or a GRAPH clause has nested Graph Patterns");
+        }
         DataPattern = pattern;
     }
 

--- a/Libraries/dotNetRdf.Core/Update/Commands/LoadCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/LoadCommand.cs
@@ -42,10 +42,13 @@ public class LoadCommand : SparqlUpdateCommand
     /// <param name="graphName">Name of the graph to store data in. If null or omitted, the target is the default graph.</param>
     /// <param name="silent">Whether errors loading should be suppressed.</param>
     /// <param name="loader">The loader to use for retrieving and parsing data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the source URI is null.</exception>
     public LoadCommand(Uri sourceUri, IRefNode graphName = null, bool silent = false, Loader loader = null)
         : base(SparqlUpdateCommandType.Load)
     {
-        if (sourceUri == null) throw new ArgumentNullException(nameof(sourceUri));
+        if (sourceUri == null) {
+            throw new ArgumentNullException(nameof(sourceUri));
+        }
         SourceUri = sourceUri;
         TargetGraphName = graphName;
         Silent = silent;

--- a/Libraries/dotNetRdf.Core/Update/Commands/ModifyCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/ModifyCommand.cs
@@ -52,8 +52,13 @@ public class ModifyCommand
     public ModifyCommand(GraphPattern deletions, GraphPattern insertions, GraphPattern where,
         IRefNode graphName = null) : base(SparqlUpdateCommandType.Modify)
     {
-        if (!IsValidDeletePattern(deletions, true)) throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
-
+        if (deletions == null) throw new ArgumentNullException(nameof(deletions));
+        if (insertions == null) throw new ArgumentNullException(nameof(insertions));
+        if (where == null) throw new ArgumentNullException(nameof(where));
+        if (!IsValidDeletePattern(deletions, true))
+        {
+            throw new SparqlUpdateException("Cannot create a DELETE command where any of the Triple Patterns are not constructable triple patterns (Blank Node Variables are not permitted) or a GRAPH clause has nested Graph Patterns");
+        }
         _deletePattern = deletions;
         _insertPattern = insertions;
         _wherePattern = where;

--- a/Libraries/dotNetRdf.Core/Update/Commands/ModifyCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/ModifyCommand.cs
@@ -49,6 +49,7 @@ public class ModifyCommand
     /// <param name="insertions">Pattern to construct Triples to insert.</param>
     /// <param name="where">Pattern to select data which is then used in evaluating the insertions and deletions.</param>
     /// <param name="graphName">Name of the affected Graph.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="deletions"/>, <paramref name="insertions"/> or <paramref name="where"/> is null.</exception>
     public ModifyCommand(GraphPattern deletions, GraphPattern insertions, GraphPattern where,
         IRefNode graphName = null) : base(SparqlUpdateCommandType.Modify)
     {

--- a/Libraries/dotNetRdf.Core/Update/Commands/MoveCommand.cs
+++ b/Libraries/dotNetRdf.Core/Update/Commands/MoveCommand.cs
@@ -36,10 +36,11 @@ public class MoveCommand : BaseTransferCommand
     /// <summary>
     /// Creates a command which moves data from one graph to another, overwriting the destination graph and deleting the source graph.
     /// </summary>
-    /// <param name="sourceGraphName">Name of the source graph.</param>
-    /// <param name="destinationGraphName">Name of the destination graph.</param>
+    /// <param name="sourceGraphName">Name of the source graph. If null, the default graph will be used as the source graph.</param>
+    /// <param name="destinationGraphName">Name of the destination graph. If null, the default graph will be used as the destination graph.</param>
     /// <param name="silent">Whether errors should be suppressed.</param>
-    public MoveCommand(IRefNode sourceGraphName, IRefNode destinationGraphName, bool silent = false):base(SparqlUpdateCommandType.Move, sourceGraphName, destinationGraphName, silent){}
+    public MoveCommand(IRefNode sourceGraphName, IRefNode destinationGraphName, bool silent = false)
+        : base(SparqlUpdateCommandType.Move, sourceGraphName, destinationGraphName, silent) { }
 
     /// <summary>
     /// Creates a Command which Moves data from one Graph to another overwriting the destination Graph and deleting the source Graph.

--- a/Testing/dotNetRdf.Tests/Update/Commands/CreateCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/CreateCommandTests.cs
@@ -1,0 +1,13 @@
+using System;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+public class CreateCommandTests
+{
+    [Fact]
+    public void GraphNameIsRequired()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new CreateCommand((IRefNode)null));
+        Assert.Equal("graphName", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/DeleteCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/DeleteCommandTests.cs
@@ -1,0 +1,33 @@
+using System;
+using VDS.RDF.Query.Patterns;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+public class DeleteCommandTests
+{
+    [Fact]
+    public void DeletionPatternIsRequired()
+    {
+        var wherePattern = new GraphPattern();
+        wherePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new DeleteCommand(null, wherePattern));
+        Assert.Equal("deletions", ex.ParamName);
+    }
+
+    [Fact]
+    public void WherePatternIsRequired()
+    {
+        var graphPattern = new GraphPattern();
+        graphPattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new DeleteCommand(graphPattern, (GraphPattern)null));
+        Assert.Equal("where", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/DeleteDataCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/DeleteDataCommandTests.cs
@@ -1,0 +1,14 @@
+using System;
+using VDS.RDF.Query.Patterns;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+public class DeleteDataCommandTests
+{
+    [Fact]
+    public void DeletionPatternIsRequired()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new DeleteDataCommand((GraphPattern)null));
+        Assert.Equal("pattern", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/DropCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/DropCommandTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+public class DropCommandTests
+{
+    [Fact]
+    public void GraphModeWithNullGraphNameIsTreatedAsDefaultMode()
+    {
+        var cmd = new DropCommand((IRefNode)null, ClearMode.Graph, false);
+        Assert.Null(cmd.TargetGraphName);
+        Assert.Equal(ClearMode.Default, cmd.Mode);
+        Assert.False(cmd.Silent);
+    }
+
+    [Fact]
+    public void DefaultModeIgnoresGraphName()
+    {
+        var cmd = new DropCommand(new UriNode(new Uri("http://example.org/graph")), ClearMode.Default, true);
+        Assert.Null(cmd.TargetGraphName);
+        Assert.Equal(ClearMode.Default, cmd.Mode);
+        Assert.True(cmd.Silent);
+    }
+
+    [Fact]
+    public void ModeCanBeAll()
+    {
+        var cmd = new DropCommand((IRefNode)null, ClearMode.All, false);
+        Assert.Null(cmd.TargetGraphName);
+        Assert.Equal(ClearMode.All, cmd.Mode);
+        Assert.False(cmd.Silent);
+    }
+
+    [Fact]
+    public void ModeCanBeGraph()
+    {
+        var cmd = new DropCommand(new UriNode(new Uri("http://example.org/graph")), ClearMode.Graph, true);
+        Assert.NotNull(cmd.TargetGraphName);
+        Assert.Equal(new Uri("http://example.org/graph"), ((IUriNode)cmd.TargetGraphName).Uri);
+        Assert.Equal(ClearMode.Graph, cmd.Mode);
+        Assert.True(cmd.Silent);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/InsertCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/InsertCommandTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+using VDS.RDF.Query.Patterns;
+
+namespace VDS.RDF.Update.Commands;
+
+public class InsertCommandTests
+{
+    [Fact]
+    public void InsertionPatternIsRequired()
+    {
+        var wherePattern = new GraphPattern();
+        wherePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new InsertCommand(null, wherePattern));
+        Assert.Equal("insertions", ex.ParamName);
+    }
+
+    [Fact]
+    public void WherePatternIsRequired() {
+        var graphPattern = new GraphPattern();
+        graphPattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new InsertCommand(graphPattern, (GraphPattern)null));
+        Assert.Equal("where", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/InsertDataCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/InsertDataCommandTests.cs
@@ -1,0 +1,28 @@
+using System;
+using VDS.RDF.Query.Patterns;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+
+public class InsertDataCommandTests
+{
+    [Fact]
+    public void InsertionPatternIsRequired()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new InsertDataCommand(null));
+        Assert.Equal("pattern", ex.ParamName);
+    }
+
+    [Fact]
+    public void InsertionPatternMustBeConcreteTriples()
+    {
+        var pattern = new GraphPattern();
+        pattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<SparqlUpdateException>(() => new InsertDataCommand(pattern));
+        Assert.Equal("Cannot create a INSERT DATA command where any of the Triple Patterns are not concrete triples (variables are not permitted) or a GRAPH clause has nested Graph Patterns", ex.Message);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/LoadCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/LoadCommandTests.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+
+public class LoadCommandTests
+{
+    [Fact]
+    public void SourceUriIsRequired()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new LoadCommand(null, (IRefNode)null, false, null));
+        Assert.Equal("sourceUri", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/Commands/ModifyCommandTests.cs
+++ b/Testing/dotNetRdf.Tests/Update/Commands/ModifyCommandTests.cs
@@ -1,0 +1,66 @@
+
+using System;
+using VDS.RDF.Query.Patterns;
+using Xunit;
+
+namespace VDS.RDF.Update.Commands;
+
+public class ModifyCommandTests
+{
+    [Fact]
+    public void DeletionPatternIsRequired()
+    {
+        var wherePattern = new GraphPattern();
+        wherePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var insertPattern = new GraphPattern();
+        insertPattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new ModifyCommand(null, insertPattern, wherePattern));
+        Assert.Equal("deletions", ex.ParamName);
+    }
+
+    [Fact]
+    public void InsertionPatternIsRequired()
+    {
+        var wherePattern = new GraphPattern();
+        wherePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var deletePattern = new GraphPattern();
+        deletePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new ModifyCommand(deletePattern, null, wherePattern));
+        Assert.Equal("insertions", ex.ParamName);
+    }
+
+    [Fact]
+    public void WherePatternIsRequired()
+    {
+        var deletePattern = new GraphPattern();
+        deletePattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var insertPattern = new GraphPattern();
+        insertPattern.AddTriplePattern(new TriplePattern(
+            new VariablePattern("s"),
+            new VariablePattern("p"),
+            new VariablePattern("o")
+        ));
+        var ex = Assert.Throws<ArgumentNullException>(() => new ModifyCommand(deletePattern, insertPattern, null));
+        Assert.Equal("where", ex.ParamName);
+    }
+}

--- a/Testing/dotNetRdf.Tests/Update/UpdateTests2.cs
+++ b/Testing/dotNetRdf.Tests/Update/UpdateTests2.cs
@@ -53,8 +53,8 @@ public class UpdateTests2
         Console.WriteLine("Store has " + store.Graphs.Count + " Graphs");
 
         //Create a couple of Graphs using Create Commands
-        var create1 = new CreateCommand(new Uri("http://example.org/1"));
-        var create2 = new CreateCommand(new Uri("http://example.org/2"));
+        var create1 = new CreateCommand(new UriNode(new Uri("http://example.org/1")));
+        var create2 = new CreateCommand(new UriNode(new Uri("http://example.org/2")));
         var nodeFactory = new NodeFactory();
         IUriNode g1 = nodeFactory.CreateUriNode(new Uri("http://example.org/1"));
         IUriNode g2 = nodeFactory.CreateUriNode(new Uri("http://example.org/2"));
@@ -77,7 +77,7 @@ public class UpdateTests2
         }
 
         //Equivalent Create with SILENT should not error
-        var create3 = new CreateCommand(new Uri("http://example.org/1"), true);
+        var create3 = new CreateCommand(new UriNode(new Uri("http://example.org/1")), true);
         try
         {
             store.ExecuteUpdate(create3);


### PR DESCRIPTION
Commands now ensure that required params are not null.
Constructor documentation on the non-obsolete constructors has been updated.