### PR TITLE
Add ISparqlUpdateClient interface for SparqlUpdateClient

### DIFF
--- a/Libraries/dotNetRdf.Core/Update/ISparqlUpdateClient.cs
+++ b/Libraries/dotNetRdf.Core/Update/ISparqlUpdateClient.cs
@@ -1,0 +1,51 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2026 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VDS.RDF.Update;
+
+/// <summary>
+/// Interface for connecting to a remote SPARQL endpoint and making queries against it.
+/// </summary>
+public interface ISparqlUpdateClient
+{
+    /// <summary>
+    /// Makes an update request to the remote endpoint.
+    /// </summary>
+    /// <param name="sparqlUpdate">The SPARQL Update request.</param>
+    /// <returns></returns>
+    Task UpdateAsync(string sparqlUpdate);
+
+    /// <summary>
+    /// Makes an update request to the remote endpoint.
+    /// </summary>
+    /// <param name="sparqlUpdate">The SPARQL Update request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    Task UpdateAsync(string sparqlUpdate, CancellationToken cancellationToken);
+}

--- a/Libraries/dotNetRdf.Core/Update/RemoteUpdateProcessor.cs
+++ b/Libraries/dotNetRdf.Core/Update/RemoteUpdateProcessor.cs
@@ -35,7 +35,7 @@ namespace VDS.RDF.Update;
 /// </summary>
 public class RemoteUpdateProcessor : ISparqlUpdateProcessor
 {
-    private readonly SparqlUpdateClient _client;
+    private readonly ISparqlUpdateClient _client;
 
     /// <summary>
     /// Creates a new Remote Update Processor.
@@ -66,7 +66,7 @@ public class RemoteUpdateProcessor : ISparqlUpdateProcessor
     /// Creates a new remote update processor.
     /// </summary>
     /// <param name="updateClient">The SPARQL update client to delegate processing of commands to.</param>
-    public RemoteUpdateProcessor(SparqlUpdateClient updateClient)
+    public RemoteUpdateProcessor(ISparqlUpdateClient updateClient)
     {
         _client = updateClient;
     }

--- a/Libraries/dotNetRdf.Core/Update/SparqlUpdateClient.cs
+++ b/Libraries/dotNetRdf.Core/Update/SparqlUpdateClient.cs
@@ -37,7 +37,7 @@ namespace VDS.RDF.Update;
 /// <summary>
 /// A class for connecting to a remote SPARQL update endpoint and executing updates against it using the System.Net.Http library.
 /// </summary>
-public class SparqlUpdateClient : IConfigurationSerializable
+public class SparqlUpdateClient : ISparqlUpdateClient, IConfigurationSerializable
 {
     private readonly HttpClient _httpClient;
 


### PR DESCRIPTION
Adds an `ISparqlUpdateClient` for improved flexibility and to match the `ISparqlQueryClient`/`SparqlQueryClient`.