### PR TITLE
Remove code coverage collection which appears to be causing CI failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,7 @@ jobs:
         fetch-depth: 0
         submodules: 'true'
     - name: Run Tests
-      run: dotnet test -c Release --filter "Category!=explicit&Category!=performance" --framework ${{ matrix.framework }} --collect:"XPlat Code Coverage" Testing/${{matrix.suite}}
-    - name: Upload Code Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: code-coverage-windows ${{matrix.suite}} ${{matrix.framework}}
-        path: Testing\${{matrix.suite}}\TestResults\**\coverage.cobertura.xml
+      run: dotnet test -c Release --filter "Category!=explicit&Category!=performance" --framework ${{ matrix.framework }} Testing/${{matrix.suite}}
     
   test-linux:
     runs-on: ubuntu-latest
@@ -77,15 +72,10 @@ jobs:
         fetch-depth: 0
     - name: Start Fuseki
       run: docker run --rm -d -p 3030:3030 --name fuseki atomgraph/fuseki --mem /ds
-    - name: Test Fuskei Connector
-      run: dotnet test -c Release --framework net8.0 --collect:"XPlat Code Coverage" Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
+    - name: Test Fuseki Connector
+      run: dotnet test -c Release --framework net8.0 Testing/dotNetRdf.Connectors.Fuseki.Tests/dotNetRdf.Connectors.Fuseki.Tests.csproj
     - name: Stop Fuseki
       run: docker stop fuseki
-    - name: Upload Code Coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: code-coverage dotNetRdf.Connectors.Fuseki.Tests net8.0
-        path: Testing/dotNetRdf.Connectors.Fuseki.Tests/TestResults/*/coverage.cobertura.xml
         
   allegrographTests:
     runs-on: ubuntu-latest
@@ -97,35 +87,7 @@ jobs:
       - name: Start Allegrograph
         run: docker run -d -e AGRAPH_SUPER_USER=test -e AGRAPH_SUPER_PASSWORD=test -p 10000-10035:10000-10035 --shm-size 1g --name agraph --restart=always franzinc/agraph
       - name: Test Allegrograph Connector
-        run: dotnet test -c Release --framework net8.0 --collect:"XPlat Code Coverage" Testing/dotNetRdf.Connectors.Allegrograph.Tests/dotNetRdf.Connectors.Allegrograph.Tests.csproj
+        run: dotnet test -c Release --framework net8.0 Testing/dotNetRdf.Connectors.Allegrograph.Tests/dotNetRdf.Connectors.Allegrograph.Tests.csproj
       - name: Stop Allegrograph
         run: docker stop agraph
-      - name: Upload Code Coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage dotNetRdf.Connectors.Allegrograph.Tests net8.0
-          path: Testing/dotNetRdf.Connectors.Allegrograph.Tests/TestResults/*/coverage.cobertura.xml
-
-  report:
-    needs: [ "test", "test-linux", "fusekiTests", "allegrographTests" ]
-    runs-on: windows-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - name: Download coverage artifacts
-      uses: actions/download-artifact@v5
-    - name: Generate coverage report
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.4.16
-      with:
-        reports: '*\*\*.xml'
-        targetdir: 'coveragereport'
-        reporttypes: 'HtmlInline;Cobertura;Badges'
-        tag: '${{ github.run_number }}_${{ github.run_id }}'
-    - name: Upload Coverage Report
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: coveragereport\*
 


### PR DESCRIPTION
The generation of code coverage data is causing exceptions in the dotnet sdk. This PR removes the generation and publication of code coverage data. This can still be done locally as needed.