### PR TITLE
fix: handling of star and plus operators in SPARQL query

### DIFF
--- a/Libraries/dotNetRdf.Query.Pull/EvaluationBuilder.cs
+++ b/Libraries/dotNetRdf.Query.Pull/EvaluationBuilder.cs
@@ -314,8 +314,8 @@ internal class EvaluationBuilder
             AlternativePath altPath => new AsyncPathUnionEvaluation(Build(altPath.LhsPath, pathStart, pathEnd, context),
                 Build(altPath.RhsPath, pathStart, pathEnd, context)),
             ZeroOrOne zeroOrOne => new AsyncRepeatablePathEvaluation(0, 1, Build(zeroOrOne.Path, pathStart, pathEnd, context)),
-            ZeroOrMore zeroOrMore => new AsyncRepeatablePathEvaluation(0, -1, Build(zeroOrMore.Path, pathStart, pathEnd, context)),
-            OneOrMore oneOrMore => new AsyncRepeatablePathEvaluation(1, -1, Build(oneOrMore.Path, pathStart, pathEnd, context)),
+            ZeroOrMore zeroOrMore => new AsyncRepeatablePathEvaluation(0, -1, Build(zeroOrMore.Path, pathStart, new VariablePattern(context.AutoVarFactory.NextId()), context)),
+            OneOrMore oneOrMore => new AsyncRepeatablePathEvaluation(1, -1, Build(oneOrMore.Path, pathStart, new VariablePattern(context.AutoVarFactory.NextId()), context)),
             NegatedSet negatedSet => new AsyncNegatedSetPathEvaluation(negatedSet, pathEnd),
             _ => throw new RdfQueryException($"Unsupported query algebra {path} ({path.GetType()})")
         };

--- a/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
+++ b/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
@@ -194,7 +194,7 @@ public class ProcessorTests
                 PREFIX ex: <http://example.org/>
 
                 SELECT ?n WHERE {
-                    ?n ex:p+* ex:n4 .
+                    ?n ex:p+ ex:n4 .
                 }
             """);
             var processor = new PullQueryProcessor(store, options => { options.UnionDefaultGraph = true; });

--- a/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
+++ b/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
@@ -31,6 +31,16 @@ public class ProcessorTests
         return store;
     }
 
+    private static TripleStore MakeTestTripleStoreFromTurtle(string turtle)
+    {
+        var turtleStore = new TripleStore();
+        var turtleParser = new TurtleParser();
+        var graph = new Graph();
+        turtleParser.Load(graph, new StringReader(turtle));
+        turtleStore.Add(graph);
+        return turtleStore;
+    }
+
     [Fact]
     public void CanQueryUnionDefaultGraph()
     {
@@ -146,4 +156,56 @@ public class ProcessorTests
         Assert.Equal(1, graph.Triples.Count);
     }
 
+    [Fact]
+    public void SelectWithWildcardOperatorSimple()
+    {
+        var sparqlParser = new SparqlQueryParser();
+        TripleStore store = MakeTestTripleStoreFromTurtle("""
+                @prefix ex: <http://example.org/> .
+
+                ex:n1 ex:p1 ex:n2 .
+                ex:n2 ex:p1 ex:n3 .
+                ex:n3 ex:p1 ex:n4 .
+
+                """);
+
+        {
+            SparqlQuery? query = sparqlParser.ParseFromString("""
+                PREFIX ex: <http://example.org/>
+
+                SELECT ?n WHERE {
+                    ?n ex:p1* ex:n4 .
+                }
+            """);
+            var processor = new PullQueryProcessor(store, options => { options.UnionDefaultGraph = true; });
+            var results = processor.ProcessQuery(query);
+            SparqlResultSet resultSet = Assert.IsType<SparqlResultSet>(results);
+
+            Assert.Equal(4, resultSet.Count);
+            var eqValues = resultSet.Select(r => r["n"].ToString()).ToHashSet();
+            Assert.Contains("http://example.org/n1", eqValues);
+            Assert.Contains("http://example.org/n2", eqValues);
+            Assert.Contains("http://example.org/n3", eqValues);
+            Assert.Contains("http://example.org/n4", eqValues);
+        }
+
+        {
+            SparqlQuery? query = sparqlParser.ParseFromString("""
+                PREFIX ex: <http://example.org/>
+
+                SELECT ?n WHERE {
+                    ?n ex:p+* ex:n4 .
+                }
+            """);
+            var processor = new PullQueryProcessor(store, options => { options.UnionDefaultGraph = true; });
+            var results = processor.ProcessQuery(query);
+            SparqlResultSet resultSet = Assert.IsType<SparqlResultSet>(results);
+
+            Assert.Equal(3, resultSet.Count);
+            var eqValues = resultSet.Select(r => r["n"].ToString()).ToHashSet();
+            Assert.Contains("http://example.org/n1", eqValues);
+            Assert.Contains("http://example.org/n2", eqValues);
+            Assert.Contains("http://example.org/n3", eqValues);
+        }
+    }
 }

--- a/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
+++ b/Testing/dotNetRdf.Query.Pull.Tests/ProcessorTests.cs
@@ -194,7 +194,7 @@ public class ProcessorTests
                 PREFIX ex: <http://example.org/>
 
                 SELECT ?n WHERE {
-                    ?n ex:p+ ex:n4 .
+                    ?n ex:p1+ ex:n4 .
                 }
             """);
             var processor = new PullQueryProcessor(store, options => { options.UnionDefaultGraph = true; });


### PR DESCRIPTION
I see that star and plus operators are not working as expected, at least in SELECT queries..

This PR adds a test to demonstrate the problem, I don't have a solution yet.

For this knowledge graph:

```ttl
@prefix ex: <http://example.org/> .
ex:n1 ex:p1 ex:n2 .
ex:n2 ex:p1 ex:n3 .
ex:n3 ex:p1 ex:n4 .
```

And this query:

```sparql
PREFIX ex: <http://example.org/>
SELECT ?n WHERE {
  ?n ex:p1* ex:n4 .
}
```

I expect four results: ex:n1, ex:n2, ex:n3, ex:n4, but it is currently returning 2 results: ex:n3, ex:n4.

When I change the `*` operator to `+`, I expect it to return three results, but it is returning only 1: ex:n3.

I checked with <https://atomgraph.github.io/SPARQL-Playground/> as a reference, that is behaving as I expect.