### PR TITLE
Fix FILTER with named graph

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -1,0 +1,3 @@
+VDS
+Utils
+langsamu

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,11 @@
 ﻿Change Log
 ==========
 
+Upcoming
+-----
+
+FIX: Fix an issue with incorrect handling of FILTER clauses with a NAMED GRAPH subclause in the Leviathan Query Processor. Thanks to @Ikeragnell for the report and repr. (#856)
+
 3.5.1
 -----
 FIX: Fix a memory-leak due to the failure to deregister graph event handlers. Thanks to @bruluk5w for the bug report and the fix.

--- a/Libraries/dotNetRdf.Core/Query/Expressions/Functions/Sparql/Boolean/ExistsFunction.cs
+++ b/Libraries/dotNetRdf.Core/Query/Expressions/Functions/Sparql/Boolean/ExistsFunction.cs
@@ -81,7 +81,9 @@ public class ExistsFunction
         { 
             return (from p in Pattern.TriplePatterns
                     from v in p.Variables
-                    select v).Distinct();
+                    select v)
+                    .Union(Pattern.Variables)
+                    .Distinct();
         }
     }
 

--- a/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
+++ b/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
@@ -120,4 +120,31 @@ public class Issue_856_Tests
         Assert.Equal("http://example.org/David", results[0]["this"].ToString());
         Assert.Equal("http://example.org/Yara", results[0]["someone"].ToString());
     }
+
+    [Fact]
+    public void ApplyFilterWithNamedGraphPatternAndBind()
+    {
+        var parser = new SparqlQueryParser();
+        SparqlQuery query = parser.ParseFromString(@"
+        PREFIX ex:   <http://example.org/>
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+        SELECT *
+        WHERE {
+        BIND(ex:David AS ?this) .
+        ?this a foaf:Person .
+        ?this foaf:knows ?someone .
+        FILTER NOT EXISTS {
+            GRAPH ex:namedGraph {
+            ?someone a ex:famousPerson .
+            }
+            ?this foaf:knows ?someone .
+        }
+        }");
+        var results = _processor.ProcessQuery(query) as SparqlResultSet;
+        Assert.NotNull(results);
+        Assert.Equal(1, results.Count);
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.Equal("http://example.org/Yara", results[0]["someone"].ToString());
+    }
 }

--- a/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
+++ b/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using VDS.RDF.Parsing;
+using VDS.RDF.Query.Datasets;
 using Xunit;
 
 namespace VDS.RDF.Query;
@@ -31,6 +32,7 @@ public class Issue_856_Tests
 
     private TripleStore _store;
     private LeviathanQueryProcessor _processor;
+    private LeviathanQueryProcessor _singleGraphProcessor;
 
     public Issue_856_Tests()
     {
@@ -38,6 +40,33 @@ public class Issue_856_Tests
         var parser = new TriGParser();
         parser.Load(_store, new StringReader(TestDataset));
         _processor = new LeviathanQueryProcessor(_store);
+        var graph = new Graph();
+        graph.LoadFromString(TestGraph);
+        _singleGraphProcessor = new LeviathanQueryProcessor(new InMemoryDataset(graph));
+    }
+
+    [Fact]
+    public void ApplyFilterWithNoNamedGraphPatternSingleGraph()
+    {
+        var parser = new SparqlQueryParser();
+        SparqlQuery query = parser.ParseFromString(@"
+            PREFIX ex:   <http://example.org/>
+            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+            SELECT *
+            WHERE {
+            ?this a foaf:Person .
+            FILTER NOT EXISTS {
+                ?someone a ex:famousPerson .
+                ?this foaf:knows ?someone .
+            }
+            ?this foaf:knows ?someone .
+            }");
+        var results = _singleGraphProcessor.ProcessQuery(query) as SparqlResultSet;
+        Assert.NotNull(results);
+        Assert.Equal(1, results.Count);
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.Equal("http://example.org/Yara", results[0]["someone"].ToString());
     }
 
     [Fact]
@@ -48,7 +77,7 @@ public class Issue_856_Tests
             PREFIX ex:   <http://example.org/>
             PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
-            SELECT ?this
+            SELECT *
             WHERE {
             ?this a foaf:Person .
             FILTER NOT EXISTS {
@@ -61,7 +90,9 @@ public class Issue_856_Tests
         Assert.NotNull(results);
         Assert.Equal(2, results.Count);
         Assert.Equal("http://example.org/David", results[0]["this"].ToString());
-        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.True(results[0]["someone"].ToString() == "http://example.org/Zach" || results[0]["someone"].ToString() == "http://example.org/Yara");
+        Assert.Equal("http://example.org/David", results[1]["this"].ToString());
+        Assert.True(results[1]["someone"].ToString() == "http://example.org/Zach" || results[1]["someone"].ToString() == "http://example.org/Yara");
     }
 
     [Fact]
@@ -72,21 +103,21 @@ public class Issue_856_Tests
             PREFIX ex:   <http://example.org/>
             PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
-            SELECT ?this
+            SELECT *
             WHERE {
             ?this a foaf:Person .
             ?this foaf:knows ?someone .
             FILTER NOT EXISTS {
                 GRAPH ex:namedGraph {
-                ?someone a ex:famousPerson .
+                    ?someone a ex:famousPerson .
                 }
                 ?this foaf:knows ?someone .
             }
             }");
         var results = _processor.ProcessQuery(query) as SparqlResultSet;
         Assert.NotNull(results);
-        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results.Count);
         Assert.Equal("http://example.org/David", results[0]["this"].ToString());
-        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.Equal("http://example.org/Yara", results[0]["someone"].ToString());
     }
 }

--- a/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
+++ b/Testing/dotNetRdf.Tests/Query/Issue_856_Tests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using VDS.RDF.Parsing;
+using Xunit;
+
+namespace VDS.RDF.Query;
+
+public class Issue_856_Tests
+{
+    private static readonly String TestDataset = @"
+        @prefix ex:   <http://example.org/> .
+        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+        ex:David a foaf:Person .
+        ex:David foaf:knows ex:Zach .
+        ex:David foaf:knows ex:Yara .
+
+        ex:namedGraph {
+            ex:Zach a ex:famousPerson .
+        }";
+
+    private static readonly String TestGraph = @"
+        @prefix ex:   <http://example.org/> .
+        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+        ex:David a foaf:Person .
+        ex:David foaf:knows ex:Zach .
+        ex:David foaf:knows ex:Yara .
+        ex:Zach a ex:famousPerson .";
+    
+
+    private TripleStore _store;
+    private LeviathanQueryProcessor _processor;
+
+    public Issue_856_Tests()
+    {
+        _store = new TripleStore();
+        var parser = new TriGParser();
+        parser.Load(_store, new StringReader(TestDataset));
+        _processor = new LeviathanQueryProcessor(_store);
+    }
+
+    [Fact]
+    public void ApplyFilterWithNoNamedGraphPattern()
+    {
+        var parser = new SparqlQueryParser();
+        SparqlQuery query = parser.ParseFromString(@"
+            PREFIX ex:   <http://example.org/>
+            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+            SELECT ?this
+            WHERE {
+            ?this a foaf:Person .
+            FILTER NOT EXISTS {
+                ?someone a ex:famousPerson .
+                ?this foaf:knows ?someone .
+            }
+            ?this foaf:knows ?someone .
+            }");
+        var results = _processor.ProcessQuery(query) as SparqlResultSet;
+        Assert.NotNull(results);
+        Assert.Equal(2, results.Count);
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+    }
+
+    [Fact]
+    public void ApplyFilterWithNamedGraphPattern()
+    {
+        var parser = new SparqlQueryParser();
+        SparqlQuery query = parser.ParseFromString(@"
+            PREFIX ex:   <http://example.org/>
+            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+            SELECT ?this
+            WHERE {
+            ?this a foaf:Person .
+            ?this foaf:knows ?someone .
+            FILTER NOT EXISTS {
+                GRAPH ex:namedGraph {
+                ?someone a ex:famousPerson .
+                }
+                ?this foaf:knows ?someone .
+            }
+            }");
+        var results = _processor.ProcessQuery(query) as SparqlResultSet;
+        Assert.NotNull(results);
+        Assert.Equal(2, results.Count);
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+        Assert.Equal("http://example.org/David", results[0]["this"].ToString());
+    }
+}


### PR DESCRIPTION
Fixes #856

Fixes an issue where the FILTER expression was exposing the wrong list of bound variables resulting in it being incorrectly ordered during query processing.