### PR TITLE
Add support for comments in SparqlParameterizedString to avoid issues…

### DIFF
--- a/Testing/dotNetRdf.Tests/Query/SparqlParameterizedStringTests.cs
+++ b/Testing/dotNetRdf.Tests/Query/SparqlParameterizedStringTests.cs
@@ -49,4 +49,21 @@ public class SparqlParameterizedStringTests
         Assert.Equal("SELECT * WHERE { ?s a \"test\" }", sut.ToString());
     }
 
+    [Fact]
+    public void SetParameterShouldIgnoreLiteralInComments()
+    {
+        var sut = new SparqlParameterizedString("# Comment that has a ' char in it\nSELECT * WHERE { ?s a @o }");
+        sut.SetParameter("@o", new NodeFactory().CreateLiteralNode("test"));
+
+        Assert.Equal("# Comment that has a ' char in it\nSELECT * WHERE { ?s a \"test\" }", sut.ToString());
+    }
+
+    [Fact]
+    public void SetParameterShouldIgnoreParametersInComments()
+    {
+        var sut = new SparqlParameterizedString("# Comment with @o reference\nSELECT * WHERE { ?s a @o }");
+        sut.SetParameter("@o", new NodeFactory().CreateLiteralNode("test"));
+
+        Assert.Equal("# Comment with @o reference\nSELECT * WHERE { ?s a \"test\" }", sut.ToString());
+    }
 }


### PR DESCRIPTION
… with parameters in comments and literals that start or end in comments

Currently when you have a query that has comments and that comment contains quotes the parser thinks that starts a literal, this causes issues if for example we use the word "Doesn't"  in a comment like this:

```SPARQL
# This is a comment that shouldn't affect parameter parsing
SELECT * WHERE { ?s a @o }
```
would not recognize or replace further parameters because the parser state would end up in literal mode and would keep looking for the closing single quote.
This PR adds supports for recognizing comments (outside of literals and iris) and ignoring further special characters until the end of line (how the SPARQL 1.1 Spec describes comments end)