### PR TITLE
Remove AngleSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
 		<PackageVersion Include="System.Interactive.Async" Version="7.0.1" />
 		<PackageVersion Include="System.Linq.Async" Version="7.0.1" />
 		<PackageVersion Include="System.Threading.Channels" Version="10.0.7" />
-		<PackageVersion Include="AngleSharp" Version="1.4.0" />
 		<PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
 		<PackageVersion Include="System.Globalization.Extensions" Version="4.3.0" />

--- a/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
@@ -24,7 +24,6 @@
 // </copyright>
 */
 
-using AngleSharp.Text;
 using System;
 using System.Text.RegularExpressions;
 using VDS.RDF.Parsing.Tokens;
@@ -855,7 +854,7 @@ public class TurtleSpecsHelper
         {
             return true;
         }
-        else if (c.IsDigit())
+        else if (char.IsDigit(c))
         {
             return true;
         }

--- a/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
+++ b/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
@@ -45,7 +45,6 @@
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="AngleSharp" />
     <PackageReference Include="System.ComponentModel.TypeConverter" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Globalization.Extensions" />


### PR DESCRIPTION
Resolves #888.

Was looking at #889 but found that there is only a single usage of this dependency:
https://github.com/dotnetrdf/dotnetrdf/blob/d14063ff4802483cd4488796d063df733878cb93/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs#L858

That extension method was implemented in AngleSharp 1.4.0 like [this](https://github.com/AngleSharp/AngleSharp/blob/v1.4.0/src/AngleSharp/Text/CharExtensions.cs#L218):
```cs
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static Boolean IsDigit(this Char c) => c >= 0x30 && c <= 0x39;
```

Using the [built-in method on `char`](https://learn.microsoft.com/en-us/dotnet/api/system.char.isdigit?view=netstandard-2.0) has slightly different semantics: [More than `0-9` are considered digits](https://dotnetfiddle.net/1GITTQ), e.g.
```cs
Console.WriteLine(char.IsDigit('६')); // true
```

So we might choose, instead of this change, to just inline the code above from AngleSharp.
OTOH the same `char.IsDigit` is used elsewhere in the same helper file, so it might be alright.

The method being changed seems to be our implementation of [`PN_CHARS`](https://www.w3.org/TR/turtle/#sec-grammar:~:text=%5B166s%5D-,PN_CHARS,-%3A%3A%3D).