### PR TITLE
Update test dependencies

### DIFF
--- a/Testing/Directory.Packages.props
+++ b/Testing/Directory.Packages.props
@@ -1,10 +1,10 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
 	<ItemGroup>
-		<PackageVersion Include="FluentAssertions" Version="8.7.0" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageVersion Include="FluentAssertions" Version="8.7.1" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="WireMock.Net" Version="1.12.0" />
+		<PackageVersion Include="WireMock.Net" Version="1.14.0" />
 		<PackageVersion Include="xunit.v3" Version="3.1.0" />
 		<PackageVersion Include="xunit.v3.assert" Version="3.1.0" />
 		<PackageVersion Include="xunit.v3.extensibility.core" Version="3.1.0" />


### PR DESCRIPTION
Applies updates that dependabot reported and then closed:

* FluentAssertions: 8.7.0 -> 8.7.1
* Microsoft.NET.Test.Sdk: 17.14.1 -> 18.0.0
* WireMock.Net: 1.12.0 -> 1.14.0
