### PR TITLE
Fix Dispose logic in ThreadSafeGraph. 

### DIFF
--- a/Libraries/dotNetRdf.Core/Core/ThreadSafeGraph.cs
+++ b/Libraries/dotNetRdf.Core/Core/ThreadSafeGraph.cs
@@ -237,7 +237,7 @@ public class ThreadSafeGraph
                 _lockManager.Dispose();
             }
         }
-        base.Dispose();
+        base.Dispose(disposing);
     }
     #endregion
 

--- a/Libraries/dotNetRdf.Core/Query/BaseSparqlView.cs
+++ b/Libraries/dotNetRdf.Core/Query/BaseSparqlView.cs
@@ -284,6 +284,9 @@ public abstract class BaseSparqlView
         }
     }
 
+    /// <summary>
+    /// Disposes of the graph, removing event handlers from the store.
+    /// </summary>
     protected override void Dispose(bool disposing)
     {
         if (disposing)


### PR DESCRIPTION
Fix call to base Dispose method to prevent a stackoverflow.
Add missing documentation to BaseSparqlView.Dispose