### PR TITLE
Migrate JSON-LD implementation to use System.Text.Json

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,8 @@
 -----
 This is a major version update to the dotNetRDF library. 
 
+BREAKING: The JSON-LD processor, parser and serialization have all been re-implemented using the .NET System.Text.Json library. This has resulted in breaking changes to those parts of the API that previously exposed the underlying Newtonsoft.Json library - in particular the API calls that allow an initial context to be set.
+
 BREAKING: In line with our deprecation policy, all APIS previously flagged as Obsolete with an error have been removed, an APIS flagged as Obsolete with a warning in 3.x will now result in a compile-time error. All of the obsolete APIs suggest their replacement.
 NEW: Introduced `VDS.RDF.Utils.RdfGraphContent` - an `HttpContent` implementation for writing the content of a `Graph` to the body of an HTTP request.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
 		<PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
 		<PackageVersion Include="System.Globalization.Extensions" Version="4.3.0" />
+        <PackageVersion Include="System.Text.Json" Version="10.0.9" />
 		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
 		<PackageVersion Include="System.Runtime" Version="4.3.1" />

--- a/Libraries/dotNetRdf.Core/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/DefaultDocumentLoader.cs
@@ -29,10 +29,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
-using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using VDS.RDF.JsonLd.Syntax;
+using System.Text.Json;
 
 namespace VDS.RDF.JsonLd;
 
@@ -155,7 +155,7 @@ public static class DefaultDocumentLoader
             {
                 ContextUrl = contextLink == null ? null : new Uri(contextLink),
                 DocumentUrl = responseMessage.RequestMessage.RequestUri,
-                Document = JToken.Parse(responseString),
+                Document = JsonDocument.Parse(responseString).RootElement,
             };
             return ret;
         }

--- a/Libraries/dotNetRdf.Core/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/DefaultDocumentLoader.cs
@@ -32,7 +32,7 @@ using System.Text;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using VDS.RDF.JsonLd.Syntax;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace VDS.RDF.JsonLd;
 
@@ -155,7 +155,7 @@ public static class DefaultDocumentLoader
             {
                 ContextUrl = contextLink == null ? null : new Uri(contextLink),
                 DocumentUrl = responseMessage.RequestMessage.RequestUri,
-                Document = JsonDocument.Parse(responseString).RootElement,
+                Document = JsonNode.Parse(responseString),
             };
             return ret;
         }

--- a/Libraries/dotNetRdf.Core/JsonLd/INodeMapGenerator.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/INodeMapGenerator.cs
@@ -24,7 +24,7 @@
 // </copyright>
 */
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Processors;
 
 namespace VDS.RDF.JsonLd;
@@ -40,12 +40,12 @@ public interface INodeMapGenerator
     /// <param name="element">The element to be processed.</param>
     /// <param name="identifierGenerator">The identifier generator instance to use when creating new blank node identifiers. Defaults to a new instance of <see cref="BlankNodeGenerator"/>.</param>
     /// <returns>The generated node map dictionary as a JObject instance.</returns>
-    JObject GenerateNodeMap(JToken element, IBlankNodeGenerator identifierGenerator = null);
+    JsonObject GenerateNodeMap(JsonNode element, IBlankNodeGenerator identifierGenerator = null);
 
     /// <summary>
     /// Creates a new node map object by merging the graph-level node maps contained in the input graph map object.
     /// </summary>
     /// <param name="graphMap">The input graph map to be merged.</param>
     /// <returns>The merged node map as a new object (the original node map is not modified).</returns>
-    JObject GenerateMergedNodeMap(JObject graphMap);
+    JsonObject GenerateMergedNodeMap(JsonObject graphMap);
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdContext.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdContext.cs
@@ -24,9 +24,9 @@
 // </copyright>
 */
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Linq;
 using VDS.RDF.JsonLd.Processors;
 using VDS.RDF.JsonLd.Syntax;
@@ -43,7 +43,7 @@ public class JsonLdContext
     /// </summary>
     private readonly Dictionary<string, JsonLdTermDefinition> _termDefinitions;
 
-    private JObject _inverseContext;
+    private JsonObject _inverseContext;
 
     /// <summary>
     /// Create a new empty context.
@@ -126,7 +126,7 @@ public class JsonLdContext
     /// <summary>
     /// Get the inverse context for this context.
     /// </summary>
-    public JObject InverseContext => _inverseContext ??= CreateInverseContext();
+    public JsonObject InverseContext => _inverseContext ??= CreateInverseContext();
 
     /// <summary>
     /// Remove the base IRI from this context.
@@ -256,7 +256,7 @@ public class JsonLdContext
         // 1 - If the active context has a null inverse context, set inverse context in active context to the result of calling the Inverse Context Creation algorithm using active context.
         // 2 - Initialize inverse context to the value of inverse context in active context.
         // 3 - Initialize container map to the value associated with iri in the inverse context.
-        var containerMap = InverseContext[iri] as JObject;
+        var containerMap = InverseContext[iri] as JsonObject;
 
         // 4 - For each item container in containers:
         foreach (var container in containers)
@@ -265,10 +265,10 @@ public class JsonLdContext
             if (!containerMap.ContainsKey(container)) continue;
 
             // 4.2 - Initialize type/language map to the value associated with the container entry in container map.
-            JToken typeLanguageMap = containerMap[container];
+            JsonNode typeLanguageMap = containerMap[container];
 
             // 4.3 - Initialize value map to the value associated with type/language entry in type/language map.
-            var valueMap = typeLanguageMap[typeLanguage] as JObject;
+            var valueMap = typeLanguageMap[typeLanguage] as JsonObject;
 
             // 4.4 - For each item in preferred values:
             foreach (var item in preferredValues)
@@ -276,17 +276,17 @@ public class JsonLdContext
                 // 4.4.1 - If item is not an entry of value map, then there is no term with a matching type mapping or language mapping, so continue to the next item.
                 if (!valueMap.ContainsKey(item)) continue;
                 // 4.4.2 - Otherwise, a matching term has been found, return the value associated with the item member in value map.
-                return valueMap[item].Value<string>();
+                return valueMap[item].GetValue<string>();
             }
         }
         // 5 - No matching term has been found. Return null.
         return null;
     }
 
-    private JObject CreateInverseContext()
+    private JsonObject CreateInverseContext()
     {
         // 1. Initialize result to an empty map.
-        var result = new JObject();
+        var result = new JsonObject();
 
         // 2. Initialize default language to @none. If the active context has a default language, set default language to the default language from the active context normalized to lower case.
         var defaultLanguage = "@none";
@@ -312,39 +312,41 @@ public class JsonLdContext
             var iri = termDefinition.IriMapping;
 
             // 3.4 - If var is not an entry of result, add an entry where the key is var and the value is an empty map to result.
-            if (result.Property(iri) == null)
+            if (!result.ContainsKey(iri))
             {
-                result.Add(iri, new JObject());
+                result.Add(iri, new JsonObject());
             }
 
             // 3.5 - Reference the value associated with the iri member in result using the variable container map.
-            var containerMap = result[iri] as JObject;
+            var containerMap = result[iri] as JsonObject;
 
             // 3.6 - If container map has no container entry, create one and set its value to a new map with three entries.
             // The first entry is @language and its value is a new empty map, the second entry is @type and its value is a new empty map,
             // and the third entry is @any and its value is a new map with the entry @none set to the term being processed.
-            if (containerMap.Property(container) == null)
+            if (!containerMap.ContainsKey(container))
             {
-                containerMap.Add(container, new JObject(
-                    new JProperty("@language", new JObject()),
-                    new JProperty("@type", new JObject()),
-                    new JProperty("@any", new JObject(new JProperty("@none", term)))));
+                containerMap.Add(container, new JsonObject
+                {
+                    { "@language", new JsonObject() },
+                    { "@type", new JsonObject() },
+                    { "@any", new JsonObject{["@none"] = term} },
+                });
             }
 
             // 3.7 - Reference the value associated with the container member in container map using the variable type/language map.
-            var typeLanguageMap = containerMap[container] as JObject;
+            var typeLanguageMap = containerMap[container] as JsonObject;
 
             // 3.8 - Reference the value associated with the @type member in type/language map using the variable type map.
-            var typeMap = typeLanguageMap["@type"] as JObject;
+            var typeMap = typeLanguageMap["@type"] as JsonObject;
 
             // 3.9 - Reference the value associated with the @language entry in type/language map using the variable language map.
-            var languageMap = typeLanguageMap["@language"] as JObject;
+            var languageMap = typeLanguageMap["@language"] as JsonObject;
 
             // 3.10 - If the term definition indicates that the term represents a reverse property:
             if (termDefinition.Reverse)
             {
                 // 3.10.1 - If type map does not have an @reverse entry, create one and set its value to the term being processed.
-                if (typeMap.Property("@reverse") == null)
+                if (!typeMap.ContainsKey("@reverse"))
                 {
                     typeMap.Add("@reverse", term);
                 }
@@ -355,19 +357,19 @@ public class JsonLdContext
                 // 3.11.1 - If language map does not have an @any entry, create one and set its value to the term being processed.
                 if (!languageMap.ContainsKey("@any"))
                 {
-                    languageMap.Add(new JProperty("@any", term));
+                    languageMap.Add("@any", term);
                 }
                 // 3.11.2 - If type map does not have an @any entry, create one and set its value to the term being processed.
                 if (!typeMap.ContainsKey("@any"))
                 {
-                    typeMap.Add(new JProperty("@any", term));
+                    typeMap.Add("@any", term);
                 }
             }
             // 3.12 - Otherwise, if term definition has a type mapping:
             else if (termDefinition.TypeMapping != null)
             {
                 // 3.12.1 - If type map does not have an entry corresponding to the type mapping in term definition, create one and set its value to the term being processed.
-                if (typeMap.Property(termDefinition.TypeMapping) == null)
+                if (!typeMap.ContainsKey(termDefinition.TypeMapping))
                 {
                     typeMap.Add(termDefinition.TypeMapping, term);
                 }
@@ -397,7 +399,7 @@ public class JsonLdContext
 
                 if (!languageMap.ContainsKey(langDir))
                 {
-                    languageMap.Add(new JProperty(langDir, term));
+                    languageMap.Add(langDir, term);
                 }
             }
             // 3.14 - Otherwise, if term definition has a language mapping (might be null):
@@ -406,7 +408,7 @@ public class JsonLdContext
                 // 3.14.1 - If the language mapping equals null, set language to @null; otherwise set it to the language code in language mapping,  normalized to lower case.
                 var language = termDefinition.LanguageMapping?.ToLowerInvariant() ?? "@null";
                 // 3.14.2 - If language map does not have a language member, create one and set its value to the term being processed.
-                if (languageMap.Property(language) == null)
+                if (!languageMap.ContainsKey(language))
                 {
                     languageMap.Add(language, term);
                 }
@@ -420,7 +422,7 @@ public class JsonLdContext
                     : "_" + JsonLdUtils.SerializeLanguageDirection(termDefinition.DirectionMapping.Value);
                 if (!languageMap.ContainsKey(direction))
                 {
-                    languageMap.Add(new JProperty(direction, term));
+                    languageMap.Add(direction, term);
                 }
             }
             // 3.16 - Otherwise, if active context has a default base direction: 
@@ -432,17 +434,17 @@ public class JsonLdContext
                 // 3.16.2 - If language map does not have a lang dir entry, create one and set its value to the term being processed.
                 if (!languageMap.ContainsKey(langDir))
                 {
-                    languageMap.Add(new JProperty(langDir, term));
+                    languageMap.Add(langDir, term);
                 }
                 // 3.16.3 - If language map does not have an @none entry, create one and set its value to the term being processed.
                 if (!languageMap.ContainsKey("@none"))
                 {
-                    languageMap.Add(new JProperty("@none", term));
+                    languageMap.Add("@none", term);
                 }
                 // 3.16.4 - If type map does not have an @none entry, create one and set its value to the term being processed.
                 if (!typeMap.ContainsKey("@none"))
                 {
-                    typeMap.Add(new JProperty("@none", term));
+                    typeMap.Add("@none", term);
                 }
             }
             // 3.17 - Otherwise
@@ -451,19 +453,19 @@ public class JsonLdContext
                 // 3.17.1 - If language map does not have a default language entry (after being normalized to lower case), create one and set its value to the term being processed.
                 if (!languageMap.ContainsKey(defaultLanguage.ToLowerInvariant()))
                 {
-                    languageMap.Add(new JProperty(defaultLanguage.ToLowerInvariant(), term));
+                    languageMap.Add(defaultLanguage.ToLowerInvariant(), term);
                 }
 
                 // 3.17.2 - If language map does not have an @none member, create one and set its value to the term being processed.
                 if (!languageMap.ContainsKey("@none"))
                 {
-                    languageMap.Add(new JProperty("@none", term));
+                    languageMap.Add("@none", term);
                 }
 
                 // 3.17.3 - If type map does not have an @none member, create one and set its value to the term being processed.
                 if (!typeMap.ContainsKey("@none"))
                 {
-                    typeMap.Add(new JProperty("@none", term));
+                    typeMap.Add("@none", term);
                 }
             }
         }

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
@@ -24,10 +24,11 @@
 // </copyright>
 */
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Processors;
 using VDS.RDF.JsonLd.Syntax;
 using VDS.RDF.Parsing;
@@ -76,11 +77,11 @@ public class JsonLdProcessor
     /// <summary>
     /// Run the Compaction algorithm.
     /// </summary>
-    /// <param name="input">The JSON-LD data to be compacted. Expected to be a JObject or JArray of JObject or a JString whose value is the IRI reference to a JSON-LD document to be retrieved.</param>
-    /// <param name="context">The context to use for the compaction process. May be a JObject, JArray of JObject, JString or JArray of JString. String values are treated as IRI references to context documents to be retrieved.</param>
+    /// <param name="input">The JSON-LD data to be compacted. Expected to be a JsonObject or JsonArray of JsonObject or a JString whose value is the IRI reference to a JSON-LD document to be retrieved.</param>
+    /// <param name="context">The context to use for the compaction process. May be a JsonObject, JsonArray of JsonObject, JString or JsonArray of JString. String values are treated as IRI references to context documents to be retrieved.</param>
     /// <param name="options">Additional processor options.</param>
     /// <returns></returns>
-    public static JObject Compact(JToken input, JToken context, JsonLdProcessorOptions options)
+    public static JsonObject Compact(JsonNode input, JsonNode context, JsonLdProcessorOptions options)
     {
         var processor = new JsonLdProcessor(options);
         return processor.Compact(input, context);
@@ -89,18 +90,18 @@ public class JsonLdProcessor
     /// <summary>
     /// Run the Compaction algorithm.
     /// </summary>
-    /// <param name="input">The JSON-LD data to be compacted. Expected to be a JObject or JArray of JObject or a JString whose value is the IRI reference to a JSON-LD document to be retrieved.</param>
-    /// <param name="context">The context to use for the compaction process. May be a JObject, JArray of JObject, JString or JArray of JString. String values are treated as IRI references to context documents to be retrieved.</param>
+    /// <param name="input">The JSON-LD data to be compacted. Expected to be a JsonObject or JsonArray of JsonObject or a JString whose value is the IRI reference to a JSON-LD document to be retrieved.</param>
+    /// <param name="context">The context to use for the compaction process. May be a JsonObject, JsonArray of JsonObject, JString or JsonArray of JString. String values are treated as IRI references to context documents to be retrieved.</param>
     /// <returns></returns>
-    public JObject Compact(JToken input, JToken context) 
+    public JsonObject Compact(JsonNode input, JsonNode context) 
     { 
         // Set expanded input to the result of using the expand method using input and options.
-        JArray expandedInput;
+        JsonArray expandedInput;
         Uri remoteDocumentUrl = null;
         Uri contextBase = null;
-        if (input.Type == JTokenType.String)
+        if (input.GetValueKind() == JsonValueKind.String)
         {
-            RemoteDocument remoteDocument = LoadJson(new Uri(input.Value<string>()),
+            RemoteDocument remoteDocument = LoadJson(new Uri(input.GetValue<string>()),
                 new JsonLdLoaderOptions {ExtractAllScripts = _options.ExtractAllScripts}, _options);
             expandedInput = Expand(remoteDocument, remoteDocument.DocumentUrl,
                 new JsonLdLoaderOptions {ExtractAllScripts = false}, _options);
@@ -116,7 +117,7 @@ public class JsonLdProcessor
             contextBase = _options.Base;
         }
 
-        if (context is JObject contextObject && contextObject.ContainsKey("@context"))
+        if (context is JsonObject contextObject && contextObject.ContainsKey("@context"))
         {
             context = contextObject["@context"];
         }
@@ -130,24 +131,25 @@ public class JsonLdProcessor
         }
 
         var compactor = new CompactProcessor(_options, contextProcessor, Warnings);
-        JToken compactedOutput = compactor.CompactElement(activeContext, null, expandedInput, _options.CompactArrays,
+        JsonNode compactedOutput = compactor.CompactElement(activeContext, null, expandedInput, _options.CompactArrays,
             _options.Ordered);
         if (JsonLdUtils.IsEmptyArray(compactedOutput))
         {
-            compactedOutput = new JObject();
+            compactedOutput = new JsonObject();
         }
-        else if (compactedOutput is JArray)
+        else if (compactedOutput is JsonArray)
         {
-            compactedOutput = new JObject(new JProperty(compactor.CompactIri(activeContext, "@graph", vocab: true),
-                compactedOutput));
+            compactedOutput = new JsonObject{
+                [compactor.CompactIri(activeContext, "@graph", vocab: true)] = compactedOutput,
+            };
         }
 
         if (context != null && !JsonLdUtils.IsEmptyObject(context))
         {
-            (compactedOutput as JObject)["@context"] = context;
+            (compactedOutput as JsonObject)["@context"] = context;
         }
 
-        return compactedOutput as JObject;
+        return compactedOutput as JsonObject;
     }
 
 
@@ -158,7 +160,7 @@ public class JsonLdProcessor
     /// <param name="options">Options to apply during the expansion processing.</param>
     /// <param name="warnings"></param>
     /// <returns>The expanded JSON-LD context.</returns>
-    public static JArray Expand(Uri contextUrl, JsonLdProcessorOptions options = null, IList<JsonLdProcessorWarning> warnings = null)
+    public static JsonArray Expand(Uri contextUrl, JsonLdProcessorOptions options = null, IList<JsonLdProcessorWarning> warnings = null)
     {
         RemoteDocument parsedJson = LoadJson(contextUrl, null, options);
         var processor = new JsonLdProcessor(options);
@@ -180,17 +182,17 @@ public class JsonLdProcessor
     /// <param name="options">Options to apply during the expansion processing.</param>
     /// <param name="warnings"></param>
     /// <returns>The expanded JSON-LD context.</returns>
-    public static JArray Expand(JToken input, JsonLdProcessorOptions options = null, IList<JsonLdProcessorWarning> warnings = null)
+    public static JsonArray Expand(JsonNode input, JsonLdProcessorOptions options = null, IList<JsonLdProcessorWarning> warnings = null)
     {
         var remoteDoc = new RemoteDocument
         {
-            Document = input is JValue v && v.Type == JTokenType.String ? v.Value<string>() : input,
+            Document = input is JsonValue v && v.GetValueKind() == JsonValueKind.String ? v.GetValue<string>() : input,
         };
         var processor = new JsonLdProcessor(options);
-        var expanded = processor.Expand(remoteDoc, null, null, options);
+        JsonArray expanded = processor.Expand(remoteDoc, null, null, options);
         if (processor.Warnings.Any() && warnings is not null)
         {
-            foreach (var warning in processor.Warnings)
+            foreach (JsonLdProcessorWarning warning in processor.Warnings)
             {
                 warnings.Add(warning);
             }
@@ -198,7 +200,7 @@ public class JsonLdProcessor
         return expanded;
     }
 
-    private JArray Expand(RemoteDocument doc, Uri documentLocation,
+    private JsonArray Expand(RemoteDocument doc, Uri documentLocation,
         JsonLdLoaderOptions loaderOptions = null,
         JsonLdProcessorOptions options = null)
     {
@@ -206,7 +208,7 @@ public class JsonLdProcessor
         {
             try
             {
-                doc.Document = JToken.Parse(docContent);
+                doc.Document = JsonNode.Parse(docContent);
             }
             catch (Exception ex)
             {
@@ -221,12 +223,16 @@ public class JsonLdProcessor
         var contextProcessor = new ContextProcessor(options, Warnings);
         if (options?.ExpandContext != null)
         {
-            if (options.ExpandContext is JObject expandObject)
+            if (options.ExpandContext is JsonObject expandObject)
             {
-                JProperty contextProperty = expandObject.Property("@context");
-                activeContext = contextProcessor.ProcessContext(activeContext,
-                    contextProperty != null ? contextProperty.Value : expandObject,
-                    activeContext.OriginalBase);
+                if (expandObject.TryGetPropertyValue("@context", out JsonNode contextValue))
+                {
+                    activeContext = contextProcessor.ProcessContext(activeContext, expandObject["@context"], activeContext.OriginalBase);
+                } 
+                else
+                {
+                    activeContext = contextProcessor.ProcessContext(activeContext, expandObject, activeContext.OriginalBase);
+                }
             }
             else
             {
@@ -240,26 +246,26 @@ public class JsonLdProcessor
             RemoteDocument contextDoc = LoadJson(doc.ContextUrl, loaderOptions, options);
             if (contextDoc.Document is string contextJson)
             {
-                contextDoc.Document = JToken.Parse(contextJson);
+                contextDoc.Document = JsonNode.Parse(contextJson);
             }
 
-            activeContext = contextProcessor.ProcessContext(activeContext, contextDoc.Document as JToken, doc.ContextUrl);
+            activeContext = contextProcessor.ProcessContext(activeContext, contextDoc.Document as JsonNode, doc.ContextUrl);
         }
         
         var expander = new ExpandProcessor(options, contextProcessor, Warnings);
-        JToken expandedOutput = expander.ExpandElement(activeContext, null, doc.Document as JToken,
+        JsonNode expandedOutput = expander.ExpandElement(activeContext, null, doc.Document as JsonNode,
             doc.DocumentUrl ?? options?.Base,
             options?.FrameExpansion ?? false,
             options?.Ordered ?? false);
-        if (expandedOutput is JObject expandedObject)
+        if (expandedOutput is JsonObject expandedObject)
         {
             if (expandedObject.ContainsKey("@graph") && expandedObject.Count == 1)
                 expandedOutput = expandedObject["@graph"];
         }
 
-        if (expandedOutput == null) expandedOutput = new JArray();
+        if (expandedOutput == null) expandedOutput = new JsonArray();
         expandedOutput = JsonLdUtils.EnsureArray(expandedOutput);
-        return expandedOutput as JArray;
+        return expandedOutput as JsonArray;
     }
 
     /// <summary>
@@ -269,13 +275,13 @@ public class JsonLdProcessor
     /// <param name="frame">The framing specification document.</param>
     /// <param name="options">Processor options.</param>
     /// <returns></returns>
-    public static JObject Frame(JToken input, JToken frame, JsonLdProcessorOptions options)
+    public static JsonObject Frame(JsonNode input, JsonNode frame, JsonLdProcessorOptions options)
     {
         var processor = new JsonLdProcessor(options);
         return processor.Frame(input, frame);
     }
 
-    private JObject Frame(JToken input, JToken frame) 
+    private JsonObject Frame(JsonNode input, JsonNode frame) 
     {
         // JSON-LD 1.0 compatible framing requires ordered processing
         if (_options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
@@ -287,41 +293,41 @@ public class JsonLdProcessor
         Uri remoteDocumentUri = null, remoteFrameUri = null;
         RemoteDocument remoteDocument = null, remoteFrame = null;
         var loaderOptions = new JsonLdLoaderOptions {ExtractAllScripts = _options.ExtractAllScripts};
-        if (input.Type == JTokenType.String)
+        if (input.GetValueKind() == JsonValueKind.String)
         {
-            remoteDocumentUri = new Uri(input.Value<string>());
+            remoteDocumentUri = new Uri(input.GetValue<string>());
             remoteDocument = LoadJson(remoteDocumentUri, loaderOptions, _options);
         }
 
         JsonLdProcessorOptions expandOptions = _options.Clone();
         expandOptions.Ordered = false;
 
-        JArray expandedInput = remoteDocument != null
+        JsonArray expandedInput = remoteDocument != null
             ? Expand(remoteDocument, remoteDocumentUri, loaderOptions, expandOptions)
             : Expand(input, expandOptions);
 
-        if (frame.Type == JTokenType.String)
+        if (frame.GetValueKind() == JsonValueKind.String)
         {
-            remoteFrameUri = new Uri(frame.Value<string>());
+            remoteFrameUri = new Uri(frame.GetValue<string>());
             remoteFrame = LoadJson(remoteFrameUri, loaderOptions, _options);
         }
 
         JsonLdProcessorOptions frameExpansionOptions = _options.Clone();
         frameExpansionOptions.Ordered = false;
         frameExpansionOptions.FrameExpansion = true;
-        JArray expandedFrame = remoteFrame != null
+        JsonArray expandedFrame = remoteFrame != null
             ? Expand(remoteFrame, remoteFrameUri, loaderOptions, frameExpansionOptions)
             : Expand(frame, frameExpansionOptions);
 
-        JToken context = new JObject();
+        JsonNode context = new JsonObject();
         var haveContext = false;
-        if (remoteFrame != null && remoteFrame.Document is JObject remoteFrameObject &&
+        if (remoteFrame != null && remoteFrame.Document is JsonObject remoteFrameObject &&
             remoteFrameObject.ContainsKey("@context"))
         {
-            context = remoteFrameObject["@context"] as JObject;
+            context = remoteFrameObject["@context"] as JsonObject;
             haveContext = true;
         }
-        else if (frame is JObject fo && fo.ContainsKey("@context"))
+        else if (frame is JsonObject fo && fo.ContainsKey("@context"))
         {
             context = fo["@context"];
             haveContext = true;
@@ -344,30 +350,30 @@ public class JsonLdProcessor
         JsonLdContext toReverse = contextProcessor.ProcessContext(new JsonLdContext(), context, reverseContextBase);
 
         // 12 - Initialize inverse context to the result of performing the Inverse Context Creation algorithm.
-        JObject inverseContext = toReverse.InverseContext;
+        JsonObject inverseContext = toReverse.InverseContext;
 
         // 13 - If frame has a top-level property which expands to @graph set the frameDefault option to options with the value true.
-        if (frame is JObject frameObject && frameObject.Properties()
-            .Any(p => contextProcessor.ExpandIri(activeContext, p.Name, true).Equals("@graph")))
+        if (frame is JsonObject frameObject && 
+            frameObject.Any(p => contextProcessor.ExpandIri(activeContext, p.Key, true).Equals("@graph")))
         {
             _options.FrameDefault = true;
         }
 
         // 14 - Initialize a new framing state (state) to an empty map. 
-        JObject graphMap = nodeMapGenerator.GenerateNodeMap(expandedInput);
+        JsonObject graphMap = nodeMapGenerator.GenerateNodeMap(expandedInput);
         if (!_options.FrameDefault)
         {
             // Add an @merged entry to graphMap
-            JObject mergedNodeMap = nodeMapGenerator.GenerateMergedNodeMap(graphMap);
+            JsonObject mergedNodeMap = nodeMapGenerator.GenerateMergedNodeMap(graphMap);
             graphMap["@merged"] = mergedNodeMap;
         }
 
         var state = new FramingState(_options, graphMap, _options.FrameDefault ? "@default" : "@merged");
 
         // 15 - Initialize results as an empty array.
-        var results = new JArray();
+        var results = new JsonArray();
         // 16 - Invoke the Framing algorithm, passing state, the keys from subject map in state for subjects, expanded frame, results for parent, and null as active property.
-        FramingProcessor.ProcessFrame(state, state.Subjects.Properties().Select(p => p.Name).ToList(), expandedFrame, results, null,
+        FramingProcessor.ProcessFrame(state, state.Subjects.Select(p => p.Key).ToList(), expandedFrame, results, null,
             processingMode: _options.ProcessingMode ?? JsonLdProcessingMode.JsonLd11);
 
         // 17 - If the processing mode is not json-ld-1.0, remove the @id entry of each node object in results where the entry value is a blank node identifier which appears only once in any property value within results.
@@ -381,26 +387,26 @@ public class JsonLdProcessor
 
         // 19 - Set compacted results to the result of using the compact method using active context, inverse context, null for active property, results as element,, and the compactArrays and ordered flags from options.
         var compactor = new CompactProcessor(_options, contextProcessor, Warnings);
-        JToken compactedResults =
+        JsonNode compactedResults =
             compactor.CompactElement(activeContext, null, results, _options.CompactArrays, _options.Ordered);
         var graphProperty = compactor.CompactIri(activeContext, "@graph", vocab: true);
         // 19.1 - If compacted results is an empty array, replace it with a new map.
         if (JsonLdUtils.IsEmptyArray(compactedResults))
         {
-            compactedResults = new JObject();
+            compactedResults = new JsonObject();
         }
         else if (JsonLdUtils.IsArray(compactedResults))
         {
             // 19.2 - Otherwise, if compacted results is an array, replace it with a new map with a single entry whose key is the result of IRI compacting @graph and value is compacted results.
-            compactedResults = new JObject(new JProperty(graphProperty, compactedResults));
+            compactedResults = new JsonObject{[graphProperty] = compactedResults};
         }
 
-        var compactedResultsObject = compactedResults as JObject;
+        var compactedResultsObject = compactedResults as JsonObject;
         // 19.3 - Add an @context entry to compacted results and set its value to the provided context.
         if (haveContext
         ) // Only if it was explicitly provided, not if context was created as part of this algorithm.
         {
-            compactedResultsObject.Add("@context", context);
+            compactedResultsObject.Add("@context", context.DeepClone());
         }
 
         // 20 - Recursively, replace all @null values in compacted results with null. If, after replacement, an array contains only the value null remove that value, leaving an empty array.
@@ -410,31 +416,31 @@ public class JsonLdProcessor
         // modify compacted results to place the non @context entry of compacted results into a map contained within the array value of @graph.
         // If omitGraph is true, a top-level @graph entry is used only to contain multiple node objects.
         if (!_options.OmitGraph && (!compactedResultsObject.ContainsKey(graphProperty) ||
-                                   compactedResultsObject[graphProperty].Type != JTokenType.Array))
+                                   compactedResultsObject[graphProperty].GetValueKind() != JsonValueKind.Array))
         {
-            var g = new JObject();
-            foreach (JProperty property in compactedResultsObject.Properties().ToList())
+            var g = new JsonObject();
+            foreach (KeyValuePair<string, JsonNode> property in compactedResultsObject.ToList())
             {
-                if (!property.Name.Equals("@context") && !property.Name.Equals(graphProperty))
+                if (!property.Key.Equals("@context") && !property.Key.Equals(graphProperty))
                 {
                     g.Add(property);
-                    compactedResultsObject.Remove(property.Name);
+                    compactedResultsObject.Remove(property.Key);
                 }
             }
 
             if (compactedResultsObject.ContainsKey(graphProperty))
             {
-                compactedResultsObject[graphProperty] = new JArray(g, compactedResultsObject[graphProperty]);
+                compactedResultsObject[graphProperty] = new JsonArray(g, compactedResultsObject[graphProperty].DeepClone());
             }
             else
             {
                 if (g.Count > 0)
                 {
-                    compactedResultsObject[graphProperty] = new JArray(g);
+                    compactedResultsObject[graphProperty] = new JsonArray(g);
                 }
                 else
                 {
-                    compactedResultsObject[graphProperty] = new JArray();
+                    compactedResultsObject[graphProperty] = new JsonArray();
                 }
             }
         }
@@ -449,12 +455,12 @@ public class JsonLdProcessor
     /// <param name="context"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static JToken Flatten(JToken input, JToken context, JsonLdProcessorOptions options)
+    public static JsonNode Flatten(JsonNode input, JsonNode context, JsonLdProcessorOptions options)
     {
         // Set expanded input to the result of using the expand method using input and options.
-        JArray expandedInput = Expand(input, options);
+        JsonArray expandedInput = Expand(input, options);
         var flattenProcessor = new FlattenProcessor();
-        JToken flattenedOutput = flattenProcessor.FlattenElement(expandedInput, options.Ordered);
+        JsonNode flattenedOutput = flattenProcessor.FlattenElement(expandedInput, options.Ordered);
         if (context != null)
         {
             flattenedOutput = Compact(flattenedOutput, context, options);
@@ -469,7 +475,7 @@ public class JsonLdProcessor
     /// <param name="input"></param>
     /// <param name="context"></param>
     /// <returns></returns>
-    public JToken Flatten(JToken input, JToken context)
+    public JsonNode Flatten(JsonNode input, JsonNode context)
     {
         return Flatten(input, context, _options);
     }
@@ -480,118 +486,121 @@ public class JsonLdProcessor
     /// <param name="input"></param>
     /// <returns></returns>
     /// <remarks>Caution: Make sure to use DateParseHandling.None when deserializing the JSON document.</remarks>
-    public static string Canonicalize(JArray input)
+    public static string Canonicalize(JsonArray input)
     {
         var store = new TripleStore();
-        new JsonLdParser().Load(store, input.DeepClone() as JArray);
+        new JsonLdParser().Load(store, input.DeepClone() as JsonArray);
 
         return new RdfCanonicalizer().Canonicalize(store).SerializedNQuads;
     }
 
-    private static void ReplaceNulls(JToken token)
+    private static void ReplaceNulls(JsonNode token)
     {
         switch (token)
         {
-            case JObject o:
-                foreach (JProperty property in o.Properties())
+            case JsonObject o:
+                foreach (KeyValuePair<string, JsonNode> property in o.ToList())
                 {
-                    switch (property.Value.Type)
+                    switch (property.Value.GetValueKind())
                     {
-                        case JTokenType.String:
-                            if ("@null".Equals(property.Value.Value<string>()))
+                        case JsonValueKind.String:
+                            if ("@null".Equals(property.Value.GetValue<string>()))
                             {
-                                property.Value = null;
+                                o[property.Key] = null;
                             }
 
                             break;
-                        case JTokenType.Array:
-                        case JTokenType.Object:
+                        case JsonValueKind.Array:
+                        case JsonValueKind.Object:
                             ReplaceNulls(property.Value);
                             break;
                     }
                 }
 
                 break;
-            case JArray a:
+            case JsonArray a:
                 for (var ix = 0; ix < a.Count; ix++)
                 {
-                    JToken item = a[ix];
-                    switch (item.Type)
+                    JsonNode item = a[ix];
+                    switch (item.GetValueKind())
                     {
-                        case JTokenType.String:
-                            if ("@null".Equals(item.Value<string>()))
+                        case JsonValueKind.String:
+                            if ("@null".Equals(item.GetValue<string>()))
                             {
                                 a[ix] = null;
                             }
 
                             break;
-                        case JTokenType.Object:
-                        case JTokenType.Array:
+                        case JsonValueKind.Object:
+                        case JsonValueKind.Array:
                             ReplaceNulls(item);
                             break;
                     }
                 }
 
-                if (a.All(x => x.Type == JTokenType.Null))
+                if (a.All(x => x.GetValueKind() == JsonValueKind.Null))
                 {
-                    a.RemoveAll();
+                    a.Clear();
                 }
 
                 break;
         }
     }
 
-    private static void ReplacePreservedValues(JToken token, JsonLdContext context, bool compactArrays)
+    private static void ReplacePreservedValues(JsonNode token, JsonLdContext context, bool compactArrays)
     {
-        switch (token.Type)
+        switch (token.GetValueKind())
         {
-            case JTokenType.Object:
-                var o = token as JObject;
+            case JsonValueKind.Object:
+                var o = token as JsonObject;
                 if (o["@preserve"] != null)
                 {
-                    JContainer parent = o.Parent;
-                    JToken preserveValue = o["@preserve"];
-                    if (preserveValue.Type == JTokenType.String && preserveValue.Value<string>().Equals("@null"))
+                    JsonNode parent = o.Parent;
+                    JsonNode preserveValue = o["@preserve"];
+                    if (preserveValue.GetValueKind() == JsonValueKind.String && preserveValue.GetValue<string>().Equals("@null"))
                     {
-                        if (parent is JArray)
+                        if (parent is JsonArray)
                         {
-                            o.Remove();
+                            parent.AsArray().Remove(o);
                         }
                         else
                         {
-                            o.Replace(JValue.CreateNull());
+                            var parentObject = o.Parent as JsonObject;
+                            var parentKey = parentObject.FirstOrDefault(p => p.Value == o).Key;
+                            parentObject[parentKey] = null;
                         }
                     }
                     else
                     {
-                        o.Replace(preserveValue);
+                        JsonLdUtils.ReplaceInParent(o, preserveValue);
                     }
                 }
 
-                foreach (KeyValuePair<string, JToken> p in o)
+                foreach (KeyValuePair<string, JsonNode> p in o)
                 {
                     ReplacePreservedValues(p.Value, context, compactArrays);
                 }
 
                 break;
-            case JTokenType.Array:
-                var a = token as JArray;
-                foreach (JToken item in a.ToList())
+            case JsonValueKind.Array:
+                var a = token as JsonArray;
+                foreach (JsonNode item in a.ToList())
                 {
                     ReplacePreservedValues(item, context, compactArrays);
                 }
 
                 if (compactArrays && a.Count == 1)
                 {
-                    if (a.Parent is JProperty parentProperty)
+                    if (a.Parent is JsonObject parentObject)
                     {
-                        JsonLdTermDefinition termDefinition = context.GetTerm(parentProperty.Name);
-                        var expandedName = termDefinition?.TypeMapping ?? parentProperty.Name;
+                        KeyValuePair<string, JsonNode> parentProperty = parentObject.FirstOrDefault(p => p.Value == a);
+                        JsonLdTermDefinition termDefinition = context.GetTerm(parentProperty.Key);
+                        var expandedName = termDefinition?.TypeMapping ?? parentProperty.Key;
                         if (expandedName != "@graph" &&
                             expandedName != "@list" &&
                             (termDefinition == null || termDefinition.ContainerMapping == null))
                         {
-                            a.Replace(a[0]);
+                            JsonLdUtils.ReplaceInParent(a, a[0]);
                         }
                     }
                 }
@@ -600,51 +609,46 @@ public class JsonLdProcessor
         }
     }
 
-    private static void PruneBlankNodeIdentifiers(JToken token)
+    private static void PruneBlankNodeIdentifiers(JsonNode token)
     {
         var objectMap = new Dictionary<string, BlankNodeMapEntry>();
-        GenerateBlankNodeMap(objectMap, token, null);
+        GenerateBlankNodeMap(objectMap, token, null, null);
         foreach (KeyValuePair<string, BlankNodeMapEntry> mapEntry in objectMap)
         {
             if (!mapEntry.Value.IsReferenced)
             {
-                PruneBlankNodeIdentifier(mapEntry.Key, mapEntry.Value.IdProperty);
+                PruneBlankNodeIdentifier(mapEntry.Key, mapEntry.Value.Parent as JsonObject, mapEntry.Value.IdProperty);
             }
         }
     }
 
-    private static void PruneBlankNodeIdentifier(string id, JProperty toUpdate)
+    private static void PruneBlankNodeIdentifier(string id, JsonObject parent, string toUpdate)
     {
-        if (toUpdate.Value.Type == JTokenType.String)
+        if (parent[toUpdate].GetValueKind() == JsonValueKind.String)
         {
-            toUpdate.Remove();
+            parent.Remove(toUpdate);
         }
-        else if (toUpdate.Value is JArray valueArray)
+        else if (parent[toUpdate].GetValueKind() == JsonValueKind.Array)
         {
-            foreach (JToken item in valueArray)
-            {
-                if (item.Value<string>().Equals(id))
-                {
-                    item.Remove();
-                    break;
-                }
-            }
+            var valueArray = parent[toUpdate] as JsonArray;
+            valueArray.RemoveAll(item => item.GetValue<string>().Equals(id));
         }
     }
 
     private class BlankNodeMapEntry
     {
         public bool IsReferenced;
-        public JProperty IdProperty;
+        public JsonObject Parent;
+        public string IdProperty;
     }
 
-    private static void GenerateBlankNodeMap(IDictionary<string, BlankNodeMapEntry> objectMap, JToken token,
-        JProperty activeProperty)
+    private static void GenerateBlankNodeMap(IDictionary<string, BlankNodeMapEntry> objectMap, JsonNode token,
+        JsonObject activePropertyParent, string activeProperty)
     {
-        switch (token.Type)
+        switch (token.GetValueKind())
         {
-            case JTokenType.String:
-                var str = token.Value<string>();
+            case JsonValueKind.String:
+                var str = token.GetValue<string>();
                 if (JsonLdUtils.IsBlankNodeIdentifier(str))
                 {
                     if (!objectMap.TryGetValue(str, out BlankNodeMapEntry mapEntry))
@@ -653,8 +657,9 @@ public class JsonLdProcessor
                         objectMap[str] = mapEntry;
                     }
 
-                    if (activeProperty.Name == "@id" && mapEntry.IdProperty == null)
+                    if (activeProperty == "@id" && mapEntry.IdProperty == null)
                     {
+                        mapEntry.Parent = activePropertyParent;
                         mapEntry.IdProperty = activeProperty;
                     }
                     else
@@ -664,18 +669,18 @@ public class JsonLdProcessor
                 }
 
                 break;
-            case JTokenType.Array:
-                foreach (JToken item in (token as JArray))
+            case JsonValueKind.Array:
+                foreach (JsonNode item in (token as JsonArray))
                 {
-                    GenerateBlankNodeMap(objectMap, item, activeProperty);
+                    GenerateBlankNodeMap(objectMap, item, token.Parent as JsonObject, activeProperty);
                 }
 
                 break;
-            case JTokenType.Object:
-                foreach (JProperty p in (token as JObject).Properties())
+            case JsonValueKind.Object:
+                foreach (KeyValuePair<string, JsonNode> p in (token as JsonObject))
                 {
-                    if (p.Name == "@value") continue;
-                    GenerateBlankNodeMap(objectMap, p.Value, p);
+                    if (p.Key == "@value") continue;
+                    GenerateBlankNodeMap(objectMap, p.Value, token as JsonObject, p.Key);
                 }
 
                 break;

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessor.cs
@@ -146,7 +146,7 @@ public class JsonLdProcessor
 
         if (context != null && !JsonLdUtils.IsEmptyObject(context))
         {
-            (compactedOutput as JsonObject)["@context"] = context;
+            (compactedOutput as JsonObject)["@context"] = context.DetachedClone();
         }
 
         return compactedOutput as JsonObject;
@@ -423,8 +423,8 @@ public class JsonLdProcessor
             {
                 if (!property.Key.Equals("@context") && !property.Key.Equals(graphProperty))
                 {
-                    g.Add(property);
                     compactedResultsObject.Remove(property.Key);
+                    g.Add(property);
                 }
             }
 
@@ -501,7 +501,7 @@ public class JsonLdProcessor
             case JsonObject o:
                 foreach (KeyValuePair<string, JsonNode> property in o.ToList())
                 {
-                    switch (property.Value.GetValueKind())
+                    switch (property.Value.SafeValueKind())
                     {
                         case JsonValueKind.String:
                             if ("@null".Equals(property.Value.GetValue<string>()))
@@ -522,7 +522,7 @@ public class JsonLdProcessor
                 for (var ix = 0; ix < a.Count; ix++)
                 {
                     JsonNode item = a[ix];
-                    switch (item.GetValueKind())
+                    switch (item.SafeValueKind())
                     {
                         case JsonValueKind.String:
                             if ("@null".Equals(item.GetValue<string>()))
@@ -538,7 +538,7 @@ public class JsonLdProcessor
                     }
                 }
 
-                if (a.All(x => x.GetValueKind() == JsonValueKind.Null))
+                if (a.All(x => x.SafeValueKind() == JsonValueKind.Null))
                 {
                     a.Clear();
                 }
@@ -549,7 +549,7 @@ public class JsonLdProcessor
 
     private static void ReplacePreservedValues(JsonNode token, JsonLdContext context, bool compactArrays)
     {
-        switch (token.GetValueKind())
+        switch (token.SafeValueKind())
         {
             case JsonValueKind.Object:
                 var o = token as JsonObject;
@@ -631,7 +631,7 @@ public class JsonLdProcessor
         else if (parent[toUpdate].GetValueKind() == JsonValueKind.Array)
         {
             var valueArray = parent[toUpdate] as JsonArray;
-            valueArray.RemoveAll(item => item.GetValue<string>().Equals(id));
+            valueArray.RemoveAll(item => item.SafeValueKind() == JsonValueKind.String && item.GetValue<string>().Equals(id));
         }
     }
 
@@ -645,7 +645,7 @@ public class JsonLdProcessor
     private static void GenerateBlankNodeMap(IDictionary<string, BlankNodeMapEntry> objectMap, JsonNode token,
         JsonObject activePropertyParent, string activeProperty)
     {
-        switch (token.GetValueKind())
+        switch (token.SafeValueKind())
         {
             case JsonValueKind.String:
                 var str = token.GetValue<string>();

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessorOptions.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdProcessorOptions.cs
@@ -24,8 +24,8 @@
 // </copyright>
 */
 
-using Newtonsoft.Json.Linq;
 using System;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd;
@@ -69,7 +69,7 @@ public class JsonLdProcessorOptions
     /// <summary>
     /// A context that is used to initialize the active context when expanding a document.
     /// </summary>
-    public JToken ExpandContext { get; set; }
+    public JsonNode ExpandContext { get; set; }
 
     /// <summary>
     /// Specifies whether HTML document processing should target all of the JSON-LD script elements in the document or not.

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdRemoteContext.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdRemoteContext.cs
@@ -25,7 +25,7 @@
 */
 
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace VDS.RDF.JsonLd;
 
@@ -34,7 +34,7 @@ namespace VDS.RDF.JsonLd;
 /// </summary>
 public class JsonLdRemoteContext
 {
-    internal JsonLdRemoteContext(Uri documentUrl, JToken loadedContext)
+    internal JsonLdRemoteContext(Uri documentUrl, JsonNode loadedContext)
     {
         DocumentUrl = documentUrl;
         Context = loadedContext;
@@ -48,5 +48,5 @@ public class JsonLdRemoteContext
     /// <summary>
     /// Get the context value as a JSON representation.
     /// </summary>
-    public JToken Context { get; }
+    public JsonNode Context { get; }
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdTermDefinition.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdTermDefinition.cs
@@ -26,7 +26,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd;
@@ -108,7 +108,7 @@ public class JsonLdTermDefinition
     /// <summary>
     /// Get or set the context specified for this term definition.
     /// </summary>
-    public JToken LocalContext { get; set; }
+    public JsonNode LocalContext { get; set; }
 
     /// <summary>
     /// Get or set the nest property for this term definition.

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLdTermDefinition.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLdTermDefinition.cs
@@ -111,6 +111,11 @@ public class JsonLdTermDefinition
     public JsonNode LocalContext { get; set; }
 
     /// <summary>
+    /// Boolean flag indicating if this term definition specifies a local context.
+    /// </summary>
+    public bool HasLocalContext { get; set; }
+
+    /// <summary>
     /// Get or set the nest property for this term definition.
     /// </summary>
     public string Nest { get; set; }
@@ -134,6 +139,7 @@ public class JsonLdTermDefinition
             LanguageMapping = LanguageMapping,
             HasLanguageMapping = HasLanguageMapping,
             Nest = Nest,
+            HasLocalContext = HasLocalContext,
             LocalContext = LocalContext?.DeepClone(), // TODO: Check if it correct to just directly clone the local context
         };
         clone.ContainerMapping.UnionWith(ContainerMapping);

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
@@ -28,9 +28,9 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using System.Globalization;
 namespace VDS.RDF.JsonLd;
 
 /// <summary>
@@ -44,43 +44,42 @@ internal class JsonLiteralSerializer
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
-    public string Serialize(JToken token)
+    public string Serialize(JsonNode token)
     {
-        var sb = new StringBuilder();
-        var sw = new StringWriter(sb);
-        using (var writer = new JsonTextWriter(sw))
+        var memoryStream = new MemoryStream();
+        
+        using (var writer = new Utf8JsonWriter(memoryStream))
         {
-            writer.Formatting = Formatting.None;
             Serialize(writer, token);
         }
 
-        return sb.ToString();
+        return Encoding.UTF8.GetString(memoryStream.ToArray());
     }
 
-    private static void Serialize(JsonWriter writer, JToken token)
+    private static void Serialize(Utf8JsonWriter writer, JsonNode token)
     {
-        switch (token.Type)
+        switch (token.GetValueKind())
         {
-            case JTokenType.Object:
+            case JsonValueKind.Object:
                 writer.WriteStartObject();
-                foreach (JProperty property in (token as JObject).Properties().OrderBy(p=>p.Name, StringComparer.Ordinal))
+                foreach (var property in (token as JsonObject).OrderBy(p => p.Key, StringComparer.Ordinal))
                 {
-                    writer.WritePropertyName(property.Name);
+                    writer.WritePropertyName(property.Key);
                     Serialize(writer, property.Value);
                 }
                 writer.WriteEndObject();
                 break;
-            case JTokenType.Array:
+            case JsonValueKind.Array:
                 writer.WriteStartArray();
-                foreach (JToken item in (token as JArray))
+                foreach (JsonNode item in (token as JsonArray))
                 {
                     Serialize(writer, item);
                 }
                 writer.WriteEndArray();
                 break;
-            case JTokenType.Float:
+            case JsonValueKind.Number:
 
-                var doubleValue = token.Value<double>();
+                var doubleValue = token.GetValue<double>();
                 switch (doubleValue)
                 {
                     case double.NaN:
@@ -94,7 +93,7 @@ internal class JsonLiteralSerializer
                         break;
                     default:
                     {
-                        var v = token.ToString(Formatting.None);
+                        var v = token.GetValue<double>().ToString("G", CultureInfo.InvariantCulture);
                         if (v.EndsWith(".0"))
                         {
                             v = v.Substring(0, v.Length - 2);
@@ -105,7 +104,7 @@ internal class JsonLiteralSerializer
                 };
                 break;
             default:
-                writer.WriteRawValue(token.ToString(Formatting.None));
+                writer.WriteRawValue(token.GetValue<string>());
                 break;
         }
     }

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
@@ -48,7 +48,7 @@ internal class JsonLiteralSerializer
     {
         var memoryStream = new MemoryStream();
         
-        using (var writer = new Utf8JsonWriter(memoryStream))
+        using (var writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping }))
         {
             Serialize(writer, token);
         }
@@ -58,6 +58,11 @@ internal class JsonLiteralSerializer
 
     private static void Serialize(Utf8JsonWriter writer, JsonNode token)
     {
+        if (token == null)
+        {
+            writer.WriteRawValue("null");
+            return;
+        }
         switch (token.GetValueKind())
         {
             case JsonValueKind.Object:

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
@@ -112,6 +112,9 @@ internal class JsonLiteralSerializer
             case JsonValueKind.Null:
                 writer.WriteRawValue("null");
                 break;
+            case JsonValueKind.String:
+                writer.WriteStringValue(token.GetValue<string>());
+                break;
             default:
                 writer.WriteRawValue(token.GetValue<string>());
                 break;

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonLiteralSerializer.cs
@@ -103,6 +103,15 @@ internal class JsonLiteralSerializer
                     }
                 };
                 break;
+            case JsonValueKind.True:
+                writer.WriteRawValue("true");
+                break;
+            case JsonValueKind.False:
+                writer.WriteRawValue("false");
+                break;
+            case JsonValueKind.Null:
+                writer.WriteRawValue("null");
+                break;
             default:
                 writer.WriteRawValue(token.GetValue<string>());
                 break;

--- a/Libraries/dotNetRdf.Core/JsonLd/JsonNodeExtensions.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/JsonNodeExtensions.cs
@@ -1,0 +1,57 @@
+/*
+// <copyright>
+// dotNetRDF is free and open source software licensed under the MIT License
+// -------------------------------------------------------------------------
+// 
+// Copyright (c) 2009-2026 dotNetRDF Project (http://dotnetrdf.org/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+*/
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+internal static class JsonNodeExtensions
+{
+    /// <summary>
+    /// Creates a detached clone of the given JsonNode.
+    /// </summary>
+    /// <remarks>
+    /// If the node is null, returns null.
+    /// If the node has no parent, returns the node itself.
+    /// Otherwise, returns a deep clone of the node.
+    /// </remarks>
+    public static JsonNode DetachedClone(this JsonNode node)
+    {
+        if (node == null) return null;
+        if (node.Parent == null) return node;
+        return node.DeepClone();
+    }
+
+    /// <summary>
+    /// Gets the value kind of the given JsonNode, returning JsonValueKind.Null if the node is null.
+    /// </summary>
+    /// <param name="node">The JsonNode to get the value kind of.</param>
+    /// <returns>The value kind of the JsonNode, or JsonValueKind.Null if the node is null.</returns>
+    public static JsonValueKind SafeValueKind(this JsonNode node)
+    {
+        if (node == null) return JsonValueKind.Null;
+        return node.GetValueKind();
+    }
+}

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -398,7 +398,7 @@ internal class CompactProcessor : ProcessorBase
                         // 12.8.7.2.2 - If expanded item contains the entry @index - value, then add an entry to compacted item where the key is the result of IRI compacting @index and value is value.
                         if (expandedItem is JsonObject expandedItemObject && expandedItemObject.ContainsKey("@index"))
                         {
-                            (compactedItem as JsonObject).Add(CompactIri(activeContext, "@index", vocab: true), expandedItemObject["@index"]);
+                            (compactedItem as JsonObject).Add(CompactIri(activeContext, "@index", vocab: true), expandedItemObject["@index"].DeepClone());
                         }
                         // 12.8.7.2.3 - Use add value to add compacted item to the item active property entry in nest result using as array.
                         JsonLdUtils.AddValue(nestResult, itemActiveProperty, compactedItem, asArray);

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -24,10 +24,12 @@
 // </copyright>
 */
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd.Processors;
@@ -52,7 +54,7 @@ internal class CompactProcessor : ProcessorBase
     /// <param name="compactArrays"></param>
     /// <param name="ordered"></param>
     /// <returns></returns>
-    public JToken CompactElement(JsonLdContext activeContext, string activeProperty, JToken element, bool compactArrays = false, bool ordered = false)
+    public JsonNode CompactElement(JsonLdContext activeContext, string activeProperty, JsonNode element, bool compactArrays = false, bool ordered = false)
     {
         JsonLdTermDefinition activeTermDefinition = null;
         if (activeProperty != null)
@@ -67,16 +69,16 @@ internal class CompactProcessor : ProcessorBase
         if (JsonLdUtils.IsScalar(element)) return element;
 
         // 3 - If element is an array: 
-        if (element is JArray elementArray)
+        if (element is JsonArray elementArray)
         {
             // 3.1 - Initialize result to an empty array.
-            var arrayResult = new JArray();
+            var arrayResult = new JsonArray();
 
             // 3.2 - For each item in element: 
-            foreach (JToken item in elementArray)
+            foreach (JsonNode item in elementArray)
             {
                 // 3.2.1 - Initialize compacted item to the result of using this algorithm recursively, passing active context, active property, item for element, and the compactArrays and ordered flags.
-                JToken compactedItem = CompactElement(activeContext, activeProperty, item, compactArrays, ordered);
+                JsonNode compactedItem = CompactElement(activeContext, activeProperty, item, compactArrays, ordered);
                 // 3.2.2 - If compacted item is not null, then append it to result.
                 if (compactedItem != null) arrayResult.Add(compactedItem);
             }
@@ -95,7 +97,7 @@ internal class CompactProcessor : ProcessorBase
         }
 
         // 4 - Otherwise element is a map.
-        var elementObject = element as JObject;
+        var elementObject = element as JsonObject;
 
         // 5 - If active context has a previous context, the active context is not propagated.
         // If element does not contain an @value entry, and element does not consist of a single @id entry,
@@ -126,7 +128,7 @@ internal class CompactProcessor : ProcessorBase
         // and element as value is a scalar, or the term definition for active property has a type mapping of @json, return that result.
         if (elementObject.ContainsKey("@value") || elementObject.ContainsKey("@id"))
         {
-            JToken compactValue = CompactValue(activeContext, activeProperty, elementObject);
+            JsonNode compactValue = CompactValue(activeContext, activeProperty, elementObject);
             if (JsonLdUtils.IsScalar(compactValue) ||
                 (activeTermDefinition != null && "@json".Equals(activeTermDefinition.TypeMapping)))
             {
@@ -142,21 +144,21 @@ internal class CompactProcessor : ProcessorBase
         // 9 - Initialize inside reverse to true if active property equals @reverse, otherwise to false.
         var insideReverse = "@reverse".Equals(activeProperty);
         // 10 - Initialize result to an empty map.
-        var result = new JObject();
+        var result = new JsonObject();
         // 11 - If element has an @type entry...
         if (elementObject.ContainsKey("@type"))
         {
             // ...create a new array compacted types initialized by transforming each expanded type of that entry into its
             // compacted form by IRI compacting expanded type. 
-            var compactedTypes = new JArray();
-            JArray expandedTypes = JsonLdUtils.EnsureArray(elementObject["@type"]);
-            foreach (JToken expandedType in expandedTypes)
+            var compactedTypes = new JsonArray();
+            JsonArray expandedTypes = JsonLdUtils.EnsureArray(elementObject["@type"]);
+            foreach (JsonNode expandedType in expandedTypes)
             {
-                var compactedType = CompactIri(activeContext, expandedType.Value<string>(), vocab: true);
+                var compactedType = CompactIri(activeContext, expandedType.GetValue<string>(), vocab: true);
                 compactedTypes.Add(compactedType);
             }
             // Then, for each term in compacted types ordered lexicographically: 
-            foreach (var term in compactedTypes.Select(t => t.Value<string>()).OrderBy(x => x))
+            foreach (var term in compactedTypes.Select(t => t.GetValue<string>()).OrderBy(x => x))
             {
                 // 11.1 - If the term definition for term in type-scoped context has a local context set active context to the result of the
                 // Context Processing algorithm, passing active context and the value of term's local context in type-scoped context as
@@ -169,44 +171,45 @@ internal class CompactProcessor : ProcessorBase
             }
         }
         // 12 - For each key expanded property and value expanded value in element, ordered lexicographically by expanded property if ordered is true: 
-        IEnumerable<JProperty> properties = elementObject.Properties();
-        if (ordered) properties = properties.OrderBy(p => p.Name);
-        foreach (JProperty p in properties)
+        IEnumerable<KeyValuePair<string, JsonNode>> properties = elementObject;
+        if (ordered) properties = properties.OrderBy(p => p.Key);
+        foreach (KeyValuePair<string, JsonNode> p in properties)
         {
-            var expandedProperty = p.Name;
-            JToken expandedValue = p.Value;
+            var expandedProperty = p.Key;
+            JsonNode expandedValue = p.Value;
             // 12.1 - If expanded property is @id:
             if (expandedProperty.Equals("@id"))
             {
                 // 12.1.1 - If expanded value is a string, then initialize compacted value by IRI compacting expanded value with vocab set to false.
-                var compactedValue = CompactIri(activeContext, expandedValue.Value<string>(), vocab: false);
+                var compactedValue = CompactIri(activeContext, expandedValue.GetValue<string>(), vocab: false);
                 // 12.1.2 - Initialize alias by IRI compacting expanded property.
                 var alias = CompactIri(activeContext, expandedProperty, vocab: true);
                 // 12.1.3 - Add an entry alias to result whose value is set to compacted value and continue to the next expanded property.
-                result.Add(new JProperty(alias, compactedValue));
+                result.Add(alias, compactedValue);
                 continue;
             }
 
             // 12.2 - If expanded property is @type:
             if (expandedProperty.Equals("@type"))
             {
-                JToken compactedValue;
+                JsonNode compactedValue;
                 // 12.2.1 - If expanded value is a string, then initialize compacted value by IRI compacting expanded value using type-scoped context for active context.
-                if (expandedValue.Type == JTokenType.String)
+                if (expandedValue.GetValueKind() == JsonValueKind.String)
                 {
-                    compactedValue = CompactIri(typeScopedContext, expandedValue.Value<string>(), vocab: true);
+                    compactedValue = CompactIri(typeScopedContext, expandedValue.GetValue<string>(), vocab: true);
                 }
                 else
                 {
                     // 12.2.2 - Otherwise, expanded value must be a @type array:
+                    var expandedValueArray = JsonLdUtils.EnsureArray(expandedValue);
                     // 12.2.2.1 - Initialize compacted value to an empty array.
-                    var compactedValueArray = new JArray();
+                    var compactedValueArray = new JsonArray();
                     compactedValue = compactedValueArray;
                     // 12.2.2.2 - For each item expanded type in expanded value:
-                    foreach (JToken item in expandedValue.Children())
+                    foreach (JsonNode item in expandedValueArray)
                     {
                         // 12.2.2.2.1 - Set term by IRI compacting expanded type using type-scoped context for active context.
-                        var term = CompactIri(typeScopedContext, item.Value<string>(), vocab: true);
+                        var term = CompactIri(typeScopedContext, item.GetValue<string>(), vocab: true);
                         // 12.2.2.2.2 - Append term, to compacted value.
                         compactedValueArray.Add(term);
                     }
@@ -231,27 +234,27 @@ internal class CompactProcessor : ProcessorBase
             if ("@reverse".Equals(expandedProperty))
             {
                 // 12.3.1 - Initialize compacted value to the result of using this algorithm recursively, passing active context, @reverse for active property, expanded value for element, and the compactArrays and ordered flags.
-                JToken compactedValue =
+                JsonNode compactedValue =
                     CompactElement(activeContext, "@reverse", expandedValue, compactArrays, ordered);
-                if (compactedValue is JObject compactedObject)
+                if (compactedValue is JsonObject compactedObject)
                 {
                     // 12.3.2 - For each property and value in compacted value:
-                    foreach (JProperty compactedObjectProperty in compactedObject.Properties().ToList())
+                    foreach (KeyValuePair<string, JsonNode> compactedObjectProperty in compactedObject)
                     {
                         // 12.3.1 - If the term definition for property in the active context indicates that property is a reverse property
-                        JsonLdTermDefinition td = activeContext.GetTerm(compactedObjectProperty.Name, true);
+                        JsonLdTermDefinition td = activeContext.GetTerm(compactedObjectProperty.Key, true);
                         if (td != null && td.Reverse)
                         {
                             // 12.3.2.1.1 - Initialize as array to true if the container mapping for property in the active context includes @set, otherwise the negation of compactArrays.
                             var asArray = td.ContainerMapping.Contains(JsonLdContainer.Set) || !compactArrays;
                             // 12.3.2.1.2 - Use add value to add value to the property entry in result using as array.
-                            JsonLdUtils.AddValue(result, compactedObjectProperty.Name, compactedObjectProperty.Value, asArray);
+                            JsonLdUtils.AddValue(result, compactedObjectProperty.Key, compactedObjectProperty.Value, asArray);
                             // 12.3.2.1.3 - Remove the property entry from compacted value.
-                            compactedObjectProperty.Remove();
+                            compactedObject.Remove(compactedObjectProperty.Key);
                         }
                     }
                     // 12.3.3 - If compacted value has some remaining map entries, i.e., it is not an empty map:
-                    if (compactedObject.HasValues)
+                    if (compactedObject.Count > 0)
                     {
                         var alias = CompactIri(activeContext, "@reverse", vocab: true);
                         result.Add(alias, compactedValue);
@@ -267,7 +270,7 @@ internal class CompactProcessor : ProcessorBase
                 {
                     // 12.4.1 - Initialize compacted value to the result of using this algorithm recursively, passing
                     // active context, active property, expanded value for element, and the compactArrays and ordered flags.
-                    JToken compactedValue = CompactElement(activeContext, activeProperty, expandedValue,
+                    JsonNode compactedValue = CompactElement(activeContext, activeProperty, expandedValue,
                         compactArrays,
                         ordered);
                     // 12.4.2 Add compacted value as the value of @preserve in result unless expanded value is an empty array.
@@ -303,7 +306,7 @@ internal class CompactProcessor : ProcessorBase
                     CompactIri(activeContext, expandedProperty, expandedValue, true, insideReverse);
                 // 12.7.2 - If the term definition for item active property in the active context has a nest value entry(nest term): 
                 JsonLdTermDefinition td = activeContext.GetTerm(itemActiveProperty);
-                JObject nestResult = null;
+                JsonObject nestResult = null;
                 if (td != null && td.Nest != null)
                 {
 
@@ -317,10 +320,10 @@ internal class CompactProcessor : ProcessorBase
                     // 12.7.2.2 - If result does not have a nest term entry, initialize it to an empty map.
                     if (!result.ContainsKey("@nest"))
                     {
-                        result.Add("@nest", new JObject());
+                        result.Add("@nest", new JsonObject());
                     }
                     // 12.7.2.3 - Initialize nest result to the value of nest term in result.
-                    nestResult = result["@nest"] as JObject;
+                    nestResult = result["@nest"] as JsonObject;
                 }
                 // 12.7.3 - Otherwise, initialize nest result to result.
                 else
@@ -328,17 +331,17 @@ internal class CompactProcessor : ProcessorBase
                     nestResult = result;
                 }
                 // 12.7.4 - Use add value to add an empty array to the item active property entry in nest result using true for as array.
-                JsonLdUtils.AddValue(nestResult, itemActiveProperty, new JArray(), true);
+                JsonLdUtils.AddValue(nestResult, itemActiveProperty, new JsonArray(), true);
             }
             // 12.8 -  At this point, expanded value must be an array due to the Expansion algorithm. For each item expanded item in expanded value: 
-            foreach (JToken expandedItem in expandedValue.Children())
+            foreach (JsonNode expandedItem in expandedValue as JsonArray)
             {
                 // 12.8.1 - Initialize item active property by IRI compacting expanded property using expanded item for value and inside reverse for reverse.
                 var itemActiveProperty =
                     CompactIri(activeContext, expandedProperty, expandedItem, true, insideReverse);
                 // 12.8.2 - If the term definition for item active property in the active context has a nest value entry (nest term):
                 JsonLdTermDefinition itemActiveTermDefinition = activeContext.GetTerm(itemActiveProperty);
-                JObject nestResult = null;
+                JsonObject nestResult = null;
                 if (itemActiveTermDefinition != null && itemActiveTermDefinition.Nest != null)
                 {
                     // 12.8.2.1 - If nest term is not @nest, or a term in the active context that expands to @nest, an invalid @nest value error has been detected, and processing is aborted.
@@ -370,9 +373,9 @@ internal class CompactProcessor : ProcessorBase
                 // 12.8.6 - Initialize compacted item to the result of using this algorithm recursively, passing active context,
                 // item active property for active property, expanded item for element, along with the compactArrays and ordered flags.
                 // If expanded item is a list object or a graph object, use the value of the @list or @graph entries, respectively, for element instead of expanded item.
-                JToken elementToCompact = JsonLdUtils.IsListObject(expandedItem) ? expandedItem["@list"] :
+                JsonNode elementToCompact = JsonLdUtils.IsListObject(expandedItem) ? expandedItem["@list"] :
                     JsonLdUtils.IsGraphObject(expandedItem) ? expandedItem["@graph"] : expandedItem;
-                JToken compactedItem = CompactElement(activeContext, itemActiveProperty, elementToCompact,
+                JsonNode compactedItem = CompactElement(activeContext, itemActiveProperty, elementToCompact,
                     compactArrays, ordered);
                 // 12.8.7 - If expanded item is a list object: 
                 if (JsonLdUtils.IsListObject(expandedItem))
@@ -384,12 +387,13 @@ internal class CompactProcessor : ProcessorBase
                     {
                         // 12.8.7.2.1 - Convert compacted item to a list object by setting it to a map containing an entry where the key is
                         // the result of IRI compacting @list and the value is the original compacted item.
-                        compactedItem = new JObject(new JProperty(CompactIri(activeContext, "@list", vocab: true), compactedItem));
+                        compactedItem = new JsonObject();
+                        (compactedItem as JsonObject).Add(CompactIri(activeContext, "@list", vocab: true), compactedItem);
 
                         // 12.8.7.2.2 - If expanded item contains the entry @index - value, then add an entry to compacted item where the key is the result of IRI compacting @index and value is value.
-                        if (expandedItem is JObject expandedItemObject && expandedItemObject.ContainsKey("@index"))
+                        if (expandedItem is JsonObject expandedItemObject && expandedItemObject.ContainsKey("@index"))
                         {
-                            (compactedItem as JObject).Add(new JProperty(CompactIri(activeContext, "@index", vocab: true), expandedItemObject["@index"]));
+                            (compactedItem as JsonObject).Add(CompactIri(activeContext, "@index", vocab: true), expandedItemObject["@index"]);
                         }
                         // 12.8.7.2.3 - Use add value to add compacted item to the item active property entry in nest result using as array.
                         JsonLdUtils.AddValue(nestResult, itemActiveProperty, compactedItem, asArray);
@@ -408,12 +412,12 @@ internal class CompactProcessor : ProcessorBase
                     if (container.Contains(JsonLdContainer.Graph) && container.Contains(JsonLdContainer.Id))
                     {
                         // 12.8.8.1.1 - Initialize map object to the value of item active property in nest result, initializing it to a new empty map, if necessary.
-                        JObject mapObject = EnsureMapEntry(nestResult, itemActiveProperty);
+                        JsonObject mapObject = EnsureMapEntry(nestResult, itemActiveProperty);
 
                         // 12.8.8.1.2 - Initialize map key by IRI compacting the value of @id in expanded item or @none if no such value exists with vocab set to false if there is an @id entry in expanded item.
                         var mapKey =
-                            (expandedItem is JObject expandedItemObject && expandedItemObject.ContainsKey("@id"))
-                                ? CompactIri(activeContext, expandedItemObject["@id"].Value<string>(),
+                            (expandedItem is JsonObject expandedItemObject && expandedItemObject.ContainsKey("@id"))
+                                ? CompactIri(activeContext, expandedItemObject["@id"].GetValue<string>(),
                                     vocab: false)
                                 : CompactIri(activeContext, "@none", vocab: true);
                         // 12.8.8.1.3 - Use add value to add compacted item to the map key entry in map object using as array.
@@ -424,11 +428,11 @@ internal class CompactProcessor : ProcessorBase
                              container.Contains(JsonLdContainer.Index))
                     {
                         // 12.8.8.2.1 - Initialize map object to the value of item active property in nest result, initializing it to a new empty map, if necessary.
-                        JObject mapObject = EnsureMapEntry(nestResult, itemActiveProperty);
+                        JsonObject mapObject = EnsureMapEntry(nestResult, itemActiveProperty);
                         // 12.8.8.2.2 - Initialize map key the value of @index in expanded item or @none, if no such value exists.
                         var mapKey =
-                            expandedItem is JObject expandedItemObject && expandedItemObject.ContainsKey("@index")
-                                ? expandedItemObject["@index"].Value<string>()
+                            expandedItem is JsonObject expandedItemObject && expandedItemObject.ContainsKey("@index")
+                                ? expandedItemObject["@index"].GetValue<string>()
                                 : "@none";
                         // 12.8.8.2.3 - Use add value to add compacted item to the map key entry in map object using as array.
                         JsonLdUtils.AddValue(mapObject, mapKey, compactedItem, asArray);
@@ -437,12 +441,11 @@ internal class CompactProcessor : ProcessorBase
                     else if (JsonLdUtils.IsSimpleGraphObject(expandedItem) && container.Contains(JsonLdContainer.Graph))
                     {
                         // 12.8.8.3.1 - If compacted item is an array with more than one value, it cannot be directly represented, as multiple objects would be interpreted as different named graphs.
-                        if ((compactedItem is JArray compactedItemArray) && compactedItemArray.Count > 1)
+                        if ((compactedItem is JsonArray compactedItemArray) && compactedItemArray.Count > 1)
                         {
                             // Set compacted item to a new map, containing the key from IRI compacting @included and the original compacted item as the value.
-                            compactedItem =
-                                new JObject(new JProperty(CompactIri(activeContext, "@included", vocab: true),
-                                    compactedItem));
+                            compactedItem = new JsonObject();
+                            (compactedItem as JsonObject).Add(CompactIri(activeContext, "@included", vocab: true), compactedItem);
                         }
 
                         // 12.8.8.3.2 - Use add value to add compacted item to the item active property entry in nest result using as array.
@@ -452,24 +455,25 @@ internal class CompactProcessor : ProcessorBase
                     else
                     {
                         // 12.8.8.4.1 - Set compacted item to a new map containing the key from IRI compacting @graph using the original compacted item as a value.
-                        compactedItem = new JObject(new JProperty(CompactIri(activeContext, "@graph", vocab: true), compactedItem));
-                        if (expandedItem is JObject expandedItemObject)
+                        compactedItem = new JsonObject();
+                        (compactedItem as JsonObject).Add(CompactIri(activeContext, "@graph", vocab: true), compactedItem);
+                        if (expandedItem is JsonObject expandedItemObject)
                         {
                             // 12.8.8.4.2 - If expanded item contains an @id entry, add an entry in compacted item using the key from IRI
                             // compacting @id using the value of IRI compacting the value of @id in expanded item using false for vocab.
                             if (expandedItemObject.ContainsKey("@id"))
                             {
-                                (compactedItem as JObject).Add(
+                                (compactedItem as JsonObject).Add(
                                     CompactIri(activeContext, "@id", vocab: true),
-                                    CompactIri(activeContext, expandedItemObject["@id"].Value<string>(),
+                                    CompactIri(activeContext, expandedItemObject["@id"].GetValue<string>(),
                                         vocab: false));
                             }
                             // 12.8.8.4.3 - If expanded item contains an @index entry, add an entry in compacted item using the key from IRI compacting @index and the value of @index in expanded item.
                             if (expandedItemObject.ContainsKey("@index"))
                             {
-                                (compactedItem as JObject).Add(
+                                (compactedItem as JsonObject).Add(
                                     CompactIri(activeContext, "@index", vocab: true),
-                                    CompactIri(activeContext, expandedItemObject["@index"].Value<string>(),
+                                    CompactIri(activeContext, expandedItemObject["@index"].GetValue<string>(),
                                         vocab: true));
                             }
                         }
@@ -486,9 +490,9 @@ internal class CompactProcessor : ProcessorBase
                     // 12.8.9.1 - Initialize map object to the value of item active property in nest result, initializing it to a new empty map, if necessary.
                     if (!nestResult.ContainsKey(itemActiveProperty))
                     {
-                        nestResult[itemActiveProperty] = new JObject();
+                        nestResult[itemActiveProperty] = new JsonObject();
                     }
-                    var mapObject = nestResult[itemActiveProperty] as JObject;
+                    var mapObject = nestResult[itemActiveProperty] as JsonObject;
 
                     // 12.8.9.2 - Initialize container key by IRI compacting either @language, @index, @id, or @type based on the contents of container.
                     string expandedKey = null;
@@ -506,14 +510,14 @@ internal class CompactProcessor : ProcessorBase
                     // 12.8.9.4 - If container includes @language and expanded item contains a @value entry, then set compacted item to the value associated with its @value entry.
                     // Set map key to the value of @language in expanded item, if any.
                     string mapKey = null;
-                    var expandedItemObject = expandedItem as JObject;
+                    var expandedItemObject = expandedItem as JsonObject;
                     if (container.Contains(JsonLdContainer.Language) && expandedItemObject != null &&
                         expandedItemObject.ContainsKey("@value"))
                     {
                         compactedItem = expandedItemObject["@value"];
                         if (expandedItemObject.ContainsKey("@language"))
                         {
-                            mapKey = expandedItemObject["@language"].Value<string>();
+                            mapKey = expandedItemObject["@language"].GetValue<string>();
                         }
                     }
                     // 12.8.9.5 - Otherwise, if container includes @index and index key is @index, set map key to the value of @index in expanded item, if any.
@@ -521,11 +525,11 @@ internal class CompactProcessor : ProcessorBase
                     {
                         if (expandedItemObject != null && expandedItemObject.ContainsKey("@index"))
                         {
-                            mapKey = expandedItemObject["@index"].Value<string>();
+                            mapKey = expandedItemObject["@index"].GetValue<string>();
                         }
                     }
                     // 12.8.9.6 - Otherwise, if container includes @index and index key is not @index: 
-                    else if (container.Contains(JsonLdContainer.Index) && compactedItem is JObject jObject)
+                    else if (container.Contains(JsonLdContainer.Index) && compactedItem is JsonObject jObject)
                     {
                         // 12.8.9.6.1 - Reinitialize container key by IRI compacting index key after first IRI expanding it.
                         var expandedIndexKey = _contextProcessor.ExpandIri(activeContext, indexKey);
@@ -533,14 +537,14 @@ internal class CompactProcessor : ProcessorBase
                         // 12.8.9.6.2 - Set map key to the first value of container key in compacted item, if any.
                         // 12.8.9.6.3 - If there are remaining values in compacted item for container key, use add value to add those remaining values to the container key in compacted item.
                         // Otherwise, remove that entry from compacted item.
-                        JArray array = JsonLdUtils.EnsureArray(compactedItem[containerKey]);
+                        JsonArray array = JsonLdUtils.EnsureArray(compactedItem[containerKey]);
 
                         jObject.Remove(containerKey);
-                        foreach (JToken item in array)
+                        foreach (JsonNode item in array)
                         {
-                            if (mapKey == null && item.Type == JTokenType.String)
+                            if (mapKey == null && item.GetValueKind() == JsonValueKind.String)
                             {
-                                mapKey = item.Value<string>();
+                                mapKey = item.GetValue<string>();
                             }
                             else
                             {
@@ -551,10 +555,10 @@ internal class CompactProcessor : ProcessorBase
                     // 12.8.9.7 - Otherwise, if container includes @id, set map key to the value of container key in compacted item and remove container key from compacted item.
                     else if (container.Contains(JsonLdContainer.Id))
                     {
-                        if (compactedItem is JObject compactedItemObject &&
+                        if (compactedItem is JsonObject compactedItemObject &&
                             compactedItemObject.ContainsKey(containerKey))
                         {
-                            mapKey = compactedItemObject[containerKey].Value<string>();
+                            mapKey = compactedItemObject[containerKey].GetValue<string>();
                             compactedItemObject.Remove(containerKey);
                         }
                     }
@@ -564,25 +568,25 @@ internal class CompactProcessor : ProcessorBase
                         // 12.8.9.8.1 - Set map key to the first value of container key in compacted item, if any.
                         // 12.8.9.8.2 - If there are remaining values in compacted item for container key, use add value to add those remaining values to the container key in compacted item.
                         // 12.8.9.8.3 - Otherwise, remove that entry from compacted item.
-                        JArray array = compactedItem.HasValues
-                            ? JsonLdUtils.EnsureArray(compactedItem[containerKey])
-                            : [];
+                        JsonArray array = compactedItem is JsonObject  compactedObject && compactedObject.ContainsKey(containerKey)
+                            ? JsonLdUtils.EnsureArray(compactedObject[containerKey])
+                            : new JsonArray();
 
                         if (array.Count > 0)
                         {
-                            mapKey = array[0].Value<string>();
+                            mapKey = array[0].GetValue<string>();
                             array.RemoveAt(0);
-                            if (array.Count == 0) (compactedItem as JObject).Remove(containerKey);
+                            if (array.Count == 0) (compactedItem as JsonObject).Remove(containerKey);
                             else if (array.Count == 1) compactedItem[containerKey] = array[0];
                         }
                         // 12.8.9.8.4 - If compacted item contains a single entry with a key expanding to @id, set compacted item to the result of using this algorithm recursively, passing active context, item active property for active property, and a map composed of the single entry for @id from expanded item for element.
-                        if ((compactedItem is JObject compactedItemObject) && compactedItemObject.Count == 1)
+                        if ((compactedItem is JsonObject compactedItemObject) && compactedItemObject.Count == 1)
                         {
-                            if (_contextProcessor.ExpandIri(activeContext, compactedItemObject.Properties().First().Name, vocab: true)
+                            if (_contextProcessor.ExpandIri(activeContext, compactedItemObject.First().Key, vocab: true)
                                 .Equals("@id"))
                             {
                                 compactedItem = CompactElement(activeContext, itemActiveProperty,
-                                    new JObject(new JProperty("@id", expandedItemObject["@id"])));
+                                    new JsonObject{["@id"] = expandedItemObject["@id"] });
                             }
                         }
                     }
@@ -602,8 +606,7 @@ internal class CompactProcessor : ProcessorBase
         return result;
     }
 
-    public string CompactIri(JsonLdContext activeContext, string iri, JToken value = null,
-bool vocab = false, bool reverse = false)
+    public string CompactIri(JsonLdContext activeContext, string iri, JsonNode value = null, bool vocab = false, bool reverse = false)
     {
         // 1 - If var is null, return null.
         // KA - note local name for var is iri to avoid clash with C# keyword
@@ -611,7 +614,7 @@ bool vocab = false, bool reverse = false)
 
         // 2 - If the active context has a null inverse context, set inverse context in active context to the result of calling the Inverse Context Creation algorithm using active context.
         // Initialize inverse context to the value of inverse context in active context.
-        JObject inverseContext = activeContext.InverseContext;
+        JsonObject inverseContext = activeContext.InverseContext;
 
         // 4 - If vocab is true and var is an entry of inverse context:
         if (vocab && inverseContext.ContainsKey(iri))
@@ -633,10 +636,10 @@ bool vocab = false, bool reverse = false)
             }
 
             // 4.2 - If value is a map containing an @preserve entry, use the first element from the value of @preserve as value.
-            if ((value is JObject valueMap) && valueMap.ContainsKey("@preserve"))
+            if ((value is JsonObject valueMap) && valueMap.ContainsKey("@preserve"))
             {
                 value = valueMap["@preserve"];
-                if (value is JArray valueArray)
+                if (value is JsonArray valueArray)
                 {
                     value = valueArray[0];
                 }
@@ -648,7 +651,7 @@ bool vocab = false, bool reverse = false)
             var typeLanguage = "@language";
             var typeLanguageValue = "@null";
             // 4.5 - If value is a map containing an @index entry, and value is not a graph object then append the values @index and @index@set to containers.
-            if (value is JObject jObject && jObject.ContainsKey("@index") && !JsonLdUtils.IsGraphObject(jObject))
+            if (value is JsonObject jObject && jObject.ContainsKey("@index") && !JsonLdUtils.IsGraphObject(jObject))
             {
                 containers.Add("@index");
                 containers.Add("@index@set");
@@ -664,11 +667,11 @@ bool vocab = false, bool reverse = false)
             else if (JsonLdUtils.IsListObject(value))
             {
                 // 4.7 - Otherwise, if value is a list object, then set type/language and type/language value to the most specific values that work for all items in the list as follows: 
-                var valueObject = value as JObject;
+                var valueObject = value as JsonObject;
                 // 4.7.1 - If @index is not an entry in value, then append @list to containers.
                 if (!valueObject.ContainsKey("@index")) containers.Add("@list");
                 // 4.7.2 - Initialize list to the array associated with the @list entry in value.
-                JArray list = JsonLdUtils.EnsureArray(valueObject["@list"]);
+                JsonArray list = JsonLdUtils.EnsureArray(valueObject["@list"]);
                 // 4.7.3 - Initialize common type and common language to null.If list is empty, set common language to default language.
                 string commonType = null;
                 string commonLanguage = null;
@@ -678,9 +681,9 @@ bool vocab = false, bool reverse = false)
                 }
 
                 // 4.7.4 - For each item in list:
-                foreach (JToken item in list)
+                foreach (JsonNode item in list)
                 {
-                    var itemObject = item as JObject;
+                    var itemObject = item as JsonObject;
                     // 4.7.4.1 - Initialize item language to @none and item type to @none.
                     var itemLanguage = "@none";
                     var itemType = "@none";
@@ -692,21 +695,21 @@ bool vocab = false, bool reverse = false)
                             if (itemObject.ContainsKey("@language"))
                             {
                                 itemLanguage =
-                                    (itemObject["@language"].Value<string>() + "_" +
-                                     itemObject["@direction"].Value<string>()).ToLowerInvariant();
+                                    (itemObject["@language"].GetValue<string>() + "_" +
+                                     itemObject["@direction"].GetValue<string>()).ToLowerInvariant();
                             }
                             else
                             {
-                                itemLanguage = "_" + itemObject["@direction"].Value<string>().ToLowerInvariant();
+                                itemLanguage = "_" + itemObject["@direction"].GetValue<string>().ToLowerInvariant();
                             }
                         }
                         else if (itemObject.ContainsKey("@language"))
                         {
-                            itemLanguage = itemObject["@language"].Value<string>().ToLowerInvariant();
+                            itemLanguage = itemObject["@language"].GetValue<string>().ToLowerInvariant();
                         }
                         else if (itemObject.ContainsKey("@type"))
                         {
-                            itemType = itemObject["@type"].Value<string>();
+                            itemType = itemObject["@type"].GetValue<string>();
                         }
                         else
                         {
@@ -770,7 +773,7 @@ bool vocab = false, bool reverse = false)
             else if (JsonLdUtils.IsGraphObject(value))
             {
                 // 4.8 - Otherwise, if value is a graph object, prefer a mapping most appropriate for the particular value. 
-                var valueObject = value as JObject;
+                var valueObject = value as JsonObject;
                 // 4.8.1 - If value contains an @index entry, append the values @graph@index and @graph@index@set to containers.
                 if (valueObject != null && valueObject.ContainsKey("@index"))
                 {
@@ -817,19 +820,19 @@ bool vocab = false, bool reverse = false)
                 // 4.9.1 - If value is a value object: 
                 if (JsonLdUtils.IsValueObject(value))
                 {
-                    var valueObject = value as JObject;
+                    var valueObject = value as JsonObject;
                     // 4.9.1.1 - If value contains an @direction entry and does not contain an @index entry, then set type/language value to the concatenation of the value's @language entry (if any) and the value's @direction entry, separated by an underscore ("_"), normalized to lower case. Append @language and @language@set to containers.
                     if (valueObject.ContainsKey("@direction") && !valueObject.ContainsKey("@index"))
                     {
                         if (valueObject.ContainsKey("@language"))
                         {
                             typeLanguageValue =
-                                (valueObject["@language"].Value<string>() + "_" +
-                                 valueObject["@direction"].Value<string>()).ToLowerInvariant();
+                                (valueObject["@language"].GetValue<string>() + "_" +
+                                 valueObject["@direction"].GetValue<string>()).ToLowerInvariant();
                         }
                         else
                         {
-                            typeLanguageValue = ("_" + valueObject["direction"].Value<string>()).ToLowerInvariant();
+                            typeLanguageValue = ("_" + valueObject["direction"].GetValue<string>()).ToLowerInvariant();
                         }
 
                         containers.Add("@language");
@@ -838,14 +841,14 @@ bool vocab = false, bool reverse = false)
                     // 4.9.1.2 - Otherwise, if value contains an @language entry and does not contain an @index entry, then set type/language value to the value of @language normalized to lower case, and append @language, and @language@set to containers.
                     else if (valueObject.ContainsKey("@language") && !valueObject.ContainsKey("@index"))
                     {
-                        typeLanguageValue = valueObject["@language"].Value<string>().ToLowerInvariant();
+                        typeLanguageValue = valueObject["@language"].GetValue<string>().ToLowerInvariant();
                         containers.Add("@language");
                         containers.Add("@language@set");
                     }
                     // 4.9.1.3 - Otherwise, if value contains an @type entry, then set type/language value to its associated value and set type/language to @type.
                     else if (valueObject.ContainsKey("@type"))
                     {
-                        typeLanguageValue = valueObject["@type"].Value<string>();
+                        typeLanguageValue = valueObject["@type"].GetValue<string>();
                         typeLanguage = "@type";
                     }
 
@@ -870,14 +873,14 @@ bool vocab = false, bool reverse = false)
             if (Options.ProcessingMode != JsonLdProcessingMode.JsonLd10)
             {
                 // 4.11 - If processing mode is not json-ld-1.0 and value is not a map or does not contain an @index entry, append @index and @index@set to containers.
-                if (value == null || value.Type != JTokenType.Object || !(value as JObject).ContainsKey("@index"))
+                if (value == null || value is not JsonObject x || !x.ContainsKey("@index"))
                 {
                     containers.Add("@index");
                     containers.Add("@index@set");
                 }
 
                 // 4.12 - If processing mode is not json - ld - 1.0 and value is a map containing only an @value entry, append @language and @language@set to containers.
-                if (value is JObject valueObject &&
+                if (value is JsonObject valueObject &&
                     valueObject.Count == 1 &&
                     valueObject.ContainsKey("@value"))
                 {
@@ -897,11 +900,11 @@ bool vocab = false, bool reverse = false)
             }
 
             // 4.16 - type/language value is @id or @reverse and value is a map containing an @id entry: 
-            if ((typeLanguageValue.Equals("@id") || typeLanguageValue.Equals("@reverse")) && (value is JObject o) &&
+            if ((typeLanguageValue.Equals("@id") || typeLanguageValue.Equals("@reverse")) && (value is JsonObject o) &&
                 o.ContainsKey("@id"))
             {
                 // 4.16.1 If the result of IRI compacting the value of the @id entry in value has a term definition in the active context with an IRI mapping that equals the value of the @id entry in value, then append @vocab, @id, and @none, in that order, to preferred values.
-                var idValue = value["@id"].Value<string>();
+                var idValue = value["@id"].GetValue<string>();
                 var compactedId = CompactIri(activeContext, idValue, vocab: true);
                 if (activeContext.TryGetTerm(compactedId, out JsonLdTermDefinition td2) && td2.IriMapping.Equals(idValue))
                 {
@@ -923,7 +926,7 @@ bool vocab = false, bool reverse = false)
                 // If value is a list object with an empty array as the value of @list, set type/language to @any.
                 preferredValues.Add(typeLanguageValue);
                 preferredValues.Add("@none");
-                if (JsonLdUtils.IsListObject(value) && (value["@list"] as JArray).Count == 0)
+                if (JsonLdUtils.IsListObject(value) && (value["@list"] as JsonArray).Count == 0)
                 {
                     typeLanguage = "@any";
                 }
@@ -1035,16 +1038,14 @@ bool vocab = false, bool reverse = false)
         // 11 - Finally, return var as is.
         return iri;
     }
-
-
     
 
-    private JToken CompactValue(JsonLdContext activeContext, string activeProperty, JObject value)
+    private JsonNode CompactValue(JsonLdContext activeContext, string activeProperty, JsonObject value)
     {
         JsonLdTermDefinition activeTermDefinition = activeProperty == null ? null : activeContext.GetTerm(activeProperty);
 
         // 1 - Initialize result to a copy of value.
-        JToken result = value.DeepClone();
+        JsonNode result = value.DeepClone();
 
         // 2 - If the active context has a null inverse context, set inverse context in active context to the result of calling the
         // Inverse Context Creation algorithm using active context.
@@ -1064,11 +1065,11 @@ bool vocab = false, bool reverse = false)
 
         var activeTermDefinitionTypeMapping = activeTermDefinition?.TypeMapping ?? null;
         var valueHasType = value.ContainsKey("@type");
-        var valueType = valueHasType && value["@type"].Type == JTokenType.String ? value["@type"].Value<string>() : null;
+        var valueType = valueHasType && value["@type"].GetValueKind() == JsonValueKind.String ? value["@type"].GetValue<string>() : null;
 
         // 6 - If value has an @id entry and has no other entries other than @index:
         if (value.ContainsKey("@id") &&
-            value.Properties().All(p => p.Name.Equals("@id") || p.Name.Equals("@index")))
+            value.All(p => p.Key.Equals("@id") || p.Key.Equals("@index")))
         {
             var typeMapping = activeTermDefinition?.TypeMapping;
             if (typeMapping != null)
@@ -1077,7 +1078,7 @@ bool vocab = false, bool reverse = false)
                 // 6.2 - Otherwise, if the type mapping of active property is set to @vocab, set result to the result of IRI compacting the value associated with the @id entry.
                 if (typeMapping.Equals("@id") || typeMapping.Equals("@vocab"))
                 {
-                    result = CompactIri(activeContext, value["@id"].Value<string>(),
+                    result = CompactIri(activeContext, value["@id"].GetValue<string>(),
                         vocab: typeMapping.Equals("@vocab"));
                 }
             }
@@ -1092,27 +1093,27 @@ bool vocab = false, bool reverse = false)
                  valueHasType && (valueType == null || valueType != activeTermDefinitionTypeMapping))
         {
             // 8.1 - Replace any value of @type in result with the result of IRI compacting the value of the @type entry.
-            if (result is JObject resultObject && resultObject.ContainsKey("@type"))
+            if (result is JsonObject resultObject && resultObject.ContainsKey("@type"))
             {
-                JToken typeValue = resultObject["@type"];
-                if (typeValue is JArray typeArray)
+                JsonNode typeValue = resultObject["@type"];
+                if (typeValue is JsonArray typeArray)
                 {
-                    var newArray = new JArray();
-                    foreach (JToken item in typeArray)
+                    var newArray = new JsonArray();
+                    foreach (JsonNode item in typeArray)
                     {
-                        newArray.Add(CompactIri(activeContext, item.Value<string>(), vocab: true));
+                        newArray.Add(CompactIri(activeContext, item.GetValue<string>(), vocab: true));
                     }
 
                     resultObject["@type"] = newArray;
                 }
                 else
                 {
-                    resultObject["@type"] = CompactIri(activeContext, typeValue.Value<string>(), vocab: true);
+                    resultObject["@type"] = CompactIri(activeContext, typeValue.GetValue<string>(), vocab: true);
                 }
             }
         }
         // 9 - Otherwise, if the value of the @value entry is not a string:
-        else if (value.ContainsKey("@value") && value["@value"].Type != JTokenType.String)
+        else if (value.ContainsKey("@value") && value["@value"].GetValueKind() != JsonValueKind.String)
         {
             // 9.1 - If value has an @index entry, and the container mapping associated to active property includes @index, or if value has no @index entry, set result to the value associated with the @value entry.
             if ((value.ContainsKey("@index") && activeTermDefinition != null &&
@@ -1136,15 +1137,15 @@ bool vocab = false, bool reverse = false)
             }
         }
         // 11 - If result is a map, replace each key in result with the result of IRI compacting that key.
-        if (result is JObject r)
+        if (result is JsonObject r)
         {
-            foreach (JProperty p in r.Properties().ToList())
+            foreach (var p in r.ToList())
             {
-                var compactKey = CompactIri(activeContext, p.Name, vocab: true);
-                if (!compactKey.Equals(p.Name))
+                var compactKey = CompactIri(activeContext, p.Key, vocab: true);
+                if (!compactKey.Equals(p.Key))
                 {
-                    r.Remove(p.Name);
-                    r.Add(new JProperty(compactKey, p.Value));
+                    r.Remove(p.Key);
+                    r.Add(compactKey, p.Value);
                 }
             }
         }
@@ -1153,7 +1154,7 @@ bool vocab = false, bool reverse = false)
     }
 
     /// <summary>
-    /// Compare a possibly null string and a possibly null JToken for equality.
+    /// Compare a possibly null string and a possibly null JsonNode for equality.
     /// </summary>
     /// <remarks>If <paramref name="str"/> is null, return true if <paramref name="t"/> is null and false if it is not null.
     /// If <paramref name="str"/> is not null, return true if <paramref name="t"/> is a non-null token of type string and the string value of <paramref name="t"/>
@@ -1162,31 +1163,31 @@ bool vocab = false, bool reverse = false)
     /// <param name="t"></param>
     /// <param name="comparisonOptions"></param>
     /// <returns></returns>
-    private static bool SafeEquals(string str, JToken t, StringComparison comparisonOptions)
+    private static bool SafeEquals(string str, JsonNode t, StringComparison comparisonOptions)
     {
         if (str == null)
         {
-            return t == null || t.Type == JTokenType.Null;
+            return t == null || t.GetValueKind() == JsonValueKind.Null;
         }
 
-        return t != null && t.Type == JTokenType.String && t.Value<string>().Equals(str, comparisonOptions);
+        return t != null && t.GetValueKind() == JsonValueKind.String && t.GetValue<string>().Equals(str, comparisonOptions);
     }
 
     
 
     /// <summary>
-    /// Ensure that a JObject has an entry for a given property, initializing it to an empty map if it does not exist.
+    /// Ensure that a JsonObject has an entry for a given property, initializing it to an empty map if it does not exist.
     /// </summary>
     /// <param name="parent"></param>
     /// <param name="property"></param>
     /// <returns></returns>
-    private static JObject EnsureMapEntry(JObject parent, string property)
+    private static JsonObject EnsureMapEntry(JsonObject parent, string property)
     {
         if (!parent.ContainsKey(property))
         {
-            parent[property] = new JObject();
+            parent[property] = new JsonObject();
         }
-        return parent[property] as JObject;
+        return parent[property] as JsonObject;
     }
 
 

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -239,7 +239,7 @@ internal class CompactProcessor : ProcessorBase
                 if (compactedValue is JsonObject compactedObject)
                 {
                     // 12.3.2 - For each property and value in compacted value:
-                    foreach (KeyValuePair<string, JsonNode> compactedObjectProperty in compactedObject)
+                    foreach (KeyValuePair<string, JsonNode> compactedObjectProperty in compactedObject.ToList())
                     {
                         // 12.3.1 - If the term definition for property in the active context indicates that property is a reverse property
                         JsonLdTermDefinition td = activeContext.GetTerm(compactedObjectProperty.Key, true);

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -120,7 +120,7 @@ internal class CompactProcessor : ProcessorBase
         }
 
         // 6 - If the term definition for active property in active context has a local context:
-        if (activeTermDefinition?.LocalContext != null)
+        if (activeTermDefinition?.HasLocalContext == true)
         {
             // 6.1 - Set active context to the result of the Context Processing algorithm, passing active context, the value of the active property's
             // local context as local context, base URL from the term definition for active property in active context, and true for override protected.
@@ -168,7 +168,7 @@ internal class CompactProcessor : ProcessorBase
                 // 11.1 - If the term definition for term in type-scoped context has a local context set active context to the result of the
                 // Context Processing algorithm, passing active context and the value of term's local context in type-scoped context as
                 // local context base URL from the term definition for term in type-scoped context, and false for propagate. 
-                if (typeScopedContext.TryGetTerm(term, out JsonLdTermDefinition termDef) && termDef.LocalContext != null)
+                if (typeScopedContext.TryGetTerm(term, out JsonLdTermDefinition termDef) && termDef.HasLocalContext)
                 {
                     activeContext = _contextProcessor.ProcessContext(activeContext, termDef.LocalContext, termDef.BaseUrl,
                         propagate: false);

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -581,8 +581,15 @@ internal class CompactProcessor : ProcessorBase
                         {
                             mapKey = array[0].GetValue<string>();
                             array.RemoveAt(0);
-                            if (array.Count == 0) (compactedItem as JsonObject).Remove(containerKey);
-                            else if (array.Count == 1) compactedItem[containerKey] = array[0];
+                            if (array.Count == 0) {
+                                (compactedItem as JsonObject).Remove(containerKey);
+                            } 
+                            else if (array.Count == 1) {
+                                // If there's only one remaining value, set the container key to that value instead of an array.
+                                JsonNode remainingValue = array[0];
+                                array.Clear();
+                                compactedItem[containerKey] = remainingValue;
+                            }
                         }
                         // 12.8.9.8.4 - If compacted item contains a single entry with a key expanding to @id, set compacted item to the result of using this algorithm recursively, passing active context, item active property for active property, and a map composed of the single entry for @id from expanded item for element.
                         if ((compactedItem is JsonObject compactedItemObject) && compactedItemObject.Count == 1)
@@ -591,7 +598,7 @@ internal class CompactProcessor : ProcessorBase
                                 .Equals("@id"))
                             {
                                 compactedItem = CompactElement(activeContext, itemActiveProperty,
-                                    new JsonObject{["@id"] = expandedItemObject["@id"] });
+                                    new JsonObject{["@id"] = expandedItemObject["@id"].DeepClone() });
                             }
                         }
                     }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -24,7 +24,6 @@
 // </copyright>
 */
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/CompactProcessor.cs
@@ -66,7 +66,7 @@ internal class CompactProcessor : ProcessorBase
         JsonLdContext typeScopedContext = activeContext;
 
         // 2 - If element is a scalar, it is already in its most compact form, so simply return element.
-        if (JsonLdUtils.IsScalar(element)) return element;
+        if (JsonLdUtils.IsScalarOrNull(element)) return element;
 
         // 3 - If element is an array: 
         if (element is JsonArray elementArray)
@@ -75,12 +75,17 @@ internal class CompactProcessor : ProcessorBase
             var arrayResult = new JsonArray();
 
             // 3.2 - For each item in element: 
-            foreach (JsonNode item in elementArray)
+            while(elementArray.Count > 0)
             {
+                JsonNode item = elementArray[0];
+                elementArray.RemoveAt(0);
                 // 3.2.1 - Initialize compacted item to the result of using this algorithm recursively, passing active context, active property, item for element, and the compactArrays and ordered flags.
                 JsonNode compactedItem = CompactElement(activeContext, activeProperty, item, compactArrays, ordered);
                 // 3.2.2 - If compacted item is not null, then append it to result.
-                if (compactedItem != null) arrayResult.Add(compactedItem);
+                if (compactedItem != null) 
+                {
+                    arrayResult.Add(compactedItem.DetachedClone());
+                }
             }
             // 3.3 - If result is empty or contains more than one value, or compactArrays is false, or active property is either @graph or @set, or container mapping for active property in active context includes either @list or @set, return result.
             if (arrayResult.Count != 1 || !compactArrays || "@graph".Equals(activeProperty) || "@set".Equals(activeProperty))
@@ -194,7 +199,7 @@ internal class CompactProcessor : ProcessorBase
             {
                 JsonNode compactedValue;
                 // 12.2.1 - If expanded value is a string, then initialize compacted value by IRI compacting expanded value using type-scoped context for active context.
-                if (expandedValue.GetValueKind() == JsonValueKind.String)
+                if (expandedValue.SafeValueKind() == JsonValueKind.String)
                 {
                     compactedValue = CompactIri(typeScopedContext, expandedValue.GetValue<string>(), vocab: true);
                 }
@@ -295,7 +300,7 @@ internal class CompactProcessor : ProcessorBase
                 // 12.6.1 - Initialize alias by IRI compacting expanded property.
                 var alias = CompactIri(activeContext, expandedProperty, vocab: true);
                 // 12.6.2 - Add an entry alias to result whose value is set to expanded value and continue with the next expanded property.
-                result.Add(alias, expandedValue);
+                result.Add(alias, expandedValue.DetachedClone());
                 continue;
             }
             // 12.7 - If expanded value is an empty array: 
@@ -387,8 +392,8 @@ internal class CompactProcessor : ProcessorBase
                     {
                         // 12.8.7.2.1 - Convert compacted item to a list object by setting it to a map containing an entry where the key is
                         // the result of IRI compacting @list and the value is the original compacted item.
-                        compactedItem = new JsonObject();
-                        (compactedItem as JsonObject).Add(CompactIri(activeContext, "@list", vocab: true), compactedItem);
+                        var tmp = new JsonObject {[CompactIri(activeContext, "@list", vocab: true)] = compactedItem.DetachedClone()};
+                        compactedItem = tmp;
 
                         // 12.8.7.2.2 - If expanded item contains the entry @index - value, then add an entry to compacted item where the key is the result of IRI compacting @index and value is value.
                         if (expandedItem is JsonObject expandedItemObject && expandedItemObject.ContainsKey("@index"))
@@ -444,8 +449,8 @@ internal class CompactProcessor : ProcessorBase
                         if ((compactedItem is JsonArray compactedItemArray) && compactedItemArray.Count > 1)
                         {
                             // Set compacted item to a new map, containing the key from IRI compacting @included and the original compacted item as the value.
-                            compactedItem = new JsonObject();
-                            (compactedItem as JsonObject).Add(CompactIri(activeContext, "@included", vocab: true), compactedItem);
+                            var tmp = new JsonObject {[CompactIri(activeContext, "@included", vocab: true)] = compactedItem.DetachedClone()};
+                            compactedItem = tmp;
                         }
 
                         // 12.8.8.3.2 - Use add value to add compacted item to the item active property entry in nest result using as array.
@@ -455,8 +460,8 @@ internal class CompactProcessor : ProcessorBase
                     else
                     {
                         // 12.8.8.4.1 - Set compacted item to a new map containing the key from IRI compacting @graph using the original compacted item as a value.
-                        compactedItem = new JsonObject();
-                        (compactedItem as JsonObject).Add(CompactIri(activeContext, "@graph", vocab: true), compactedItem);
+                        var tmp = new JsonObject {[CompactIri(activeContext, "@graph", vocab: true)] = compactedItem.DetachedClone()};
+                        compactedItem = tmp;
                         if (expandedItem is JsonObject expandedItemObject)
                         {
                             // 12.8.8.4.2 - If expanded item contains an @id entry, add an entry in compacted item using the key from IRI
@@ -542,7 +547,7 @@ internal class CompactProcessor : ProcessorBase
                         jObject.Remove(containerKey);
                         foreach (JsonNode item in array)
                         {
-                            if (mapKey == null && item.GetValueKind() == JsonValueKind.String)
+                            if (mapKey == null && item.SafeValueKind() == JsonValueKind.String)
                             {
                                 mapKey = item.GetValue<string>();
                             }
@@ -1065,7 +1070,7 @@ internal class CompactProcessor : ProcessorBase
 
         var activeTermDefinitionTypeMapping = activeTermDefinition?.TypeMapping ?? null;
         var valueHasType = value.ContainsKey("@type");
-        var valueType = valueHasType && value["@type"].GetValueKind() == JsonValueKind.String ? value["@type"].GetValue<string>() : null;
+        var valueType = valueHasType && value["@type"].SafeValueKind() == JsonValueKind.String ? value["@type"].GetValue<string>() : null;
 
         // 6 - If value has an @id entry and has no other entries other than @index:
         if (value.ContainsKey("@id") &&
@@ -1113,7 +1118,7 @@ internal class CompactProcessor : ProcessorBase
             }
         }
         // 9 - Otherwise, if the value of the @value entry is not a string:
-        else if (value.ContainsKey("@value") && value["@value"].GetValueKind() != JsonValueKind.String)
+        else if (value.ContainsKey("@value") && value["@value"].SafeValueKind() != JsonValueKind.String)
         {
             // 9.1 - If value has an @index entry, and the container mapping associated to active property includes @index, or if value has no @index entry, set result to the value associated with the @value entry.
             if ((value.ContainsKey("@index") && activeTermDefinition != null &&
@@ -1167,10 +1172,10 @@ internal class CompactProcessor : ProcessorBase
     {
         if (str == null)
         {
-            return t == null || t.GetValueKind() == JsonValueKind.Null;
+            return t == null || t.SafeValueKind() == JsonValueKind.Null;
         }
 
-        return t != null && t.GetValueKind() == JsonValueKind.String && t.GetValue<string>().Equals(str, comparisonOptions);
+        return t != null && t.SafeValueKind() == JsonValueKind.String && t.GetValue<string>().Equals(str, comparisonOptions);
     }
 
     

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
@@ -609,7 +609,7 @@ internal class ContextProcessor : ProcessorBase
         }
         // 14 - Otherwise, if value contains the key @id and its value does not equal term:
         else if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@id", out JsonNode idValue) &&
-                    (!JsonLdUtils.IsString(value) || !term.Equals(idValue.GetValue<string>())))
+                    (!JsonLdUtils.IsString(idValue) || !term.Equals(idValue.GetValue<string>())))
         {
             // 14.1 - If the @id entry of value is null, the term is not used for IRI expansion, but is retained to be able to detect future redefinitions of this term.
             // 14.2 - Otherwise:

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
@@ -810,6 +810,7 @@ internal class ContextProcessor : ProcessorBase
 
             // 21.4 - Set the local context of definition to context, and base URL to base URL.
             definition.LocalContext = context;
+            definition.HasLocalContext = true;
             definition.BaseUrl = baseUrl;
         }
 
@@ -999,7 +1000,7 @@ internal class ContextProcessor : ProcessorBase
             // This will ensure that a term definition is created for prefix in active context during Context Processing.
             if (localContext != null &&
                 localContext.TryGetPropertyValue(prefix, out var prefixValue) &&
-                !defined.TryGetValue(prefix, out var definedValue))
+                (!defined.TryGetValue(prefix, out var definedValue) || !definedValue))
             {
                 CreateTermDefinition(activeContext, localContext, prefix, defined);
             }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
@@ -27,7 +27,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 using VDS.RDF.Parsing;
 
@@ -75,22 +76,22 @@ internal class ContextProcessor : ProcessorBase
     /// <param name="propagate">Boolean flag used to mark term definitions associated with non-propagated contexts.</param>
     /// <param name="validateScopedContext">Boolean flag used to limit recursion when validating possibly recursive scoped contexts.</param>
     /// <returns></returns>
-    public JsonLdContext ProcessContext(JsonLdContext activeContext, JToken localContext, Uri baseUrl,
+    public JsonLdContext ProcessContext(JsonLdContext activeContext, JsonNode localContext, Uri baseUrl,
         List<Uri> remoteContexts = null, bool overrideProtected = false, bool propagate = true, bool validateScopedContext = true)
     {
-        if (remoteContexts == null) remoteContexts = [];
+        if (remoteContexts == null) remoteContexts = new List<Uri>();
 
         // 1. Initialize result to the result of cloning active context
         JsonLdContext result = activeContext.Clone();
 
         // 2. If local context is an object containing the member @propagate, its value MUST be boolean true or false, set propagate to that value. 
-        if (localContext is JObject localContextObject)
+        if (localContext is JsonObject localContextObject)
         {
             if (localContextObject.ContainsKey("@propagate"))
             {
-                if (localContextObject["@propagate"].Type == JTokenType.Boolean)
+                if (JsonLdUtils.IsBooleanNode(localContextObject["@propagate"]))
                 {
-                    propagate = localContextObject["@propagate"].Value<bool>();
+                    propagate = localContextObject["@propagate"].GetValue<bool>();
                 }
                 else
                 {
@@ -109,10 +110,11 @@ internal class ContextProcessor : ProcessorBase
         localContext = JsonLdUtils.EnsureArray(localContext);
 
         // 5. For each item context in local context:
-        foreach (JToken context in (JArray)localContext)
+        foreach (JsonNode context in (JsonArray)localContext)
         {
+            var contextKind = context.GetValueKind();
             // 5.1 if context is null:
-            if (context.Type == JTokenType.Null)
+            if (contextKind == JsonValueKind.Null)
             {
                 // 5.1.1 If override protected is false and active context contains any protected term definitions,
                 // an invalid context nullification has been detected and processing is aborted.
@@ -136,12 +138,12 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 5.2 If context is a string
-            if (context.Type == JTokenType.String)
+            if (contextKind == JsonValueKind.String)
             {
                 // 5.2.1 Initialize context to the result of resolving context against base URL.
                 // If base URL is not a valid IRI, then context MUST be a valid IRI, otherwise a loading document failed error
                 // has been detected and processing is aborted. 
-                var contextStr = (context as JValue).Value<string>();
+                var contextStr = context.GetValue<string>();
                 Uri remoteUrl = baseUrl == null ? new Uri(contextStr) : new Uri(baseUrl, contextStr);
                 if (!remoteUrl.IsAbsoluteUri)
                 {
@@ -179,20 +181,19 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 5.3 - If context is not a map, an invalid local context error has been detected and processing is aborted.
-            if (context.Type != JTokenType.Object)
+            if (contextKind != JsonValueKind.Object)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidLocalContext, "Local context must be a string, array of strings or JSON object");
             }
 
             // 5.4 - Otherwise, context is a context definition.
-            var contextDefinition = context as JObject;
+            var contextDefinition = context as JsonObject;
 
             // 5.5 - If context has an @version entry:
-            JProperty versionProperty = contextDefinition.Property("@version");
-            if (versionProperty != null)
+            if (contextDefinition.ContainsKey("@version"))
             {
                 // 5.5.1 - If the associated value is not 1.1, an invalid @version value has been detected, and processing is aborted.
-                var versionValue = versionProperty.Value.Value<string>();
+                var versionValue = contextDefinition["@version"].GetValue<string>();
                 if (!"1.1".Equals(versionValue))
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidVersionValue, $"Found invalid value for @version property: {versionValue}.");
@@ -206,25 +207,25 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 5.6 - If context has an @import entry: 
-            JProperty importProperty = contextDefinition.Property("@import");
-            if (importProperty != null)
+            if (contextDefinition.ContainsKey("@import"))
             {
+                var importProperty = contextDefinition["@import"];
                 // 5.6.1 - If processing mode is json-ld-1.0, an invalid context entry error has been detected and processing is aborted.
                 CheckProcessingMode("@import", JsonLdErrorCode.InvalidContextEntry);
 
                 // 5.6.2 - Otherwise, if the value of @import is not a string, an invalid @import value error has been detected and processing is aborted.
-                if (importProperty.Value.Type != JTokenType.String)
+                if (importProperty.GetValueKind() != JsonValueKind.String)
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidImportValue,
                         "The value of an @import property must be a string");
                 }
 
                 // 5.6.3 - Initialize import to the result of resolving the value of @import against base URL.
-                var import = new Uri(baseUrl, importProperty.Value.Value<string>());
+                var import = new Uri(baseUrl, importProperty.GetValue<string>());
 
                 // Implements 5.6.4, 5.6.5, 5.6.6
                 JsonLdRemoteContext remoteContext = _contextProvider.GetRemoteContext(import);
-                if (remoteContext.Context is not JObject importContext)
+                if (remoteContext.Context is not JsonObject importContext)
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidRemoteContext,
                         "The value of the @context of the remote document referenced by @import must be a map.");
@@ -236,26 +237,23 @@ internal class ContextProcessor : ProcessorBase
                         $"The remote context from {import} contains an @import property.");
                 }
                 // 5.6.8 - Set context to the result of merging context into import context, replacing common entries with those from context.
-                var tmp = new JObject(importContext);
-                tmp.Merge(contextDefinition);
-                contextDefinition = tmp;
+                contextDefinition = JsonLdUtils.MergeObjects(contextDefinition, importContext);
             }
 
             // 5.7 - If context has an @base key and remote contexts is empty, i.e., the currently being processed context is not a remote context
-            JProperty baseProperty = contextDefinition.Property("@base");
-            if (baseProperty != null && remoteContexts.Count == 0)
+            if (contextDefinition.ContainsKey("@base") && remoteContexts.Count == 0)
             {
                 // 5.7.1 - Initialize value to the value associated with the @base entry.
-                JToken value = baseProperty.Value;
+                JsonNode value = contextDefinition["@base"];
                 // 5.7.2 - If value is null, remove the base IRI of result.
-                if (value.Type == JTokenType.Null)
+                if (value.GetValueKind() == JsonValueKind.Null)
                 {
                     result.RemoveBase();
                 }
                 // 5.7.3 - Otherwise, if value is an absolute IRI, the base IRI of result is set to value.
                 else if (JsonLdUtils.IsAbsoluteIri(value))
                 {
-                    result.Base = new Uri(value.Value<string>());
+                    result.Base = new Uri(value.GetValue<string>());
                 }
                 // 5.7.4 - Otherwise, if value is a relative IRI and the base IRI of result is not null, set the base IRI of result to the result of resolving
                 // value against the current base IRI of result.
@@ -263,7 +261,7 @@ internal class ContextProcessor : ProcessorBase
                 {
                     if (result.Base != null)
                     {
-                        result.Base = new Uri(result.Base, value.Value<string>());
+                        result.Base = new Uri(result.Base, value.GetValue<string>());
                     }
                     else
                     {
@@ -280,27 +278,27 @@ internal class ContextProcessor : ProcessorBase
 
 
             // 5.8 - If context has an @vocab key:
-            JProperty contextProperty = contextDefinition.Property("@vocab");
-            if (contextProperty != null)
+            if (contextDefinition.ContainsKey("@vocab"))
             {
                 // 5.8.1 - Initialize value to the value associated with the @vocab key.
-                JToken value = contextProperty.Value;
+                JsonNode value = contextDefinition["@vocab"];
+                JsonValueKind valueKind = value.GetValueKind();
                 // 5.8.2 - If value is null, remove any vocabulary mapping from result.
-                if (value.Type == JTokenType.Null)
+                if (valueKind == JsonValueKind.Null)
                 {
                     result.Vocab = null;
                 }
                 // 5.8.3 -Otherwise, if value is an IRI or blank node identifier, the vocabulary mapping of result is set to
                 // the result of IRI expanding value using true for document relative . If it is not an IRI, or a blank node
                 // identifier, an invalid vocab mapping error has been detected and processing is aborted. 
-                else if (value.Type != JTokenType.String)
+                else if (valueKind != JsonValueKind.String)
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidVocabMapping,
                         "The value of @vocab must be a string.");
                 }
                 else
                 {
-                    var str = value.Value<string>();
+                    var str = value.GetValue<string>();
                     if (JsonLdUtils.IsIri(str) || string.Empty.Equals(str) || JsonLdUtils.IsBlankNodeIdentifier(str))
                     {
                         // Expanding using result ensures that we expand relative to @base if it is specified
@@ -314,20 +312,19 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 5.9 - If context has an @language key
-            JProperty languageProperty = contextDefinition.Property("@language");
-            if (languageProperty != null)
+            if (contextDefinition.ContainsKey("@language"))
             {
                 // 5.9.1 - Initialize value to the value associated with the @language key.
-                JToken value = languageProperty.Value;
-                switch (value.Type)
+                JsonNode value = contextDefinition["@language"];
+                switch (value.GetValueKind())
                 {
-                    case JTokenType.Null:
+                    case JsonValueKind.Null:
                         // 5.9.2 - If value is null, remove any default language from result.
                         result.Language = null;
                         break;
-                    case JTokenType.String:
+                    case JsonValueKind.String:
                         // 5.9.3 - Otherwise, if value is string, the default language of result is set to value.
-                        result.Language = value.Value<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
+                        result.Language = value.GetValue<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
                         if (!LanguageTag.IsWellFormed(result.Language))
                         {
                             Warn(JsonLdErrorCode.MalformedLanguageTag,
@@ -342,27 +339,27 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 5.10 - If context has an @direction entry
-            JProperty directionProperty = contextDefinition.Property("@direction");
-            if (directionProperty != null)
+            if (contextDefinition.ContainsKey("@direction"))
             {
+                JsonNode directionProperty = contextDefinition["@direction"];
                 // 5.10.1 - If processing mode is json - ld - 1.0, an invalid context entry error has been detected and processing is aborted.
                 CheckProcessingMode("@direction");
                 // 5.10.2 - Initialize value to the value associated with the @direction entry.
                 // 5.10.3 - If value is null, remove any base direction from result.
                 // 5.10.4 - Otherwise, if value is a string, the base direction of result is set to value.
                 // If it is not null, "ltr", or "rtl", an invalid base direction error has been detected and processing is aborted.
-                result.BaseDirection = JsonLdUtils.ParseLanguageDirection(directionProperty.Value);
+                result.BaseDirection = JsonLdUtils.ParseLanguageDirection(directionProperty.GetValue<string>());
             }
 
             // 5.11 - context has an @propagate entry:
-            JProperty propagateProperty = contextDefinition.Property("@propagate");
-            if (propagateProperty != null)
+            if (contextDefinition.ContainsKey("@propagate"))
             {
+                JsonNode propagateProperty = contextDefinition["@propagate"];
                 // 5.11.1 - If processing mode is json - ld - 1.0, an invalid context entry error has been detected and processing is aborted.
                 CheckProcessingMode("@propagate", JsonLdErrorCode.InvalidContextEntry);
 
                 // 5.11.2 - Otherwise, if the value of @propagate is not boolean true or false, an invalid @propagate value error has been detected and processing is aborted.
-                if (propagateProperty.Value.Type != JTokenType.Boolean)
+                if (!JsonLdUtils.IsBooleanNode(propagateProperty))
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidPropagateValue,
                         "The value of @propagate must be a boolean");
@@ -376,23 +373,23 @@ internal class ContextProcessor : ProcessorBase
             // Create Term Definition algorithm, passing result for active context, context for local context, key, defined, base URL, the value of the @protected
             // entry from context, if any, for protected, override protected, and a copy of remote contexts. 
             var @protected = false;
-            JProperty protectedProperty = contextDefinition.Property("@protected");
-            if (protectedProperty != null)
+            if (contextDefinition.ContainsKey("@protected"))
             {
-                if (protectedProperty.Value.Type != JTokenType.Boolean)
+                var protectedValue = contextDefinition["@protected"];
+                if (!JsonLdUtils.IsBooleanNode(protectedValue))
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidProtectedValue,
                         "The value of @protected must be a boolean");
                 }
 
-                @protected = protectedProperty.Value.Value<bool>();
+                @protected = protectedValue.GetValue<bool>();
             }
-            foreach (JProperty property in contextDefinition.Properties())
+            foreach (var property in contextDefinition)
             {
-                var key = property.Name;
+                var key = property.Key;
                 if (!JsonLdKeywords.JsonLdContextKeywords.Contains(key))
                 {
-                    CreateTermDefinition(result, contextDefinition, key, defined, baseUrl, @protected, overrideProtected, new List<Uri>(remoteContexts));
+                    CreateTermDefinition(result, contextDefinition, key, defined, baseUrl, @protected, overrideProtected, [.. remoteContexts]);
                 }
             }
 
@@ -400,10 +397,11 @@ internal class ContextProcessor : ProcessorBase
         return result;
     }
 
-    private void CreateTermDefinition(JsonLdContext activeContext, JObject localContext, string term,
-Dictionary<string, bool> defined = null,
-Uri baseUrl = null, bool @protected = false, bool overrideProtected = false,
-List<Uri> remoteContexts = null, bool validateScopedContexts = true)
+    private void CreateTermDefinition(
+        JsonLdContext activeContext, JsonObject localContext, string term,
+        Dictionary<string, bool> defined = null,
+        Uri baseUrl = null, bool @protected = false, bool overrideProtected = false,
+        List<Uri> remoteContexts = null, bool validateScopedContexts = true)
     {
         if (defined == null) defined = [];
         if (remoteContexts == null) remoteContexts = [];
@@ -432,7 +430,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         defined[term] = false;
 
         // 3 - Initialize value to a copy of the value associated with the entry term in local context.
-        JToken v = localContext[term]?.DeepClone();
+        JsonNode v = localContext[term]?.DeepClone();
 
         // 4 - If term is @type, and processing mode is json-ld-1.0, a keyword redefinition error has been detected and processing is aborted.
         if (term.Equals("@type"))
@@ -468,26 +466,26 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         var simpleTerm = false;
 
         // 7 - If value is null, convert it to a map consisting of a single entry whose key is @id and whose value is null.
-        if (v == null || v.Type == JTokenType.Null)
+        if (v == null || v.GetValueKind() == JsonValueKind.Null)
         {
-            v = new JObject(new JProperty("@id", JValue.CreateNull()));
+            v = new JsonObject { ["@id"] = JsonValue.Create((bool?)null) };
         }
 
         // 8 - Otherwise, if value is a string, convert it to a map consisting of a single entry whose key is @id and whose value is value. Set simple term to true.
-        if (v.Type == JTokenType.String)
+        if (v.GetValueKind() == JsonValueKind.String)
         {
-            v = new JObject(new JProperty("@id", v));
+            v = new JsonObject { ["@id"] = v };
             simpleTerm = true;
         }
 
         // 9 - Otherwise, value MUST be a map, if not, an invalid term definition error has been detected and processing is aborted. Set simple term to false.
-        if (v.Type != JTokenType.Object)
+        if (v.GetValueKind() != JsonValueKind.Object)
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition,
                 "A term definition must be a string, a map or null.");
         }
 
-        var value = v as JObject;
+        var value = v as JsonObject;
 
         // 10 - Create a new term definition, definition, initializing prefix flag to false, protected to protected, and reverse property to false.
         var definition = new JsonLdTermDefinition { Prefix = false, Protected = @protected, Reverse = false };
@@ -496,22 +494,22 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         definition.Protected = GetProtectedProperty(value, @protected);
 
         // 12 - If value contains the key @type:
-        JToken typeValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@type");
+        JsonNode typeValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@type");
         if (typeValue != null)
         {
             // 12.1 Initialize type to the value associated with the @type key, which must be a string. Otherwise, an invalid type mapping error has been detected and processing is aborted.
-            if (typeValue.Type != JTokenType.String)
+            if (typeValue.GetValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeMapping,
-                    $"Invalid type mapping for term {term}. The @type value must be a string, got {typeValue.Type}");
+                    $"Invalid type mapping for term {term}. The @type value must be a string, got {typeValue.GetValueKind()}");
             }
 
             // 12.2 - Set type to the result of IRI expanding type, using local context, and defined.
-            var type = ExpandIri(activeContext, typeValue.Value<string>(), true, false, localContext, defined);
+            var type = ExpandIri(activeContext, typeValue.GetValue<string>(), true, false, localContext, defined);
             if ((type == "@json" || type == "@none") && Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeMapping,
-                    $"Invalid type mapping for term {term}. Unexpanded value was {typeValue.Value<string>()}, and the expanded type IRI is '{type}', but the JSON-LD Processing mode is set to 1.0 which does not support @none or @json types.");
+                    $"Invalid type mapping for term {term}. Unexpanded value was {typeValue.GetValue<string>()}, and the expanded type IRI is '{type}', but the JSON-LD Processing mode is set to 1.0 which does not support @none or @json types.");
             }
             if (type == "@id" || type == "@vocab" || type == "@json" || type == "@none" || JsonLdUtils.IsAbsoluteIri(type))
             {
@@ -521,12 +519,12 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             else
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeMapping,
-                    $"Invalid type mapping for term {term}. Expected @type value to expand to @id, @vocab, @json, @none or an absolute IRI. Unexpanded value was {typeValue.Value<string>()}, expanded value was {type}.");
+                    $"Invalid type mapping for term {term}. Expected @type value to expand to @id, @vocab, @json, @none or an absolute IRI. Unexpanded value was {typeValue.GetValue<string>()}, expanded value was {type}.");
             }
         }
 
-        JToken reverseValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@reverse");
-        JToken containerValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@container");
+        JsonNode reverseValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@reverse");
+        JsonNode containerValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@container");
         // 13 - If value contains the key @reverse:
         if (reverseValue != null)
         {
@@ -539,24 +537,24 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             }
 
             // 13.2 - If the value associated with the @reverse key is not a string, an invalid IRI mapping error has been detected and processing is aborted.
-            if (reverseValue.Type != JTokenType.String)
+            if (reverseValue.GetValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIriMapping,
                     $"@reverse property value must be a string on term {term}");
             }
 
             // 13.3 - If the value associated with the @reverse entry is a string having the form of a keyword (i.e., it matches the ABNF rule "@"1*ALPHA from [RFC5234]), return; processors SHOULD generate a warning.
-            if (JsonLdUtils.MatchesKeywordProduction(reverseValue.Value<string>()))
+            if (JsonLdUtils.MatchesKeywordProduction(reverseValue.GetValue<string>()))
             {
                 Warn(JsonLdErrorCode.InvalidIriMapping,
-                    "$@reverse property value on {term} matches the JSON-LD keyword production @[a-zA-Z]+.");
+                    $"@reverse property value on {term} matches the JSON-LD keyword production @[a-zA-Z]+.");
                 return;
             }
 
             // 13.4 - Otherwise, set the IRI mapping of definition to the result of IRI expanding the value associated with the @reverse entry, using local context,
             // and defined. If the result does not have the form of an IRI or a blank node identifier, an invalid IRI mapping error has been detected and processing
             // is aborted.
-            var iriMapping = ExpandIri(activeContext, reverseValue.Value<string>(), true, false, localContext, defined);
+            var iriMapping = ExpandIri(activeContext, reverseValue.GetValue<string>(), true, false, localContext, defined);
             if (iriMapping == null || !(JsonLdUtils.IsAbsoluteIri(iriMapping) || JsonLdUtils.IsBlankNodeIdentifier(iriMapping)))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIriMapping,
@@ -567,14 +565,15 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             // 13.5 - If value contains an @container entry, set the container mapping of definition to an array containing its value; if its value is neither @set, nor @index, nor null, an invalid reverse property error has been detected (reverse properties only support set- and index-containers) and processing is aborted.
             if (containerValue != null)
             {
-                if (containerValue.Type == JTokenType.Null)
+                JsonValueKind containerKind = containerValue.GetValueKind();
+                if (containerKind == JsonValueKind.Null)
                 {
                     definition.ContainerMapping.Clear();
                     definition.ContainerMapping.Add(JsonLdContainer.Null);
                 }
-                else if (containerValue.Type == JTokenType.String)
+                else if (containerKind == JsonValueKind.String)
                 {
-                    var containerMapping = containerValue.Value<string>();
+                    var containerMapping = containerValue.GetValue<string>();
                     if (containerMapping == "@set")
                     {
                         definition.ContainerMapping.Clear();
@@ -605,21 +604,22 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             defined[term] = true;
         }
         // 14 - Otherwise, if value contains the key @id and its value does not equal term:
-        else if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") is { } idValue && !term.Equals(idValue.Value<string>()))
+        else if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") is { } idValue && !term.Equals(idValue.GetValue<string>()))
         {
             // 14.1 - If the @id entry of value is null, the term is not used for IRI expansion, but is retained to be able to detect future redefinitions of this term.
             // 14.2 - Otherwise:
-            if (idValue.Type != JTokenType.Null)
+            JsonValueKind idValueKind = idValue.GetValueKind();
+            if (idValueKind != JsonValueKind.Null)
             {
                 // 14.2.1 - If the value associated with the @id entry is not a string, an invalid IRI mapping error has been detected and processing is aborted.
-                if (idValue.Type != JTokenType.String)
+                if (idValueKind != JsonValueKind.String)
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIriMapping,
                         $"Invalid IRI Mapping. The value of the @id property of term {term} must be a string.");
                 }
                 // 14.2.2 - If the value associated with the @id entry is not a keyword, but has the form of a keyword (i.e., it matches the ABNF rule "@"1*ALPHA from [RFC5234]), return;
                 // processors SHOULD generate a warning.
-                var idValueString = idValue.Value<string>();
+                var idValueString = idValue.GetValue<string>();
                 if (!JsonLdUtils.IsKeyword(idValueString) && JsonLdUtils.MatchesKeywordProduction(idValueString))
                 {
                     Warn(JsonLdErrorCode.InvalidIdValue,
@@ -627,7 +627,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
                     return;
                 }
                 // 14.2.3 - Otherwise, set the IRI mapping of definition to the result of IRI expanding the value associated with the @id entry, using local context, and defined.
-                var iriMapping = ExpandIri(activeContext, idValue.Value<string>(), vocab: true, documentRelative: false, localContext: localContext, defined: defined);
+                var iriMapping = ExpandIri(activeContext, idValue.GetValue<string>(), vocab: true, documentRelative: false, localContext: localContext, defined: defined);
 
                 // If the resulting IRI mapping is neither a keyword, nor an IRI, nor a blank node identifier, an invalid IRI mapping error has been detected and processing is aborted;
                 if (!JsonLdUtils.IsKeyword(iriMapping) && !JsonLdUtils.IsAbsoluteIri(iriMapping) && !JsonLdUtils.IsBlankNodeIdentifier(iriMapping))
@@ -680,7 +680,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             var rest = term.Substring(ix + 1);
             // 15.1 - If term is a compact IRI with a prefix that is an entry in local context a dependency has been found.
             // Use this algorithm recursively passing active context, local context, the prefix as term, and defined.
-            if (localContext.Property(prefix) != null)
+            if (!localContext.ContainsKey(prefix))
             {
                 CreateTermDefinition(activeContext, localContext, prefix, defined);
             }
@@ -750,7 +750,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             }
         }
         // 20 - If value contains the entry @index: 
-        JToken indexValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@index");
+        JsonNode indexValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@index");
         if (indexValue != null)
         {
             // 20.1 - If processing mode is json-ld-1.0 or container mapping does not include @index, an invalid term definition has been detected and processing is aborted.
@@ -766,12 +766,12 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
                     $"Invalid Term Definition. The definition of term '{term}' includes an @index entry, but the container mapping for the term does not include @index.");
             }
 
-            if (indexValue.Type != JTokenType.String)
+            if (indexValue.GetValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition,
                     $"Invalid Term Definition. The @index property on '{term}' must expand to an IRI.");
             }
-            var index = indexValue.Value<string>();
+            var index = indexValue.GetValue<string>();
             if (!JsonLdUtils.IsAbsoluteIri(ExpandIri(activeContext, index, vocab: true)))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition,
@@ -782,7 +782,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 21 - If value contains the entry @context: 
-        JToken contextValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@context");
+        JsonNode contextValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@context");
         if (contextValue != null)
         {
             // 21.1 - If processingMode is json-ld-1.0, an invalid term definition has been detected and processing is aborted.
@@ -792,7 +792,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
                     $"Invalid Term Definition for term '{term}'. The @context property is not supported on a term definition when the processing mode is JSON-LD 1.0.");
             }
             // 21.2 - Initialize context to the value associated with the @context key, which is treated as a local context.
-            JToken context = contextValue;
+            JsonNode context = contextValue;
 
             // 21.3 - Invoke the Context Processing algorithm using the active context and context as local context. If any error is detected, an invalid scoped context error has been detected and processing is aborted.
             try
@@ -811,20 +811,20 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 22 - if value contains the key @language and does not contain the key @type
-        JToken languageValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@language");
+        JsonNode languageValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@language");
         if (languageValue != null && typeValue == null)
         {
-            switch (languageValue.Type)
+            switch (languageValue.GetValueKind())
             {
                 // 22.1 - Initialize language to the value associated with the @language entry, which MUST be either null or a string.
                 // If language is not well-formed according to section 2.2.9 of [BCP47], processors SHOULD issue a warning.
                 // Otherwise, an invalid language mapping error has been detected and processing is aborted.
                 // 22.2 - Set the language mapping of definition to language. 
-                case JTokenType.Null:
+                case JsonValueKind.Null:
                     definition.LanguageMapping = null;
                     break;
-                case JTokenType.String:
-                    definition.LanguageMapping = languageValue.Value<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
+                case JsonValueKind.String:
+                    definition.LanguageMapping = languageValue.GetValue<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
                     if (!LanguageTag.IsWellFormed(definition.LanguageMapping))
                     {
                         Warn(JsonLdErrorCode.MalformedLanguageTag,
@@ -838,7 +838,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 23 - If value contains the entry @direction and does not contain the entry @type:
-        JToken directionValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@direction");
+        JsonNode directionValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@direction");
         if (directionValue != null && typeValue == null)
         {
             // 23.1 - Initialize direction to the value associated with the @direction entry, which MUST be either null, "ltr", or "rtl".Otherwise, an invalid base direction error has been detected and processing is aborted.
@@ -847,7 +847,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 24 - If value contains the key @nest:
-        JToken nestValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@nest");
+        JsonNode nestValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@nest");
         if (nestValue != null)
         {
             // 24.1 - If processingMode is json-ld-1.0, an invalid term definition has been detected and processing is aborted.
@@ -859,12 +859,12 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
 
             // 24.2 - Initialize nest to the value associated with the @nest key, which must be a string and must not be a keyword other than @nest.
             // Otherwise, an invalid @nest value error has been detected and processing is aborted.
-            if (nestValue.Type != JTokenType.String)
+            if (nestValue.GetValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidNestValue,
                     $"Invalid Nest Value for term '{term}'. The value of the @nest property must be a string.");
             }
-            var nest = nestValue.Value<string>();
+            var nest = nestValue.GetValue<string>();
             if (JsonLdUtils.IsKeyword(nest) && !"@nest".Equals(nest))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidNestValue,
@@ -874,7 +874,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 25 - If value contains the entry @prefix:
-        JToken prefixValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@prefix");
+        JsonNode prefixValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@prefix");
         if (prefixValue != null)
         {
             // 25.1 - If processing mode is json - ld - 1.0, or if term contains a colon(:) or slash(/), an invalid term definition has been detected and processing is aborted.
@@ -891,12 +891,12 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             }
 
             // 25.2 - Set the prefix flag to the value associated with the @prefix entry, which MUST be a boolean. Otherwise, an invalid @prefix value error has been detected and processing is aborted.
-            if (prefixValue.Type != JTokenType.Boolean)
+            if (!JsonLdUtils.IsBooleanNode(prefixValue))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidPrefixValue,
                     $"Invalid @prefix Value. The value of the @prefix property of the term '{term}' must be a boolean value.");
             }
-            definition.Prefix = prefixValue.Value<bool>();
+            definition.Prefix = prefixValue.GetValue<bool>();
 
             // 25.3 - If the prefix flag of definition is set to true, and its IRI mapping is a keyword, an invalid term definition has been detected and processing is aborted.
             if (definition.Prefix && JsonLdUtils.IsKeyword(definition.IriMapping))
@@ -907,7 +907,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
 
         // 26 - If the value contains any key other than @id, @reverse, @container, @context, @nest, or @type, an invalid term definition error has been detected and processing is aborted.
-        var unrecognizedKeys = value.Properties().Select(prop => prop.Name).Where(x => !JsonLdKeywords.TermDefinitionKeys.Contains(x)).ToList();
+        var unrecognizedKeys = value.Select(prop => prop.Key).Where(x => !JsonLdKeywords.TermDefinitionKeys.Contains(x)).ToList();
         if (unrecognizedKeys.Any())
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition, $"Invalid Term Definition for term '{term}'. Term definition contains unrecognised property key(s) {string.Join(", ", unrecognizedKeys)}");
@@ -941,7 +941,7 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
     /// <param name="localContext"></param>
     /// <param name="defined"></param>
     /// <returns></returns>
-    public string ExpandIri(JsonLdContext activeContext, string value, bool vocab = false, bool documentRelative = false, JObject localContext = null, Dictionary<string, bool> defined = null)
+    public string ExpandIri(JsonLdContext activeContext, string value, bool vocab = false, bool documentRelative = false, JsonObject localContext = null, Dictionary<string, bool> defined = null)
     {
         if (defined == null) defined = [];
 
@@ -996,8 +996,9 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
             // 6.3 If local context is not null, it contains a prefix entry, and the value of the prefix entry in defined is not true,
             // invoke the Create Term Definition algorithm, passing active context, local context, prefix as term, and defined.
             // This will ensure that a term definition is created for prefix in active context during Context Processing.
-            defined.TryGetValue(prefix, out var prefixDefined);
-            if (localContext?.Property(prefix) != null && !prefixDefined)
+            if (localContext != null &&
+                localContext.TryGetPropertyValue(prefix, out var prefixValue) &&
+                !defined.TryGetValue(prefix, out var definedValue))
             {
                 CreateTermDefinition(activeContext, localContext, prefix, defined);
             }
@@ -1032,20 +1033,20 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
     }
 
 
-    private static void ValidateTypeRedefinition(JToken value)
+    private static void ValidateTypeRedefinition(JsonNode value)
     {
         // At this point, value MUST be a map with only either or both of the following entries:
         //   An entry for @container with value @set.
         //   An entry for @protected.
         // Any other value means that a keyword redefinition error has been detected and processing is aborted.
-        var isValid = value.Type == JTokenType.Object;
+        var isValid = value.GetValueKind() == JsonValueKind.Object;
         if (isValid)
         {
             isValid = false;
-            var o = value as JObject;
-            foreach (JProperty p in o.Properties())
+            var o = value as JsonObject;
+            foreach (KeyValuePair<string, JsonNode> p in o)
             {
-                isValid = p.Name == "@container" ? "@set".Equals(p.Value.Value<string>()) : p.Name.Equals("@protected");
+                isValid = p.Key == "@container" ? "@set".Equals(p.Value.GetValue<string>()) : p.Key.Equals("@protected");
                 if (!isValid) break;
             }
         }
@@ -1057,51 +1058,51 @@ List<Uri> remoteContexts = null, bool validateScopedContexts = true)
         }
     }
 
-    private bool GetProtectedProperty(JObject map, bool defaultValue)
+    private bool GetProtectedProperty(JsonObject map, bool defaultValue)
     {
-        JProperty protectedProperty = map.Property("@protected");
-        if (protectedProperty == null) return defaultValue;
+        if (!map.ContainsKey("@protected")) return defaultValue;
         if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.ProcessingModeConflict,
                 "Processing mode conflict. Processor options specify JSON-LD 1.0 processing mode, but encountered @protected that requires JSON-LD 1.1 processing features");
         }
 
-        if (protectedProperty.Value.Type != JTokenType.Boolean)
+        JsonNode protectedProperty = map["@protected"];
+        if (!JsonLdUtils.IsBooleanNode(protectedProperty))
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidProtectedValue,
                 "The value of @protected must be a boolean true or false.");
         }
 
-        return protectedProperty.Value.Value<bool>();
+        return protectedProperty.GetValue<bool>();
     }
 
-    private ISet<JsonLdContainer> ValidateContainerMapping(string term, JToken containerValue)
+    private ISet<JsonLdContainer> ValidateContainerMapping(string term, JsonNode containerValue)
     {
         // 19.1 Initialize container to the value associated with the @container entry, which MUST be either @graph, @id, @index, @language, @list, @set, @type,
         // or an array containing exactly any one of those keywords, an array containing @graph and either @id or @index optionally including @set,
         // or an array containing a combination of @set and any of @index, @graph, @id, @type, @language in any order.
         // Otherwise, an invalid container mapping has been detected and processing is aborted.
         var containerMapping = new HashSet<JsonLdContainer>();
-        switch (containerValue.Type)
+        switch (containerValue.GetValueKind())
         {
-            case JTokenType.String:
-                containerMapping.Add(ParseContainerMapping(term, containerValue.Value<string>()));
+            case JsonValueKind.String:
+                containerMapping.Add(ParseContainerMapping(term, containerValue.GetValue<string>()));
                 break;
-            case JTokenType.Array when Options.ProcessingMode == JsonLdProcessingMode.JsonLd10:
+            case JsonValueKind.Array when Options.ProcessingMode == JsonLdProcessingMode.JsonLd10:
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidContainerMapping,
                     $"Invalid Container Mapping. The value of the @container property of term '{term}' is an array, but the processing mode is set to JSON-LD 1.0.");
-            case JTokenType.Array:
+            case JsonValueKind.Array:
                 {
-                    foreach (JToken entry in containerValue.Children())
+                    foreach (JsonNode entry in containerValue.AsArray())
                     {
-                        if (entry.Type != JTokenType.String)
+                        if (entry.GetValueKind() != JsonValueKind.String)
                         {
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidContainerMapping,
                                 $"Invalid Container Mapping. The value of the @container property of term '{term}' is an array containing non-string entries.");
                         }
 
-                        containerMapping.Add(ParseContainerMapping(term, entry.Value<string>()));
+                        containerMapping.Add(ParseContainerMapping(term, entry.GetValue<string>()));
                     }
 
                     break;

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
@@ -112,7 +112,7 @@ internal class ContextProcessor : ProcessorBase
         // 5. For each item context in local context:
         foreach (JsonNode context in (JsonArray)localContext)
         {
-            var contextKind = context.GetValueKind();
+            var contextKind = context.SafeValueKind();
             // 5.1 if context is null:
             if (contextKind == JsonValueKind.Null)
             {
@@ -193,7 +193,7 @@ internal class ContextProcessor : ProcessorBase
             if (contextDefinition.ContainsKey("@version"))
             {
                 // 5.5.1 - If the associated value is not 1.1, an invalid @version value has been detected, and processing is aborted.
-                var versionValue = contextDefinition["@version"].GetValue<string>();
+                var versionValue = contextDefinition["@version"].ToString();
                 if (!"1.1".Equals(versionValue))
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidVersionValue, $"Found invalid value for @version property: {versionValue}.");
@@ -214,7 +214,7 @@ internal class ContextProcessor : ProcessorBase
                 CheckProcessingMode("@import", JsonLdErrorCode.InvalidContextEntry);
 
                 // 5.6.2 - Otherwise, if the value of @import is not a string, an invalid @import value error has been detected and processing is aborted.
-                if (importProperty.GetValueKind() != JsonValueKind.String)
+                if (importProperty.SafeValueKind() != JsonValueKind.String)
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidImportValue,
                         "The value of an @import property must be a string");
@@ -246,7 +246,7 @@ internal class ContextProcessor : ProcessorBase
                 // 5.7.1 - Initialize value to the value associated with the @base entry.
                 JsonNode value = contextDefinition["@base"];
                 // 5.7.2 - If value is null, remove the base IRI of result.
-                if (value.GetValueKind() == JsonValueKind.Null)
+                if (value.SafeValueKind() == JsonValueKind.Null)
                 {
                     result.RemoveBase();
                 }
@@ -282,7 +282,7 @@ internal class ContextProcessor : ProcessorBase
             {
                 // 5.8.1 - Initialize value to the value associated with the @vocab key.
                 JsonNode value = contextDefinition["@vocab"];
-                JsonValueKind valueKind = value.GetValueKind();
+                JsonValueKind valueKind = value.SafeValueKind();
                 // 5.8.2 - If value is null, remove any vocabulary mapping from result.
                 if (valueKind == JsonValueKind.Null)
                 {
@@ -316,25 +316,32 @@ internal class ContextProcessor : ProcessorBase
             {
                 // 5.9.1 - Initialize value to the value associated with the @language key.
                 JsonNode value = contextDefinition["@language"];
-                switch (value.GetValueKind())
+                if (value == null)
                 {
-                    case JsonValueKind.Null:
-                        // 5.9.2 - If value is null, remove any default language from result.
-                        result.Language = null;
-                        break;
-                    case JsonValueKind.String:
-                        // 5.9.3 - Otherwise, if value is string, the default language of result is set to value.
-                        result.Language = value.GetValue<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
-                        if (!LanguageTag.IsWellFormed(result.Language))
-                        {
-                            Warn(JsonLdErrorCode.MalformedLanguageTag,
-                                $"The value of the @language property ({result.Language}) is not a well-formed BCP-47 language tag.");
-                        }
-                        break;
-                    default:
-                        // 5.9.3 (cont) - If it is not a string, an invalid default language error has been detected and processing is aborted.
-                        throw new JsonLdProcessorException(JsonLdErrorCode.InvalidDefaultLanguage,
-                            "@language property value must be a JSON string or null.");
+                    result.Language = null;
+                }
+                else 
+                {
+                    switch (value.SafeValueKind())
+                    {
+                        case JsonValueKind.Null:
+                            // 5.9.2 - If value is null, remove any default language from result.
+                            result.Language = null;
+                            break;
+                        case JsonValueKind.String:
+                            // 5.9.3 - Otherwise, if value is string, the default language of result is set to value.
+                            result.Language = value.GetValue<string>().ToLowerInvariant(); // Processors MAY normalize language tags to lower case.
+                            if (!LanguageTag.IsWellFormed(result.Language))
+                            {
+                                Warn(JsonLdErrorCode.MalformedLanguageTag,
+                                    $"The value of the @language property ({result.Language}) is not a well-formed BCP-47 language tag.");
+                            }
+                            break;
+                        default:
+                            // 5.9.3 (cont) - If it is not a string, an invalid default language error has been detected and processing is aborted.
+                            throw new JsonLdProcessorException(JsonLdErrorCode.InvalidDefaultLanguage,
+                                "@language property value must be a JSON string or null.");
+                    }
                 }
             }
 
@@ -466,20 +473,20 @@ internal class ContextProcessor : ProcessorBase
         var simpleTerm = false;
 
         // 7 - If value is null, convert it to a map consisting of a single entry whose key is @id and whose value is null.
-        if (v == null || v.GetValueKind() == JsonValueKind.Null)
+        if (v == null || v.SafeValueKind() == JsonValueKind.Null)
         {
             v = new JsonObject { ["@id"] = JsonValue.Create((bool?)null) };
         }
 
         // 8 - Otherwise, if value is a string, convert it to a map consisting of a single entry whose key is @id and whose value is value. Set simple term to true.
-        if (v.GetValueKind() == JsonValueKind.String)
+        if (v.SafeValueKind() == JsonValueKind.String)
         {
             v = new JsonObject { ["@id"] = v };
             simpleTerm = true;
         }
 
         // 9 - Otherwise, value MUST be a map, if not, an invalid term definition error has been detected and processing is aborted. Set simple term to false.
-        if (v.GetValueKind() != JsonValueKind.Object)
+        if (v.SafeValueKind() != JsonValueKind.Object)
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition,
                 "A term definition must be a string, a map or null.");
@@ -498,10 +505,10 @@ internal class ContextProcessor : ProcessorBase
         if (typeValue != null)
         {
             // 12.1 Initialize type to the value associated with the @type key, which must be a string. Otherwise, an invalid type mapping error has been detected and processing is aborted.
-            if (typeValue.GetValueKind() != JsonValueKind.String)
+            if (typeValue.SafeValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeMapping,
-                    $"Invalid type mapping for term {term}. The @type value must be a string, got {typeValue.GetValueKind()}");
+                    $"Invalid type mapping for term {term}. The @type value must be a string, got {typeValue.SafeValueKind()}");
             }
 
             // 12.2 - Set type to the result of IRI expanding type, using local context, and defined.
@@ -537,7 +544,7 @@ internal class ContextProcessor : ProcessorBase
             }
 
             // 13.2 - If the value associated with the @reverse key is not a string, an invalid IRI mapping error has been detected and processing is aborted.
-            if (reverseValue.GetValueKind() != JsonValueKind.String)
+            if (reverseValue.SafeValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIriMapping,
                     $"@reverse property value must be a string on term {term}");
@@ -565,7 +572,7 @@ internal class ContextProcessor : ProcessorBase
             // 13.5 - If value contains an @container entry, set the container mapping of definition to an array containing its value; if its value is neither @set, nor @index, nor null, an invalid reverse property error has been detected (reverse properties only support set- and index-containers) and processing is aborted.
             if (containerValue != null)
             {
-                JsonValueKind containerKind = containerValue.GetValueKind();
+                JsonValueKind containerKind = containerValue.SafeValueKind();
                 if (containerKind == JsonValueKind.Null)
                 {
                     definition.ContainerMapping.Clear();
@@ -604,11 +611,11 @@ internal class ContextProcessor : ProcessorBase
             defined[term] = true;
         }
         // 14 - Otherwise, if value contains the key @id and its value does not equal term:
-        else if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") is { } idValue && !term.Equals(idValue.GetValue<string>()))
+        else if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") is { } idValue && (!JsonLdUtils.IsString(value) || !term.Equals(idValue.GetValue<string>())))
         {
             // 14.1 - If the @id entry of value is null, the term is not used for IRI expansion, but is retained to be able to detect future redefinitions of this term.
             // 14.2 - Otherwise:
-            JsonValueKind idValueKind = idValue.GetValueKind();
+            JsonValueKind idValueKind = idValue.SafeValueKind();
             if (idValueKind != JsonValueKind.Null)
             {
                 // 14.2.1 - If the value associated with the @id entry is not a string, an invalid IRI mapping error has been detected and processing is aborted.
@@ -680,7 +687,7 @@ internal class ContextProcessor : ProcessorBase
             var rest = term.Substring(ix + 1);
             // 15.1 - If term is a compact IRI with a prefix that is an entry in local context a dependency has been found.
             // Use this algorithm recursively passing active context, local context, the prefix as term, and defined.
-            if (!localContext.ContainsKey(prefix))
+            if (localContext.ContainsKey(prefix))
             {
                 CreateTermDefinition(activeContext, localContext, prefix, defined);
             }
@@ -766,7 +773,7 @@ internal class ContextProcessor : ProcessorBase
                     $"Invalid Term Definition. The definition of term '{term}' includes an @index entry, but the container mapping for the term does not include @index.");
             }
 
-            if (indexValue.GetValueKind() != JsonValueKind.String)
+            if (indexValue.SafeValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTermDefinition,
                     $"Invalid Term Definition. The @index property on '{term}' must expand to an IRI.");
@@ -814,7 +821,7 @@ internal class ContextProcessor : ProcessorBase
         JsonNode languageValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@language");
         if (languageValue != null && typeValue == null)
         {
-            switch (languageValue.GetValueKind())
+            switch (languageValue.SafeValueKind())
             {
                 // 22.1 - Initialize language to the value associated with the @language entry, which MUST be either null or a string.
                 // If language is not well-formed according to section 2.2.9 of [BCP47], processors SHOULD issue a warning.
@@ -859,7 +866,7 @@ internal class ContextProcessor : ProcessorBase
 
             // 24.2 - Initialize nest to the value associated with the @nest key, which must be a string and must not be a keyword other than @nest.
             // Otherwise, an invalid @nest value error has been detected and processing is aborted.
-            if (nestValue.GetValueKind() != JsonValueKind.String)
+            if (nestValue.SafeValueKind() != JsonValueKind.String)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidNestValue,
                     $"Invalid Nest Value for term '{term}'. The value of the @nest property must be a string.");
@@ -1039,7 +1046,7 @@ internal class ContextProcessor : ProcessorBase
         //   An entry for @container with value @set.
         //   An entry for @protected.
         // Any other value means that a keyword redefinition error has been detected and processing is aborted.
-        var isValid = value.GetValueKind() == JsonValueKind.Object;
+        var isValid = value.SafeValueKind() == JsonValueKind.Object;
         if (isValid)
         {
             isValid = false;
@@ -1084,7 +1091,7 @@ internal class ContextProcessor : ProcessorBase
         // or an array containing a combination of @set and any of @index, @graph, @id, @type, @language in any order.
         // Otherwise, an invalid container mapping has been detected and processing is aborted.
         var containerMapping = new HashSet<JsonLdContainer>();
-        switch (containerValue.GetValueKind())
+        switch (containerValue.SafeValueKind())
         {
             case JsonValueKind.String:
                 containerMapping.Add(ParseContainerMapping(term, containerValue.GetValue<string>()));
@@ -1096,7 +1103,7 @@ internal class ContextProcessor : ProcessorBase
                 {
                     foreach (JsonNode entry in containerValue.AsArray())
                     {
-                        if (entry.GetValueKind() != JsonValueKind.String)
+                        if (entry.SafeValueKind() != JsonValueKind.String)
                         {
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidContainerMapping,
                                 $"Invalid Container Mapping. The value of the @container property of term '{term}' is an array containing non-string entries.");

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ContextProcessor.cs
@@ -501,8 +501,7 @@ internal class ContextProcessor : ProcessorBase
         definition.Protected = GetProtectedProperty(value, @protected);
 
         // 12 - If value contains the key @type:
-        JsonNode typeValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@type");
-        if (typeValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@type", out JsonNode typeValue))
         {
             // 12.1 Initialize type to the value associated with the @type key, which must be a string. Otherwise, an invalid type mapping error has been detected and processing is aborted.
             if (typeValue.SafeValueKind() != JsonValueKind.String)
@@ -530,14 +529,12 @@ internal class ContextProcessor : ProcessorBase
             }
         }
 
-        JsonNode reverseValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@reverse");
-        JsonNode containerValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@container");
         // 13 - If value contains the key @reverse:
-        if (reverseValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@reverse", out JsonNode reverseValue))
         {
             // 13.1 - If value contains @id or @nest, members, an invalid reverse property error has been detected and processing is aborted.
-            if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") != null ||
-                JsonLdUtils.GetPropertyValue(activeContext, value, "@nest") != null)
+            if (JsonLdUtils.HasProperty(activeContext, value, "@id") ||
+                JsonLdUtils.HasProperty(activeContext, value, "@nest"))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidReverseProperty,
                     $"Invalid reverse property. The @reverse property cannot be combined with @id or @nest property on term {term}.");
@@ -570,9 +567,9 @@ internal class ContextProcessor : ProcessorBase
             definition.IriMapping = iriMapping;
 
             // 13.5 - If value contains an @container entry, set the container mapping of definition to an array containing its value; if its value is neither @set, nor @index, nor null, an invalid reverse property error has been detected (reverse properties only support set- and index-containers) and processing is aborted.
-            if (containerValue != null)
+            if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@container", out JsonNode containerEntry))
             {
-                JsonValueKind containerKind = containerValue.SafeValueKind();
+                JsonValueKind containerKind = containerEntry.SafeValueKind();
                 if (containerKind == JsonValueKind.Null)
                 {
                     definition.ContainerMapping.Clear();
@@ -580,7 +577,7 @@ internal class ContextProcessor : ProcessorBase
                 }
                 else if (containerKind == JsonValueKind.String)
                 {
-                    var containerMapping = containerValue.GetValue<string>();
+                    var containerMapping = containerEntry.GetValue<string>();
                     if (containerMapping == "@set")
                     {
                         definition.ContainerMapping.Clear();
@@ -611,7 +608,8 @@ internal class ContextProcessor : ProcessorBase
             defined[term] = true;
         }
         // 14 - Otherwise, if value contains the key @id and its value does not equal term:
-        else if (JsonLdUtils.GetPropertyValue(activeContext, value, "@id") is { } idValue && (!JsonLdUtils.IsString(value) || !term.Equals(idValue.GetValue<string>())))
+        else if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@id", out JsonNode idValue) &&
+                    (!JsonLdUtils.IsString(value) || !term.Equals(idValue.GetValue<string>())))
         {
             // 14.1 - If the @id entry of value is null, the term is not used for IRI expansion, but is retained to be able to detect future redefinitions of this term.
             // 14.2 - Otherwise:
@@ -735,7 +733,7 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 19 - if value contains the key @container
-        if (containerValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@container", out JsonNode containerValue))
         {
             // 19.1 Initialize container to the value associated with the @container entry, which MUST be either @graph, @id, @index, @language, @list, @set, @type, or an array containing exactly any one of those keywords, an array containing @graph and either @id or @index optionally including @set, or an array containing a combination of @set and any of @index, @graph, @id, @type, @language in any order . Otherwise, an invalid container mapping has been detected and processing is aborted.
             // 19.2 If the container value is @graph, @id, or @type, or is otherwise not a string, generate an invalid container mapping error and abort processing if processing mode is json - ld - 1.0.
@@ -757,8 +755,7 @@ internal class ContextProcessor : ProcessorBase
             }
         }
         // 20 - If value contains the entry @index: 
-        JsonNode indexValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@index");
-        if (indexValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@index", out JsonNode indexValue))
         {
             // 20.1 - If processing mode is json-ld-1.0 or container mapping does not include @index, an invalid term definition has been detected and processing is aborted.
             if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
@@ -789,8 +786,7 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 21 - If value contains the entry @context: 
-        JsonNode contextValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@context");
-        if (contextValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@context", out JsonNode contextValue))
         {
             // 21.1 - If processingMode is json-ld-1.0, an invalid term definition has been detected and processing is aborted.
             if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
@@ -818,8 +814,8 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 22 - if value contains the key @language and does not contain the key @type
-        JsonNode languageValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@language");
-        if (languageValue != null && typeValue == null)
+        if (!JsonLdUtils.HasProperty(activeContext, value, "@type") &&
+            JsonLdUtils.TryGetPropertyValue(activeContext, value, "@language", out JsonNode languageValue))
         {
             switch (languageValue.SafeValueKind())
             {
@@ -845,8 +841,8 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 23 - If value contains the entry @direction and does not contain the entry @type:
-        JsonNode directionValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@direction");
-        if (directionValue != null && typeValue == null)
+        if (!JsonLdUtils.HasProperty(activeContext, value, "@type") &&
+            JsonLdUtils.TryGetPropertyValue(activeContext, value, "@direction", out JsonNode directionValue))
         {
             // 23.1 - Initialize direction to the value associated with the @direction entry, which MUST be either null, "ltr", or "rtl".Otherwise, an invalid base direction error has been detected and processing is aborted.
             // 23.2 - Set the direction mapping of definition to direction.
@@ -854,8 +850,7 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 24 - If value contains the key @nest:
-        JsonNode nestValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@nest");
-        if (nestValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@nest", out JsonNode nestValue))
         {
             // 24.1 - If processingMode is json-ld-1.0, an invalid term definition has been detected and processing is aborted.
             if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
@@ -881,8 +876,7 @@ internal class ContextProcessor : ProcessorBase
         }
 
         // 25 - If value contains the entry @prefix:
-        JsonNode prefixValue = JsonLdUtils.GetPropertyValue(activeContext, value, "@prefix");
-        if (prefixValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, value, "@prefix", out JsonNode prefixValue))
         {
             // 25.1 - If processing mode is json - ld - 1.0, or if term contains a colon(:) or slash(/), an invalid term definition has been detected and processing is aborted.
             if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
@@ -27,7 +27,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 using VDS.RDF.Parsing;
 
@@ -55,13 +56,13 @@ internal class ExpandProcessor : ProcessorBase
     /// <param name="ordered"></param>
     /// <param name="fromMap"></param>
     /// <returns></returns>
-    public JToken ExpandElement(JsonLdContext activeContext, string activeProperty, JToken element, Uri baseUrl,
+    public JsonNode ExpandElement(JsonLdContext activeContext, string activeProperty, JsonNode element, Uri baseUrl,
         bool frameExpansion = false, bool ordered = false, bool fromMap = false)
     {
-        JToken result;
+        JsonNode result;
 
         // 1 - If element is null, return null.
-        if (element.Type == JTokenType.Null)
+        if (element == null || element.GetValueKind() == JsonValueKind.Null)
         {
             return null;
         }
@@ -73,7 +74,7 @@ internal class ExpandProcessor : ProcessorBase
         var hasTermDefinition = activeProperty != null && activeContext.TryGetTerm(activeProperty,
             out activePropertyTermDefinition);
         // 3 - If active property has a term definition in active context with a local context, initialize property-scoped context to that local context.
-        JToken propertyScopedContext = null;
+        JsonNode propertyScopedContext = null;
         if (hasTermDefinition && activePropertyTermDefinition.LocalContext != null)
         {
             propertyScopedContext = activePropertyTermDefinition.LocalContext;
@@ -97,31 +98,31 @@ internal class ExpandProcessor : ProcessorBase
         }
 
         // 5 - If element is an array,
-        if (element is JArray elementArray)
+        if (element is JsonArray elementArray)
         {
             // 5.1 - Initialize an empty array, result.
-            result = new JArray();
-            var resultArray = (JArray)result;
+            result = new JsonArray();
+            var resultArray = (JsonArray)result;
 
             // 5.2 - For each item in element:
-            foreach (JToken item in elementArray)
+            foreach (JsonNode item in elementArray)
             {
                 // 5.2.1 - Initialize expanded item to the result of using this algorithm recursively, passing active context, active property, and item as element.
-                JToken expandedItem = ExpandElement(activeContext, activeProperty, item, baseUrl, frameExpansion, ordered, fromMap);
+                JsonNode expandedItem = ExpandElement(activeContext, activeProperty, item, baseUrl, frameExpansion, ordered, fromMap);
                 if (expandedItem != null)
                 {
                     // 5.2.2 - If the container mapping of active property includes @list, and expanded item is an array, set expanded item to a new map
                     // containing the entry @list where the value is the original expanded item.
                     if (hasTermDefinition &&
                         activePropertyTermDefinition.ContainerMapping.Contains(JsonLdContainer.List) &&
-                        expandedItem.Type == JTokenType.Array)
+                        expandedItem is JsonArray)
                     {
-                        expandedItem = new JObject(new JProperty("@list", expandedItem));
+                        expandedItem = new JsonObject {["@list"] = expandedItem };
                     }
                     // 5.2.3 - If expanded item is an array, append each of its items to result. Otherwise, if expanded item is not null, append it to result.
-                    if (expandedItem is JArray expandedItemArray)
+                    if (expandedItem is JsonArray expandedItemArray)
                     {
-                        foreach (JToken arrayItem in expandedItemArray)
+                        foreach (JsonNode arrayItem in expandedItemArray)
                         {
                             resultArray.Add(arrayItem);
                         }
@@ -137,7 +138,7 @@ internal class ExpandProcessor : ProcessorBase
         }
 
         // 6 - Otherwise element is a map.
-        var elementObject = element as JObject;
+        var elementObject = element as JsonObject;
 
         // 7 - If active context has a previous context, the active context is not propagated.
         // If from map is undefined or false, and element does not contain an entry expanding to @value,
@@ -160,7 +161,7 @@ internal class ExpandProcessor : ProcessorBase
         // 9 - If element contains the key @context, set active context to the 
         // result of the Context Processing algorithm, passing active context 
         // and the value of the @context key as local context.
-        JToken contextValue = JsonLdUtils.GetPropertyValue(activeContext, elementObject, "@context");
+        JsonNode contextValue = JsonLdUtils.GetPropertyValue(activeContext, elementObject, "@context");
         if (contextValue != null)
         {
             activeContext = _contextProcessor.ProcessContext(activeContext, contextValue, baseUrl);
@@ -170,17 +171,17 @@ internal class ExpandProcessor : ProcessorBase
         JsonLdContext typeScopedContext = activeContext;
 
         // 11 - For each key/value pair in element ordered lexicographically by key where key expands to @type using the IRI Expansion algorithm, passing active context, key for value, and true for vocab:
-        var typeProperties = elementObject.Properties().Where(property => "@type".Equals(_contextProcessor.ExpandIri(activeContext, property.Name, true))).OrderBy(p => p.Name).ToList();
-        foreach (JProperty property in typeProperties)
+        var typeProperties = elementObject.Where(property => "@type".Equals(_contextProcessor.ExpandIri(activeContext, property.Key, true))).OrderBy(p => p.Key).ToList();
+        foreach (var property in typeProperties)
         {
             // 11.1 Convert value into an array, if necessary.
-            JArray values = property.Value.Type == JTokenType.Array ? property.Value as JArray : new JArray(property.Value);
+            JsonArray values = property.Value as JsonArray ?? new JsonArray(property.Value);
             // 11.2 For each term which is a value of value ordered lexicographically
-            foreach (JToken term in values.OrderBy(v => v))
+            foreach (JsonNode term in values.OrderBy(v => v))
             {
                 // if term is a string, and term's term definition in type-scoped context has a local context, set active context to the result Context Processing algorithm, passing active context, the value of the term's local context as local context, base URL from the term definition for value in active context, and false for propagate.
-                if (term.Type == JTokenType.String &&
-                    typeScopedContext.TryGetTerm(term.Value<string>(), out JsonLdTermDefinition termDefinition) &&
+                if (term.GetValueKind() == JsonValueKind.String &&
+                    typeScopedContext.TryGetTerm(term.GetValue<string>(), out JsonLdTermDefinition termDefinition) &&
                     termDefinition.LocalContext != null)
                 {
                     activeContext = _contextProcessor.ProcessContext(activeContext, termDefinition.LocalContext,
@@ -191,19 +192,18 @@ internal class ExpandProcessor : ProcessorBase
 
         // 12 - Initialize two empty maps, result and nests. Initialize input type to expansion of the last value of the first entry in element expanding to @type (if any), ordering entries lexicographically by key. Both the key and value of the matched entry are IRI expanded. 
         // NOTE: nests is only used in steps 13/14 so is initialized in ExpandElement
-        result = new JObject();
-        var resultObject = result as JObject;
-        JProperty firstTypeProperty = elementObject.Properties()
-            .OrderBy(p => p.Name).FirstOrDefault(p => "@type".Equals(_contextProcessor.ExpandIri(activeContext, p.Name, true)));
-        JToken inputType = null;
-        if (firstTypeProperty != null)
+        result = new JsonObject();
+        var resultObject = result as JsonObject;
+        KeyValuePair<string, JsonNode> firstTypeProperty = elementObject.OrderBy(p => p.Key).FirstOrDefault(p => "@type".Equals(_contextProcessor.ExpandIri(activeContext, p.Key, true)));
+        JsonNode inputType = null;
+        if (!firstTypeProperty.Equals(default(KeyValuePair<string, JsonNode>)))
         {
-            inputType = firstTypeProperty.Value is JArray typeArray
+            inputType = firstTypeProperty.Value is JsonArray typeArray
                 ? (typeArray.Count > 0 ? typeArray[typeArray.Count - 1] : null)
                 : firstTypeProperty.Value;
-            if (inputType is JValue) // Don't try to expand a framing wildcard
+            if (inputType.GetValueKind() == JsonValueKind.String) // Don't try to expand a framing wildcard
             {
-                inputType = _contextProcessor.ExpandIri(activeContext, inputType.Value<string>(), true);
+                inputType = _contextProcessor.ExpandIri(activeContext, inputType.GetValue<string>(), true);
             }
         }
 
@@ -214,7 +214,7 @@ internal class ExpandProcessor : ProcessorBase
         if (resultObject.ContainsKey("@value"))
         {
             // 15.1 - The result must not contain any entries other than @direction, @index, @language, @type, and @value. It must not contain an @type entry if it contains either @language or @direction entries. Otherwise, an invalid value object error has been detected and processing is aborted.
-            if (resultObject.Properties().Any(p => !JsonLdKeywords.ValueObjectKeys.Contains(p.Name)))
+            if (resultObject.Any(p => !JsonLdKeywords.ValueObjectKeys.Contains(p.Key)))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidValueObject,
                     $"Invalid value object. Expanding the value of {activeProperty} resulted in a value object with additional properties.");
@@ -225,19 +225,19 @@ internal class ExpandProcessor : ProcessorBase
                     $"Invalid value object. The expansion of {activeProperty} resulted in a value object with both @type and either @language or @direction.");
             }
 
-            JToken resultType = resultObject.ContainsKey("@type") ? resultObject["@type"] : null;
-            JToken resultValue = resultObject["@value"];
+            JsonNode resultType = resultObject.ContainsKey("@type") ? resultObject["@type"] : null;
+            JsonNode resultValue = resultObject["@value"];
             // If the result's @type entry is @json, then the @value entry may contain any value, and is treated as a JSON literal.
-            if (resultType != null && resultType.Type == JTokenType.String && resultType.Value<string>().Equals("@json"))
+            if (resultType != null && resultType.GetValueKind() == JsonValueKind.String && resultType.GetValue<string>().Equals("@json"))
             {
                 // No-op
             }
             // Otherwise, if the value of result's @value entry is null, or an empty array, return null.
-            else if (resultValue == null || resultValue.Type == JTokenType.Null || resultValue is JArray resultArray && resultArray.Count == 0)
+            else if (resultValue == null || resultValue.GetValueKind() == JsonValueKind.Null || resultValue is JsonArray resultArray && resultArray.Count == 0)
             {
                 return null;
             }
-            else if (resultObject.ContainsKey("@language") && resultValue.Type != JTokenType.String && !frameExpansion) // KA: in frame expansion @language could be an empty object or array
+            else if (resultObject.ContainsKey("@language") && resultValue.GetValueKind() != JsonValueKind.String && !frameExpansion) // KA: in frame expansion @language could be an empty object or array
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidLanguageTaggedValue,
                     $"Invalid language-tagged value. The expansion of {activeProperty} has an @language entry, but its @value entry is not a JSON string.");
@@ -257,7 +257,7 @@ internal class ExpandProcessor : ProcessorBase
         else if (resultObject.ContainsKey("@set"))
         {
             // 17.1 - The result must contain at most one other entry which must be @index. Otherwise, an invalid set or list object error has been detected and processing is aborted.
-            if (resultObject.Properties().Any(p => p.Name != "@set" && p.Name != "@index"))
+            if (resultObject.Any(p => p.Key != "@set" && p.Key != "@index"))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidSetOrListObject,
                     $"Invalid set or list object. The expansion of {activeProperty} resulted in a set object that has a property other than @set and @index.");
@@ -268,27 +268,27 @@ internal class ExpandProcessor : ProcessorBase
         else if (resultObject.ContainsKey("@list"))
         {
             // 17.1 - The result must contain at most one other entry which must be @index. Otherwise, an invalid set or list object error has been detected and processing is aborted.
-            if (resultObject.Properties().Any(p => p.Name != "@list" && p.Name != "@index"))
+            if (resultObject.Any(p => p.Key != "@list" && p.Key != "@index"))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidSetOrListObject,
                     $"Invalid set or list object. The expansion of {activeProperty} resulted in a list object that has a property other than @list and @index.");
             }
         }
         // 18 - If result is a map that contains only the entry @language, return null.
-        if (result is JObject o && o.ContainsKey("@language") && o.Count == 1)
+        if (result is JsonObject o && o.ContainsKey("@language") && o.Count == 1)
         {
             return null;
         }
         // 19 - If active property is null or @graph, drop free-floating values as follows:
         if (activeProperty == null || activeProperty.Equals("@graph"))
         {
-            resultObject = result as JObject;
+            resultObject = result as JsonObject;
             if (resultObject != null)
             {
                 // 19.1 - If result is a map which is empty, or contains only the entries @value or @list, set result to null.
                 // KA: Confirmed that the filter should apply whenever resultObject contains @value or @list (not just when they are the only properties)
                 if (resultObject.Count == 0 ||
-                    resultObject.Properties().Any(p => p.Name.Equals("@value") || p.Name.Equals("@list")))
+                    resultObject.Any(p => p.Key.Equals("@value") || p.Key.Equals("@list")))
                 {
                     if (!frameExpansion)
                     {
@@ -308,16 +308,16 @@ internal class ExpandProcessor : ProcessorBase
     }
 
     private void ExpandNestedElement(
-        JObject resultObject, JToken inputType, JsonLdContext activeContext, string activeProperty, Uri baseUrl,
+        JsonObject resultObject, JsonNode inputType, JsonLdContext activeContext, string activeProperty, Uri baseUrl,
         bool frameExpansion,
-        bool ordered, JObject elementObject, JsonLdContext typeScopedContext
+        bool ordered, JsonObject elementObject, JsonLdContext typeScopedContext
     )
     {
         // 3 - If active property has a term definition in active context with a local context, initialize property-scoped context to that local context.
         JsonLdTermDefinition activePropertyTermDefinition = null;
         var hasTermDefinition = activeProperty != null && activeContext.TryGetTerm(activeProperty,
             out activePropertyTermDefinition);
-        JToken propertyScopedContext = null;
+        JsonNode propertyScopedContext = null;
         if (hasTermDefinition && activePropertyTermDefinition.LocalContext != null)
         {
             propertyScopedContext = activePropertyTermDefinition.LocalContext;
@@ -332,18 +332,18 @@ internal class ExpandProcessor : ProcessorBase
         ExpandElement(resultObject, inputType, activeContext, activeProperty, baseUrl, frameExpansion, ordered, elementObject, typeScopedContext);
     }
 
-    private void ExpandElement(JObject resultObject, JToken inputType, JsonLdContext activeContext, string activeProperty, Uri baseUrl, bool frameExpansion,
-        bool ordered, JObject elementObject, JsonLdContext typeScopedContext)
+    private void ExpandElement(JsonObject resultObject, JsonNode inputType, JsonLdContext activeContext, string activeProperty, Uri baseUrl, bool frameExpansion,
+        bool ordered, JsonObject elementObject, JsonLdContext typeScopedContext)
     {
-        var nests = new JObject();
+        var nests = new JsonObject();
 
         // 13 - For each key and value in element, ordered lexicographically by key if ordered is true: 
-        IEnumerable<JProperty> elementProperties = elementObject.Properties();
-        if (ordered) elementProperties = elementProperties.OrderBy(p => p.Name);
-        foreach (JProperty p in elementProperties)
+        IEnumerable<KeyValuePair<string, JsonNode>> elementProperties = elementObject;
+        if (ordered) elementProperties = elementProperties.OrderBy(p => p.Key);
+        foreach (var p in elementProperties)
         {
-            var key = p.Name;
-            JToken value = p.Value;
+            var key = p.Key;
+            JsonNode value = p.Value;
             // 13.1 - If key is @context, continue to the next key.
             if (key.Equals("@context")) continue;
             // 13.2 - Initialize expanded property to the result of IRI expanding key.
@@ -365,7 +365,7 @@ internal class ExpandProcessor : ProcessorBase
                 }
                 continue;
             }
-            JToken expandedValue = null;
+            JsonNode expandedValue = null;
 
             // 13.4 - If expanded property is a keyword: 
             if (JsonLdUtils.IsKeyword(expandedProperty))
@@ -392,35 +392,35 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.4.3.1 - If value is not a string, an invalid @id value error has been detected and processing is aborted. When the frameExpansion flag is set, value MAY be an empty map, or an array of one or more strings.
                     // 13.4.3.2 - Otherwise, set expanded value to the result of IRI expanding value using true for document relative and false for vocab.
                     // When the frameExpansion flag is set, expanded value will be an array of one or more of the values, with string values expanded using the IRI Expansion algorithm as above.
-                    switch (value.Type)
+                    switch (value.GetValueKind())
                     {
-                        case JTokenType.String:
-                            expandedValue = _contextProcessor.ExpandIri(activeContext, value.Value<string>(), false, true);
-                            if (frameExpansion) expandedValue = new JArray(expandedValue);
+                        case JsonValueKind.String:
+                            expandedValue = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), false, true);
+                            if (frameExpansion) expandedValue = new JsonArray(expandedValue);
                             break;
 
-                        case JTokenType.Array when !frameExpansion:
-                        case JTokenType.Object when !frameExpansion:
+                        case JsonValueKind.Array when !frameExpansion:
+                        case JsonValueKind.Object when !frameExpansion:
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIdValue,
                                 $"Invalid @id value. The value of the property {key} in the value of {activeProperty} is not a string, but {key} expands to the keyword @id.");
 
-                        case JTokenType.Array when value.Children().Any(c => c.Type != JTokenType.String):
+                        case JsonValueKind.Array when value.AsArray().Any(c => c.GetValueKind() != JsonValueKind.String):
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIdValue,
                                 $"Invalid @id value. The property {key} in the value of {activeProperty} expands to the @id keyword, but its array value contains one or more non-string items.");
 
-                        case JTokenType.Array:
-                            var newArray = new JArray();
-                            foreach (JToken child in value.Children())
-                                newArray.Add(_contextProcessor.ExpandIri(activeContext, child.Value<string>(), false, true));
+                        case JsonValueKind.Array:
+                            var newArray = new JsonArray();
+                            foreach (JsonNode child in value.AsArray())
+                                newArray.Add(_contextProcessor.ExpandIri(activeContext, child.GetValue<string>(), false, true));
                             expandedValue = newArray;
                             break;
 
-                        case JTokenType.Object when value.Children().Any():
+                        case JsonValueKind.Object when value.AsObject().Any():
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIdValue,
                                 $"Invalid @id value. The property {key} in the value of {activeProperty} expands to the @id keyword, but its map value contains one or more entries.");
 
-                        case JTokenType.Object:
-                            expandedValue = frameExpansion ? new JArray(value) : value;
+                        case JsonValueKind.Object:
+                            expandedValue = frameExpansion ? new JsonArray(value) : value;
                             break;
 
                         default:
@@ -438,30 +438,29 @@ internal class ExpandProcessor : ProcessorBase
                 // 13.4.4 - If expanded property is @type: 
                 if ("@type" == expandedProperty)
                 {
-                    switch (value.Type)
+                    switch (value.GetValueKind())
                     {
-                        case JTokenType.String:
-                            expandedValue = _contextProcessor.ExpandIri(typeScopedContext, value.Value<string>(), true, true);
+                        case JsonValueKind.String:
+                            expandedValue = _contextProcessor.ExpandIri(typeScopedContext, value.GetValue<string>(), true, true);
                             break;
-                        case JTokenType.Array when value.Children().Any(c => c.Type != JTokenType.String):
+                        case JsonValueKind.Array when value.AsArray().Any(c => c.GetValueKind() != JsonValueKind.String):
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeValue,
                                 $"Invalid @type value. The property {key} in the value of {activeProperty} expands to the @type keyword, but its array value contains one or more non-string items.");
-                        case JTokenType.Array:
-                            var expandedItems = new JArray();
-                            foreach (JToken item in value.Children())
+                        case JsonValueKind.Array:
+                            var expandedItems = new JsonArray();
+                            foreach (JsonNode item in value.AsArray())
                             {
-                                expandedItems.Add(_contextProcessor.ExpandIri(typeScopedContext, item.Value<string>(), true, true));
+                                expandedItems.Add(_contextProcessor.ExpandIri(typeScopedContext, item.GetValue<string>(), true, true));
                             }
 
                             expandedValue = expandedItems;
                             break;
-                        case JTokenType.Object when frameExpansion && !value.HasValues:
+                        case JsonValueKind.Object when frameExpansion && value.AsObject().Count == 0:
                             expandedValue = value;
                             break;
-                        case JTokenType.Object when frameExpansion && (value as JObject).ContainsKey("@default"):
-                            var toExpand = (value as JObject)["@default"].Value<string>();
-                            expandedValue = new JObject(new JProperty("@default",
-                                _contextProcessor.ExpandIri(typeScopedContext, toExpand, true, true)));
+                        case JsonValueKind.Object when frameExpansion && value.AsObject().ContainsKey("@default"):
+                            var toExpand = value.AsObject()["@default"].GetValue<string>();
+                            expandedValue = new JsonObject{["@default"] = _contextProcessor.ExpandIri(typeScopedContext, toExpand, true, true)};
                             break;
                         default:
                             if (frameExpansion)
@@ -487,9 +486,9 @@ internal class ExpandProcessor : ProcessorBase
                 {
                     expandedValue = ExpandElement(activeContext, "@graph", value, baseUrl, frameExpansion,
                         ordered);
-                    if (expandedValue.Type == JTokenType.Object)
+                    if (expandedValue.GetValueKind() == JsonValueKind.Object)
                     {
-                        expandedValue = new JArray(expandedValue);
+                        expandedValue = new JsonArray(expandedValue);
                     }
                 }
 
@@ -502,7 +501,7 @@ internal class ExpandProcessor : ProcessorBase
                     expandedValue = JsonLdUtils.EnsureArray(ExpandElement(activeContext, null, value, baseUrl, frameExpansion,
                         ordered));
                     // 13.4.6.3 - If any element of expanded value is not a node object, an invalid @included value error has been detected and processing is aborted.
-                    if (expandedValue.Children().Any(c => !JsonLdUtils.IsNodeObject(c)))
+                    if (expandedValue.AsArray().Any(c => !JsonLdUtils.IsNodeObject(c)))
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIncludedValue,
                             $"Invalid @included value. The expanded value for the {key} property of {activeProperty} contains one or more values that are not valid node objects.");
@@ -519,7 +518,7 @@ internal class ExpandProcessor : ProcessorBase
                 {
                     // 13.4.7.1 - If input type is @json, set expanded value to value.
                     // If processing mode is json-ld-1.0, an invalid value object value error has been detected and processing is aborted.
-                    if (inputType != null && inputType.Type == JTokenType.String && inputType.Value<string>().Equals("@json"))
+                    if (inputType != null && inputType.GetValueKind() == JsonValueKind.String && inputType.GetValue<string>().Equals("@json"))
                     {
                         if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
                         {
@@ -530,8 +529,9 @@ internal class ExpandProcessor : ProcessorBase
                         expandedValue = value;
                     }
                     else if ((!frameExpansion && !(JsonLdUtils.IsScalar(value) || JsonLdUtils.IsNull(value))) ||
-                             (frameExpansion && !(JsonLdUtils.IsScalar(value) || JsonLdUtils.IsNull(value) || JsonLdUtils.IsEmptyMap(value) ||
-                                                  JsonLdUtils.IsArray(value, JsonLdUtils.IsScalar))))
+                             (frameExpansion && !(JsonLdUtils.IsScalar(value) || JsonLdUtils.IsNull(value) || 
+                                                  JsonLdUtils.IsEmptyObject(value) || JsonLdUtils.IsArray(value, JsonLdUtils.IsScalar)))
+                            )
                     {
                         // 13.4.7.2 - Otherwise, if value is not a scalar or null, an invalid value object value error has been detected and processing is aborted.
                         // When the frameExpansion flag is set, value MAY be an empty map or an array of scalar values.
@@ -560,7 +560,7 @@ internal class ExpandProcessor : ProcessorBase
                     // When the frameExpansion flag is set, value MAY be an empty map or an array of zero or more strings.
                     if (!frameExpansion && !JsonLdUtils.IsString(value) ||
                         frameExpansion && !(JsonLdUtils.IsString(value) || 
-                                            JsonLdUtils.IsEmptyMap(value) || 
+                                            JsonLdUtils.IsEmptyObject(value) || 
                                             JsonLdUtils.IsArray(value, JsonLdUtils.IsString)))
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidLanguageTaggedString,
@@ -574,14 +574,14 @@ internal class ExpandProcessor : ProcessorBase
                     // Processors MAY normalize language tags to lower case.
                     if (JsonLdUtils.IsString(expandedValue))
                     {
-                        var languageTag = expandedValue.Value<string>().ToLowerInvariant();
+                        var languageTag = expandedValue.GetValue<string>().ToLowerInvariant();
                         if (!LanguageTag.IsWellFormed(languageTag))
                         {
                             Warn(JsonLdErrorCode.MalformedLanguageTag,
                                 $"The @language value of {activeProperty} is not a well-formed BCP-47 language tag.");
                         }
 
-                        expandedValue = new JValue(languageTag);
+                        expandedValue = JsonValue.Create(languageTag);
                     }
                 }
 
@@ -597,7 +597,8 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.4.9.2 - If value is neither "ltr" nor "rtl", an invalid base direction error has been detected and processing is aborted.
                     // When the frameExpansion flag is set, value MAY be an empty map or an array of zero or more strings.
                     if (!frameExpansion && !JsonLdUtils.IsValidBaseDirection(value) ||
-                        frameExpansion && !(JsonLdUtils.IsValidBaseDirection(value) || JsonLdUtils.IsEmptyMap(value) ||
+                        frameExpansion && !(JsonLdUtils.IsValidBaseDirection(value) ||
+                                            JsonLdUtils.IsEmptyObject(value) ||
                                             JsonLdUtils.IsArray(value, JsonLdUtils.IsString)))
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidBaseDirection,
@@ -608,7 +609,7 @@ internal class ExpandProcessor : ProcessorBase
                     // When the frameExpansion flag is set, expanded value will be an array of one or more string values or an array containing an empty map.
                     expandedValue = value;
                     if (frameExpansion) expandedValue = JsonLdUtils.EnsureArray(expandedValue);
-                    if (frameExpansion && !(JsonLdUtils.IsArray(expandedValue, JsonLdUtils.IsString) || JsonLdUtils.IsArray(expandedValue, JsonLdUtils.IsEmptyMap)))
+                    if (frameExpansion && !(JsonLdUtils.IsArray(expandedValue, JsonLdUtils.IsString) || JsonLdUtils.IsArray(expandedValue, JsonLdUtils.IsEmptyObject)))
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidBaseDirection,
                             $"Invalid base direction. During frame expansion, the value of the property {key} of {activeProperty} does not expand to an array of strings or an array containing an empty map.");
@@ -656,7 +657,7 @@ internal class ExpandProcessor : ProcessorBase
                 if ("@reverse".Equals(expandedProperty))
                 {
                     // 13.4.13.1 - If value is not a map, an invalid @reverse value error has been detected and processing is aborted.
-                    if (value.Type != JTokenType.Object)
+                    if (value.GetValueKind() != JsonValueKind.Object)
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidReverseValue,
                             $"Invalid reverse value. The property {key} of {activeProperty} expands to an @reverse property but its value is not a JSON object.");
@@ -665,36 +666,36 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.4.13.2 - Otherwise initialize expanded value to the result of using this algorithm recursively, passing active context, @reverse as active property, value as element, base URL, and the frameExpansion and ordered flags.
                     expandedValue = ExpandElement(activeContext, "@reverse", value, baseUrl, frameExpansion,
                         ordered);
-                    if (expandedValue is JObject expandedValueObject)
+                    if (expandedValue is JsonObject expandedValueObject)
                     {
                         // 13.4.13.3 - If expanded value contains an @reverse entry, i.e., properties that are reversed twice, execute for each of its property and item the following steps: 
                         if (expandedValueObject.ContainsKey("@reverse"))
                         {
-                            if (expandedValueObject["@reverse"] is JObject reverseObject)
+                            if (expandedValueObject["@reverse"] is JsonObject reverseObject)
                             {
-                                foreach (JProperty property in reverseObject.Properties())
+                                foreach (KeyValuePair<string, JsonNode> property in reverseObject)
                                 {
                                     // 13.4.13.3.1 - Use add value to add item to the property entry in result using true for as array.
-                                    JsonLdUtils.AddValue(resultObject, property.Name, property.Value, true);
+                                    JsonLdUtils.AddValue(resultObject, property.Key, property.Value, true);
                                 }
                             }
                         }
                         // 13.4.13.4 - If expanded value contains an entry other than @reverse:
-                        if (expandedValueObject.Properties().Any(x => !x.Name.Equals("@reverse")))
+                        if (expandedValueObject.Any(x => !x.Key.Equals("@reverse")))
                         {
                             // 13.4.13.4.1 - Set reverse map to the value of the @reverse entry in result, initializing it to an empty map, if necessary.
-                            if (!resultObject.ContainsKey("@reverse")) resultObject["@reverse"] = new JObject();
-                            var reverseMap = resultObject["@reverse"] as JObject;
+                            if (!resultObject.ContainsKey("@reverse")) resultObject["@reverse"] = new JsonObject();
+                            var reverseMap = resultObject["@reverse"] as JsonObject;
                             // 13.4.13.4.2 - For each property and items in expanded value other than @reverse: 
-                            foreach (KeyValuePair<string, JToken> property in expandedValueObject)
+                            foreach (KeyValuePair<string, JsonNode> property in expandedValueObject)
                             {
                                 if (property.Key.Equals("@reverse")) continue;
                                 // 13.4.13.4.2.1 - For each item in items:
                                 // KA: Spec is not quite clear here but appears to indicate that the value of all properties should be an array or that array property values should be iterated over
-                                IEnumerable<JToken> items = property.Value is JArray itemsArray
-                                    ? (IEnumerable<JToken>)itemsArray.Children()
+                                IEnumerable<JsonNode> items = property.Value is JsonArray itemsArray
+                                    ? (IEnumerable<JsonNode>)itemsArray
                                     : [property.Value];
-                                foreach (JToken item in items)
+                                foreach (JsonNode item in items)
                                 {
                                     // 13.4.13.4.2.1.1 - If item is a value object or list object, an invalid reverse property value has been detected and processing is aborted.
                                     if (JsonLdUtils.IsValueObject(item) || JsonLdUtils.IsListObject(item))
@@ -720,7 +721,7 @@ internal class ExpandProcessor : ProcessorBase
                 {
                     if (!nests.ContainsKey(key))
                     {
-                        nests.Add(key, new JArray());
+                        nests.Add(key, new JsonArray());
                     }
 
                     continue;
@@ -734,8 +735,9 @@ internal class ExpandProcessor : ProcessorBase
                 }
 
                 // 13.4.16 - Unless expanded value is null, expanded property is @value, and input type is not @json, set the expanded property entry of result to expanded value.
-                var inputTypeIsJson = inputType != null && inputType.Type == JTokenType.String &&
-                                      inputType.Value<string>().Equals("@json");
+                var inputTypeIsJson = inputType != null &&
+                                      inputType.GetValueKind() == JsonValueKind.String &&
+                                      inputType.GetValue<string>().Equals("@json");
                 if (!(expandedValue == null && "@value".Equals(expandedProperty) && !inputTypeIsJson))
                 {
                     resultObject[expandedProperty] = expandedValue;
@@ -751,13 +753,16 @@ internal class ExpandProcessor : ProcessorBase
             // 13.6 - If key's term definition in active context has a type mapping of @json, set expanded value to a new map, set the entry @value to value, and set the entry @type to @json.
             if ("@json".Equals(termDefinition?.TypeMapping))
             {
-                expandedValue = new JObject(new JProperty("@value", value), new JProperty("@type", "@json"));
+                expandedValue = new JsonObject{
+                    ["@value"] = value,
+                    ["@type"] = "@json",
+                };
             }
             // 13.7 - Otherwise, if container mapping includes @language and value is a map then value is expanded from a language map as follows: 
-            else if (containerMapping.Contains(JsonLdContainer.Language) && value.Type == JTokenType.Object)
+            else if (containerMapping.Contains(JsonLdContainer.Language) && value.GetValueKind() == JsonValueKind.Object)
             {
                 // 13.7.1 - Initialize expanded value to an empty array.
-                var expandedValueArray = new JArray();
+                var expandedValueArray = new JsonArray();
                 expandedValue = expandedValueArray;
 
                 // 13.7.2 - Initialize direction to the default base direction from active context.
@@ -765,15 +770,15 @@ internal class ExpandProcessor : ProcessorBase
                 LanguageDirection? direction = termDefinition.DirectionMapping ?? activeContext.BaseDirection;
 
                 // 13.7.4 - For each key - value pair language-language value in value, ordered lexicographically by language if ordered is true: 
-                IEnumerable<JProperty> properties = (value as JObject).Properties();
-                if (ordered) properties = properties.OrderBy(prop => prop.Name);
-                foreach (JProperty languageMappingProperty in properties)
+                IEnumerable<KeyValuePair<string, JsonNode>> properties = value as JsonObject;
+                if (ordered) properties = properties.OrderBy(prop => prop.Key);
+                foreach (var languageMappingProperty in properties)
                 {
-                    var language = languageMappingProperty.Name;
+                    var language = languageMappingProperty.Key;
                     // 13.4.7.1 - If language value is not an array set language value to an array containing only language value.
-                    JArray languageValue = JsonLdUtils.EnsureArray(languageMappingProperty.Value);
+                    JsonArray languageValue = JsonLdUtils.EnsureArray(languageMappingProperty.Value);
                     // 13.4.7.2 - For each item in language value: 
-                    foreach (JToken item in languageValue)
+                    foreach (JsonNode item in languageValue)
                     {
                         // 13.4.7.2.1 - If item is null, continue to the next entry in language value.
                         if (JsonLdUtils.IsNull(item)) continue;
@@ -793,9 +798,10 @@ internal class ExpandProcessor : ProcessorBase
                                 $"The property {languageMappingProperty} in {activeProperty} must be either a " +
                                 $"well-formed BCP-47 language tag or '@none'.");
                         }
-                        var v = new JObject(
-                            new JProperty("@value", item),
-                            new JProperty("@language", language.ToLowerInvariant())); // Processors MAY normalize language tags to lower case.
+                        var v = new JsonObject{
+                            ["@value"] = item,
+                            ["@language"] = language.ToLowerInvariant(),
+                        }; // Processors MAY normalize language tags to lower case.
 
                         // 13.4.7.2.4 - If language is @none, or expands to @none, remove @language from v.
                         if (language.Equals("@none") || activeContext.GetAliases("@none").Contains(language))
@@ -814,25 +820,25 @@ internal class ExpandProcessor : ProcessorBase
                 }
             }
             // 13.8 - Otherwise, if container mapping includes @index, @type, or @id and value is a map then value is expanded from an map as follows: 
-            else if (value.Type == JTokenType.Object &&
+            else if (value.GetValueKind() == JsonValueKind.Object &&
                      (containerMapping.Contains(JsonLdContainer.Index) ||
                       containerMapping.Contains(JsonLdContainer.Type) ||
                       containerMapping.Contains(JsonLdContainer.Id)))
             {
                 // 13.8.1 Initialize expanded value to an empty array.
-                var expandedValueArray = new JArray();
+                var expandedValueArray = new JsonArray();
                 expandedValue = expandedValueArray;
 
                 // 13.8.2 - Initialize index key to the key's index mapping in active context, or @index, if it does not exist.
                 var indexKey = termDefinition.IndexMapping ?? "@index";
 
                 // 13.8.3 - For each key - value pair index-index value in value, ordered lexicographically by index if ordered is true: 
-                IEnumerable<JProperty> properties = (value as JObject).Properties();
-                if (ordered) properties = properties.OrderBy(prop => prop.Name);
-                foreach (JProperty indexValueProperty in properties)
+                IEnumerable<KeyValuePair<string, JsonNode>> properties = value as JsonObject;
+                if (ordered) properties = properties.OrderBy(prop => prop.Key);
+                foreach (var indexValueProperty in properties)
                 {
-                    var index = indexValueProperty.Name;
-                    JArray indexValue = JsonLdUtils.EnsureArray(indexValueProperty.Value);
+                    var index = indexValueProperty.Key;
+                    JsonArray indexValue = JsonLdUtils.EnsureArray(indexValueProperty.Value);
 
                     JsonLdContext mapContext = null;
                     // 13.8.3.1 - If container mapping includes @id or @type, initialize map context to the previous context from active context if it exists, otherwise, set map context to active context.
@@ -870,11 +876,11 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.8.3.7 - For each item in index value: 
                     for (var ix = 0; ix < indexValue.Count; ix++)
                     {
-                        var item = indexValue[ix] as JObject;
+                        var item = indexValue[ix] as JsonObject;
                         // 13.8.7.3.1 - If container mapping includes @graph, and item is not a graph object, set item to a new map containing the key - value pair @graph-item, ensuring that the value is represented using an array.
                         if (containerMapping.Contains(JsonLdContainer.Graph) && !JsonLdUtils.IsGraphObject(item))
                         {
-                            item = new JObject(new JProperty("@graph", JsonLdUtils.EnsureArray(item)));
+                            item = new JsonObject{ ["@graph"] = JsonLdUtils.EnsureArray(item) };
                         }
 
                         // 13.8.3.7.2 - If container mapping includes @index, index key is not @index, and expanded index is not @none: 
@@ -882,13 +888,13 @@ internal class ExpandProcessor : ProcessorBase
                             !expandedIndex.Equals("@none"))
                         {
                             // 13.8.3.7.2.1 - Initialize re-expanded index to the result of calling the Value Expansion algorithm, passing the active context, index key as active property, and index as value.
-                            JToken reExpandedIndex = ExpandValue(activeContext, indexKey, index);
+                            JsonNode reExpandedIndex = ExpandValue(activeContext, indexKey, index);
 
                             // 13.8.3.7.2.2 - Initialize expanded index key to the result of IRI expanding index key.
                             var expandedIndexKey = _contextProcessor.ExpandIri(activeContext, indexKey, true);
 
                             // 13.8.3.7.2.3 - Initialize index property values to an array consisting of re-expanded index followed by the existing values of the concatenation of expanded index key in item, if any.
-                            var indexPropertyValues = new JArray(reExpandedIndex);
+                            var indexPropertyValues = new JsonArray(reExpandedIndex);
                             if (item.ContainsKey(expandedIndexKey))
                             {
                                 indexPropertyValues =
@@ -897,7 +903,7 @@ internal class ExpandProcessor : ProcessorBase
 
                             // 13.8.3.7.2.4 - Add the key - value pair(expanded index key - index property values) to item.
                             item.Remove(expandedIndexKey); // Overwriting any existing value (which should have been appended to indexPropertyValues
-                            item.Add(new JProperty(expandedIndexKey, indexPropertyValues));
+                            item.Add(expandedIndexKey, indexPropertyValues);
 
                             // 13.8.3.7.2.5 - If item is a value object, it MUST NOT contain any extra properties; an invalid value object error has been detected and processing is aborted.
                             if (item.ContainsKey("@value") && item.Count > 1)
@@ -922,7 +928,7 @@ internal class ExpandProcessor : ProcessorBase
                         // 13.8.7.5 - Otherwise, if container mapping includes @type and expanded index is not @none, initialize types to a new array consisting of expanded index followed by any existing values of @type in item.Add the key - value pair(@type - types) to item.
                         else if (containerMapping.Contains(JsonLdContainer.Type) && !expandedIndex.Equals("@none"))
                         {
-                            var types = new JArray(expandedIndex);
+                            var types = new JsonArray(expandedIndex);
                             if (item.ContainsKey("@type"))
                             {
                                 types = JsonLdUtils.ConcatenateValues(types, item["@type"]);
@@ -947,7 +953,7 @@ internal class ExpandProcessor : ProcessorBase
             // 13.11 If container mapping includes @list and expanded value is not already a list object, convert expanded value to a list object by first setting it to an array containing only expanded value if it is not already an array, and then by setting it to a map containing the key-value pair @list-expanded value.
             if (containerMapping.Contains(JsonLdContainer.List) && !JsonLdUtils.IsListObject(expandedValue))
             {
-                expandedValue = new JObject(new JProperty("@list", JsonLdUtils.EnsureArray(expandedValue)));
+                expandedValue = new JsonObject{ ["@list"] = JsonLdUtils.EnsureArray(expandedValue) };
             }
 
             // 13.12 - If container mapping includes @graph, and includes neither @id nor @index, convert expanded value into an array, if necessary,
@@ -955,13 +961,15 @@ internal class ExpandProcessor : ProcessorBase
             if (containerMapping.Contains(JsonLdContainer.Graph) &&
                 !containerMapping.Contains(JsonLdContainer.Id) && !containerMapping.Contains(JsonLdContainer.Index))
             {
-                JArray tmp = JsonLdUtils.EnsureArray(expandedValue);
-                var expandedValueArray = new JArray();
-                foreach (JToken ev in tmp)
+                JsonArray tmp = JsonLdUtils.EnsureArray(expandedValue);
+                var expandedValueArray = new JsonArray();
+                foreach (JsonNode ev in tmp)
                 {
                     // 13.12.1 - Convert ev into a graph object by creating a map containing the key-value pair @graph-ev where ev is represented as an array.
                     // Note: This may lead to a graph object including another graph object, if ev was already in the form of a graph object.
-                    expandedValueArray.Add(new JObject(new JProperty("@graph", JsonLdUtils.EnsureArray(ev))));
+                    expandedValueArray.Add(
+                        new JsonObject{ ["@graph"] = JsonLdUtils.EnsureArray(ev) }
+                    );
                 }
 
                 expandedValue = expandedValueArray;
@@ -974,13 +982,13 @@ internal class ExpandProcessor : ProcessorBase
                 // 13.13.2 - Reference the value of the @reverse entry in result using the variable reverse map.
                 if (!resultObject.ContainsKey("@reverse"))
                 {
-                    resultObject.Add(new JProperty("@reverse", new JObject()));
+                    resultObject.Add("@reverse", new JsonObject());
                 }
-                var reverseMap = resultObject["@reverse"] as JObject;
+                var reverseMap = resultObject["@reverse"] as JsonObject;
                 // 13.13.3 - If expanded value is not an array, set it to an array containing expanded value.
                 expandedValue = JsonLdUtils.EnsureArray(expandedValue);
                 // 13.13.4 - For each item in expanded value
-                foreach (JToken item in expandedValue.Children())
+                foreach (JsonNode item in expandedValue.AsArray())
                 {
                     // 13.13.4.1 - If item is a value object or list object, an invalid reverse property value has been detected and processing is aborted.
                     if (JsonLdUtils.IsValueObject(item) || JsonLdUtils.IsListObject(item))
@@ -992,7 +1000,7 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.13.4.2 - If reverse map has no expanded property entry, create one and initialize its value to an empty array.
                     if (!reverseMap.ContainsKey(expandedProperty))
                     {
-                        reverseMap[expandedProperty] = new JArray();
+                        reverseMap[expandedProperty] = new JsonArray();
                     }
 
                     // 13.13.4.3 - Use add value to add item to the expanded property entry in reverse map using true for as array.
@@ -1006,23 +1014,21 @@ internal class ExpandProcessor : ProcessorBase
         }
 
         // 14 - For each key nesting-key in nests, ordered lexicographically if ordered is true: 
-        IEnumerable<JProperty> nestProperties = nests.Properties();
-        if (ordered) nestProperties = nestProperties.OrderBy(p => p.Name);
-        foreach (JProperty nestingProperty in nestProperties)
+        IEnumerable<string> nestPropertyKeys = nests.Select(kvp => kvp.Key);
+        if (ordered) nestPropertyKeys = nestPropertyKeys.OrderBy(p => p);
+        foreach (var nestingKey in nestPropertyKeys.ToList())
         {
-            var nestingKey = nestingProperty.Name;
             // 14.1 - Initialize nested values to the value of nesting-key in element, ensuring that it is an array.
-            JArray nestedValues = JsonLdUtils.EnsureArray(elementObject[nestingKey]);
-            var expandedNestedValues = new JArray();
+            JsonArray nestedValues = JsonLdUtils.EnsureArray(elementObject[nestingKey]);
+            var expandedNestedValues = new JsonArray();
             // 14.2 - For each nested value in nested values: 
-            foreach (JToken nestedValue in nestedValues)
+            foreach (JsonNode nestedValue in nestedValues)
             {
                 // 14.2.1 - If nested value is not a map, or any key within nested value expands to @value, an invalid @nest value error has been detected and processing is aborted.
                 // 14.2.2 - Recursively repeat steps 3, 8, 13 and 14 using nesting-key for active property, and nested value for element.
-                if (nestedValue is JObject nestedValueObject)
+                if (nestedValue is JsonObject nestedValueObject)
                 {
-                    if (nestedValueObject.Properties()
-                        .Any(p => _contextProcessor.ExpandIri(activeContext, p.Name, true).Equals("@value")))
+                    if (nestedValueObject.Any(p => _contextProcessor.ExpandIri(activeContext, p.Key, true).Equals("@value")))
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidNestValue,
                             $"Invalid nest value. Invalid value found when expanding the nesting property {nestingKey} of {activeProperty}. The nested value contains a property which is, or which expands to @value.");
@@ -1036,7 +1042,7 @@ internal class ExpandProcessor : ProcessorBase
                         $"Invalid nest value. Invalid value found when expanding the nesting property {nestingKey} of {activeProperty}. The nested value is not a JSON object.");
                 }
             }
-            nestingProperty.Value = expandedNestedValues;
+            nests[nestingKey] = expandedNestedValues;
         }
     }
 
@@ -1048,34 +1054,38 @@ internal class ExpandProcessor : ProcessorBase
     /// <param name="activeProperty"></param>
     /// <param name="value"></param>
     /// <returns></returns>
-    private JToken ExpandValue(JsonLdContext activeContext, string activeProperty, JToken value)
+    private JsonNode ExpandValue(JsonLdContext activeContext, string activeProperty, JsonNode value)
     {
         activeContext.TryGetTerm(activeProperty, out JsonLdTermDefinition activePropertyTermDefinition, true);
         var typeMapping = activePropertyTermDefinition?.TypeMapping;
 
         // 1 - If the active property has a type mapping in active context that is @id, and the value is a string, return a new map containing a single entry
         // where the key is @id and the value is the result IRI expanding value using true for document relative and false for vocab.
-        if (typeMapping != null && typeMapping == "@id" && value.Type == JTokenType.String)
+        if (typeMapping != null && typeMapping == "@id" && value.GetValueKind() == JsonValueKind.String)
         {
-            return new JObject(new JProperty("@id", _contextProcessor.ExpandIri(activeContext, value.Value<string>(), documentRelative: true, vocab: false)));
+            return new JsonObject{
+                ["@id"] = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), documentRelative: true, vocab: false),
+            };
         }
 
         // 2 - If active property has a type mapping in active context that is @vocab, and the value is a string, return a new map containing a single entry where the key is @id and the value is the result of IRI expanding value using true for document relative.
-        if (typeMapping != null && typeMapping == "@vocab" && value.Type == JTokenType.String)
+        if (typeMapping != null && typeMapping == "@vocab" && value.GetValueKind() == JsonValueKind.String)
         {
-            return new JObject(new JProperty("@id", _contextProcessor.ExpandIri(activeContext, value.Value<string>(), vocab: true, documentRelative: true)));
+            return new JsonObject{
+                ["@id"] = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), vocab: true, documentRelative: true),
+            };
         }
 
         // 3 - Otherwise, initialize result to a map with an @value entry whose value is set to value.
-        var result = new JObject(new JProperty("@value", value));
+        var result = new JsonObject{["@value"] = value};
 
         // 4 - If active property has a type mapping in active context, other than @id, @vocab, or @none, add @type to result and set its value to the value associated with the type mapping.
         if (typeMapping != null && typeMapping != "@id" && typeMapping != "@vocab" && typeMapping != "@none")
         {
-            result.Add(new JProperty("@type", typeMapping));
+            result.Add("@type", typeMapping);
         }
         // 5 - Otherwise, if value is a string:
-        else if (value.Type == JTokenType.String)
+        else if (value.GetValueKind() == JsonValueKind.String)
         {
             // 5.1 - Initialize language to the language mapping for active property in active context, if any, otherwise to the default language of active context.
             var language =
@@ -1089,12 +1099,12 @@ internal class ExpandProcessor : ProcessorBase
             // 5.3 - If language is not null, add @language to result with the value language.
             if (language != null)
             {
-                result.Add(new JProperty("@language", language));
+                result.Add("@language", language);
             }
             // 5.4 - If direction is not null, add @direction to result with the value direction.
             if (direction != LanguageDirection.Unspecified)
             {
-                result.Add(new JProperty("@direction", JsonLdUtils.SerializeLanguageDirection(direction)));
+                result.Add("@direction", JsonLdUtils.SerializeLanguageDirection(direction));
             }
         }
         // 6 - Return result.

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
@@ -147,8 +147,8 @@ internal class ExpandProcessor : ProcessorBase
         // and element does not consist of a single entry expanding to @id (where entries are IRI expanded, set active context to previous context from active context, as the scope of a term-scoped context does not apply when processing new node objects.
         if (activeContext.PreviousContext != null &&
             !fromMap &&
-            JsonLdUtils.GetPropertyValue(activeContext, elementObject, "@value") == null &&
-            !(elementObject.Count == 1 && JsonLdUtils.GetPropertyValue(activeContext, elementObject, "@id") != null))
+            !JsonLdUtils.HasProperty(activeContext, elementObject, "@value") == false &&
+            !(elementObject.Count == 1 && JsonLdUtils.HasProperty(activeContext, elementObject, "@id")))
         {
             activeContext = activeContext.PreviousContext;
         }
@@ -163,8 +163,7 @@ internal class ExpandProcessor : ProcessorBase
         // 9 - If element contains the key @context, set active context to the 
         // result of the Context Processing algorithm, passing active context 
         // and the value of the @context key as local context.
-        JsonNode contextValue = JsonLdUtils.GetPropertyValue(activeContext, elementObject, "@context");
-        if (contextValue != null)
+        if (JsonLdUtils.TryGetPropertyValue(activeContext, elementObject, "@context", out JsonNode contextValue))
         {
             activeContext = _contextProcessor.ProcessContext(activeContext, contextValue, baseUrl);
         }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
@@ -62,7 +62,7 @@ internal class ExpandProcessor : ProcessorBase
         JsonNode result;
 
         // 1 - If element is null, return null.
-        if (element == null || element.GetValueKind() == JsonValueKind.Null)
+        if (element == null || element.SafeValueKind() == JsonValueKind.Null)
         {
             return null;
         }
@@ -122,9 +122,11 @@ internal class ExpandProcessor : ProcessorBase
                     // 5.2.3 - If expanded item is an array, append each of its items to result. Otherwise, if expanded item is not null, append it to result.
                     if (expandedItem is JsonArray expandedItemArray)
                     {
-                        foreach (JsonNode arrayItem in expandedItemArray)
+                        while (expandedItemArray.Count > 0)
                         {
-                            resultArray.Add(arrayItem);
+                            JsonNode n = expandedItemArray[0];
+                            expandedItemArray.RemoveAt(0);
+                            resultArray.Add(n);
                         }
                     }
                     else
@@ -175,12 +177,12 @@ internal class ExpandProcessor : ProcessorBase
         foreach (var property in typeProperties)
         {
             // 11.1 Convert value into an array, if necessary.
-            JsonArray values = property.Value as JsonArray ?? new JsonArray(property.Value);
+            JsonArray values = JsonLdUtils.EnsureArray(property.Value);
             // 11.2 For each term which is a value of value ordered lexicographically
-            foreach (JsonNode term in values.OrderBy(v => v))
+            foreach (JsonNode term in values.OrderBy(v => v.ToJsonString()))
             {
                 // if term is a string, and term's term definition in type-scoped context has a local context, set active context to the result Context Processing algorithm, passing active context, the value of the term's local context as local context, base URL from the term definition for value in active context, and false for propagate.
-                if (term.GetValueKind() == JsonValueKind.String &&
+                if (term.SafeValueKind() == JsonValueKind.String &&
                     typeScopedContext.TryGetTerm(term.GetValue<string>(), out JsonLdTermDefinition termDefinition) &&
                     termDefinition.LocalContext != null)
                 {
@@ -201,7 +203,7 @@ internal class ExpandProcessor : ProcessorBase
             inputType = firstTypeProperty.Value is JsonArray typeArray
                 ? (typeArray.Count > 0 ? typeArray[typeArray.Count - 1] : null)
                 : firstTypeProperty.Value;
-            if (inputType.GetValueKind() == JsonValueKind.String) // Don't try to expand a framing wildcard
+            if (inputType.SafeValueKind() == JsonValueKind.String) // Don't try to expand a framing wildcard
             {
                 inputType = _contextProcessor.ExpandIri(activeContext, inputType.GetValue<string>(), true);
             }
@@ -228,16 +230,16 @@ internal class ExpandProcessor : ProcessorBase
             JsonNode resultType = resultObject.ContainsKey("@type") ? resultObject["@type"] : null;
             JsonNode resultValue = resultObject["@value"];
             // If the result's @type entry is @json, then the @value entry may contain any value, and is treated as a JSON literal.
-            if (resultType != null && resultType.GetValueKind() == JsonValueKind.String && resultType.GetValue<string>().Equals("@json"))
+            if (resultType != null && resultType.SafeValueKind() == JsonValueKind.String && resultType.GetValue<string>().Equals("@json"))
             {
                 // No-op
             }
             // Otherwise, if the value of result's @value entry is null, or an empty array, return null.
-            else if (resultValue == null || resultValue.GetValueKind() == JsonValueKind.Null || resultValue is JsonArray resultArray && resultArray.Count == 0)
+            else if (resultValue == null || resultValue.SafeValueKind() == JsonValueKind.Null || resultValue is JsonArray resultArray && resultArray.Count == 0)
             {
                 return null;
             }
-            else if (resultObject.ContainsKey("@language") && resultValue.GetValueKind() != JsonValueKind.String && !frameExpansion) // KA: in frame expansion @language could be an empty object or array
+            else if (resultObject.ContainsKey("@language") && resultValue.SafeValueKind() != JsonValueKind.String && !frameExpansion) // KA: in frame expansion @language could be an empty object or array
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidLanguageTaggedValue,
                     $"Invalid language-tagged value. The expansion of {activeProperty} has an @language entry, but its @value entry is not a JSON string.");
@@ -392,7 +394,7 @@ internal class ExpandProcessor : ProcessorBase
                     // 13.4.3.1 - If value is not a string, an invalid @id value error has been detected and processing is aborted. When the frameExpansion flag is set, value MAY be an empty map, or an array of one or more strings.
                     // 13.4.3.2 - Otherwise, set expanded value to the result of IRI expanding value using true for document relative and false for vocab.
                     // When the frameExpansion flag is set, expanded value will be an array of one or more of the values, with string values expanded using the IRI Expansion algorithm as above.
-                    switch (value.GetValueKind())
+                    switch (value.SafeValueKind())
                     {
                         case JsonValueKind.String:
                             expandedValue = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), false, true);
@@ -404,7 +406,7 @@ internal class ExpandProcessor : ProcessorBase
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIdValue,
                                 $"Invalid @id value. The value of the property {key} in the value of {activeProperty} is not a string, but {key} expands to the keyword @id.");
 
-                        case JsonValueKind.Array when value.AsArray().Any(c => c.GetValueKind() != JsonValueKind.String):
+                        case JsonValueKind.Array when value.AsArray().Any(c => c.SafeValueKind() != JsonValueKind.String):
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidIdValue,
                                 $"Invalid @id value. The property {key} in the value of {activeProperty} expands to the @id keyword, but its array value contains one or more non-string items.");
 
@@ -420,7 +422,7 @@ internal class ExpandProcessor : ProcessorBase
                                 $"Invalid @id value. The property {key} in the value of {activeProperty} expands to the @id keyword, but its map value contains one or more entries.");
 
                         case JsonValueKind.Object:
-                            expandedValue = frameExpansion ? new JsonArray(value) : value;
+                            expandedValue = frameExpansion ? new JsonArray(value.DetachedClone()) : value.DetachedClone();
                             break;
 
                         default:
@@ -438,12 +440,12 @@ internal class ExpandProcessor : ProcessorBase
                 // 13.4.4 - If expanded property is @type: 
                 if ("@type" == expandedProperty)
                 {
-                    switch (value.GetValueKind())
+                    switch (value.SafeValueKind())
                     {
                         case JsonValueKind.String:
                             expandedValue = _contextProcessor.ExpandIri(typeScopedContext, value.GetValue<string>(), true, true);
                             break;
-                        case JsonValueKind.Array when value.AsArray().Any(c => c.GetValueKind() != JsonValueKind.String):
+                        case JsonValueKind.Array when value.AsArray().Any(c => c.SafeValueKind() != JsonValueKind.String):
                             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidTypeValue,
                                 $"Invalid @type value. The property {key} in the value of {activeProperty} expands to the @type keyword, but its array value contains one or more non-string items.");
                         case JsonValueKind.Array:
@@ -486,7 +488,7 @@ internal class ExpandProcessor : ProcessorBase
                 {
                     expandedValue = ExpandElement(activeContext, "@graph", value, baseUrl, frameExpansion,
                         ordered);
-                    if (expandedValue.GetValueKind() == JsonValueKind.Object)
+                    if (expandedValue.SafeValueKind() == JsonValueKind.Object)
                     {
                         expandedValue = new JsonArray(expandedValue);
                     }
@@ -518,7 +520,7 @@ internal class ExpandProcessor : ProcessorBase
                 {
                     // 13.4.7.1 - If input type is @json, set expanded value to value.
                     // If processing mode is json-ld-1.0, an invalid value object value error has been detected and processing is aborted.
-                    if (inputType != null && inputType.GetValueKind() == JsonValueKind.String && inputType.GetValue<string>().Equals("@json"))
+                    if (inputType != null && inputType.SafeValueKind() == JsonValueKind.String && inputType.GetValue<string>().Equals("@json"))
                     {
                         if (Options.ProcessingMode == JsonLdProcessingMode.JsonLd10)
                         {
@@ -657,7 +659,7 @@ internal class ExpandProcessor : ProcessorBase
                 if ("@reverse".Equals(expandedProperty))
                 {
                     // 13.4.13.1 - If value is not a map, an invalid @reverse value error has been detected and processing is aborted.
-                    if (value.GetValueKind() != JsonValueKind.Object)
+                    if (value.SafeValueKind() != JsonValueKind.Object)
                     {
                         throw new JsonLdProcessorException(JsonLdErrorCode.InvalidReverseValue,
                             $"Invalid reverse value. The property {key} of {activeProperty} expands to an @reverse property but its value is not a JSON object.");
@@ -736,11 +738,11 @@ internal class ExpandProcessor : ProcessorBase
 
                 // 13.4.16 - Unless expanded value is null, expanded property is @value, and input type is not @json, set the expanded property entry of result to expanded value.
                 var inputTypeIsJson = inputType != null &&
-                                      inputType.GetValueKind() == JsonValueKind.String &&
+                                      inputType.SafeValueKind() == JsonValueKind.String &&
                                       inputType.GetValue<string>().Equals("@json");
                 if (!(expandedValue == null && "@value".Equals(expandedProperty) && !inputTypeIsJson))
                 {
-                    resultObject[expandedProperty] = expandedValue;
+                    resultObject[expandedProperty] = expandedValue.DetachedClone();
                 }
 
                 // 13.4.17 - Continue with the next key from element.
@@ -754,12 +756,12 @@ internal class ExpandProcessor : ProcessorBase
             if ("@json".Equals(termDefinition?.TypeMapping))
             {
                 expandedValue = new JsonObject{
-                    ["@value"] = value,
+                    ["@value"] = value.DetachedClone(),
                     ["@type"] = "@json",
                 };
             }
             // 13.7 - Otherwise, if container mapping includes @language and value is a map then value is expanded from a language map as follows: 
-            else if (containerMapping.Contains(JsonLdContainer.Language) && value.GetValueKind() == JsonValueKind.Object)
+            else if (containerMapping.Contains(JsonLdContainer.Language) && value.SafeValueKind() == JsonValueKind.Object)
             {
                 // 13.7.1 - Initialize expanded value to an empty array.
                 var expandedValueArray = new JsonArray();
@@ -799,7 +801,7 @@ internal class ExpandProcessor : ProcessorBase
                                 $"well-formed BCP-47 language tag or '@none'.");
                         }
                         var v = new JsonObject{
-                            ["@value"] = item,
+                            ["@value"] = item.Parent == null ? item : item.DeepClone(),
                             ["@language"] = language.ToLowerInvariant(),
                         }; // Processors MAY normalize language tags to lower case.
 
@@ -820,7 +822,8 @@ internal class ExpandProcessor : ProcessorBase
                 }
             }
             // 13.8 - Otherwise, if container mapping includes @index, @type, or @id and value is a map then value is expanded from an map as follows: 
-            else if (value.GetValueKind() == JsonValueKind.Object &&
+            else if (value != null &&
+                     value.SafeValueKind() == JsonValueKind.Object &&
                      (containerMapping.Contains(JsonLdContainer.Index) ||
                       containerMapping.Contains(JsonLdContainer.Type) ||
                       containerMapping.Contains(JsonLdContainer.Id)))
@@ -874,9 +877,11 @@ internal class ExpandProcessor : ProcessorBase
                         ordered, true));
 
                     // 13.8.3.7 - For each item in index value: 
-                    for (var ix = 0; ix < indexValue.Count; ix++)
+                    while(indexValue.Count > 0)
                     {
-                        var item = indexValue[ix] as JsonObject;
+                        var item = indexValue[0] as JsonObject;
+                        indexValue.RemoveAt(0); // Detach item from indexValue
+
                         // 13.8.7.3.1 - If container mapping includes @graph, and item is not a graph object, set item to a new map containing the key - value pair @graph-item, ensuring that the value is represented using an array.
                         if (containerMapping.Contains(JsonLdContainer.Graph) && !JsonLdUtils.IsGraphObject(item))
                         {
@@ -931,7 +936,9 @@ internal class ExpandProcessor : ProcessorBase
                             var types = new JsonArray(expandedIndex);
                             if (item.ContainsKey("@type"))
                             {
-                                types = JsonLdUtils.ConcatenateValues(types, item["@type"]);
+                                var t = item["@type"];
+                                item.Remove("@type"); // Detach the existing @type value from item
+                                types = JsonLdUtils.ConcatenateValues(types, t);
                             }
 
                             item["@type"] = types;
@@ -1061,7 +1068,7 @@ internal class ExpandProcessor : ProcessorBase
 
         // 1 - If the active property has a type mapping in active context that is @id, and the value is a string, return a new map containing a single entry
         // where the key is @id and the value is the result IRI expanding value using true for document relative and false for vocab.
-        if (typeMapping != null && typeMapping == "@id" && value.GetValueKind() == JsonValueKind.String)
+        if (typeMapping != null && typeMapping == "@id" && value.SafeValueKind() == JsonValueKind.String)
         {
             return new JsonObject{
                 ["@id"] = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), documentRelative: true, vocab: false),
@@ -1069,7 +1076,7 @@ internal class ExpandProcessor : ProcessorBase
         }
 
         // 2 - If active property has a type mapping in active context that is @vocab, and the value is a string, return a new map containing a single entry where the key is @id and the value is the result of IRI expanding value using true for document relative.
-        if (typeMapping != null && typeMapping == "@vocab" && value.GetValueKind() == JsonValueKind.String)
+        if (typeMapping != null && typeMapping == "@vocab" && value.SafeValueKind() == JsonValueKind.String)
         {
             return new JsonObject{
                 ["@id"] = _contextProcessor.ExpandIri(activeContext, value.GetValue<string>(), vocab: true, documentRelative: true),
@@ -1085,7 +1092,7 @@ internal class ExpandProcessor : ProcessorBase
             result.Add("@type", typeMapping);
         }
         // 5 - Otherwise, if value is a string:
-        else if (value.GetValueKind() == JsonValueKind.String)
+        else if (value.SafeValueKind() == JsonValueKind.String)
         {
             // 5.1 - Initialize language to the language mapping for active property in active context, if any, otherwise to the default language of active context.
             var language =

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
@@ -1077,7 +1077,7 @@ internal class ExpandProcessor : ProcessorBase
         }
 
         // 3 - Otherwise, initialize result to a map with an @value entry whose value is set to value.
-        var result = new JsonObject{["@value"] = value};
+        var result = new JsonObject{["@value"] = value.DeepClone()};
 
         // 4 - If active property has a type mapping in active context, other than @id, @vocab, or @none, add @type to result and set its value to the value associated with the type mapping.
         if (typeMapping != null && typeMapping != "@id" && typeMapping != "@vocab" && typeMapping != "@none")

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/ExpandProcessor.cs
@@ -75,9 +75,11 @@ internal class ExpandProcessor : ProcessorBase
             out activePropertyTermDefinition);
         // 3 - If active property has a term definition in active context with a local context, initialize property-scoped context to that local context.
         JsonNode propertyScopedContext = null;
-        if (hasTermDefinition && activePropertyTermDefinition.LocalContext != null)
+        bool propertyScopedContextDefined = false;
+        if (hasTermDefinition && activePropertyTermDefinition.HasLocalContext)
         {
             propertyScopedContext = activePropertyTermDefinition.LocalContext;
+            propertyScopedContextDefined = true;
         }
 
         // 4 - If element is a scalar,
@@ -87,7 +89,7 @@ internal class ExpandProcessor : ProcessorBase
             if (activeProperty == null || activeProperty == "@graph") return null;
 
             // 4.2 - If property-scoped context is defined, set active context to the result of the Context Processing algorithm, passing active context, property-scoped context as local context, and base URL from the term definition for active property in active context.
-            if (propertyScopedContext != null)
+            if (propertyScopedContextDefined)
             {
                 activeContext = _contextProcessor.ProcessContext(activeContext, propertyScopedContext,
                     activePropertyTermDefinition.BaseUrl);
@@ -147,14 +149,14 @@ internal class ExpandProcessor : ProcessorBase
         // and element does not consist of a single entry expanding to @id (where entries are IRI expanded, set active context to previous context from active context, as the scope of a term-scoped context does not apply when processing new node objects.
         if (activeContext.PreviousContext != null &&
             !fromMap &&
-            !JsonLdUtils.HasProperty(activeContext, elementObject, "@value") == false &&
+            !JsonLdUtils.HasProperty(activeContext, elementObject, "@value") &&
             !(elementObject.Count == 1 && JsonLdUtils.HasProperty(activeContext, elementObject, "@id")))
         {
             activeContext = activeContext.PreviousContext;
         }
 
         // 8 - If property-scoped context is defined, set active context to the result of the Context Processing algorithm, passing active context, property-scoped context as local context, base URL from the term definition for active property, in active context and true for override protected.
-        if (propertyScopedContext != null)
+        if (propertyScopedContextDefined)
         {
             activeContext = _contextProcessor.ProcessContext(activeContext, propertyScopedContext,
                 activePropertyTermDefinition.BaseUrl, overrideProtected: true);
@@ -183,7 +185,7 @@ internal class ExpandProcessor : ProcessorBase
                 // if term is a string, and term's term definition in type-scoped context has a local context, set active context to the result Context Processing algorithm, passing active context, the value of the term's local context as local context, base URL from the term definition for value in active context, and false for propagate.
                 if (term.SafeValueKind() == JsonValueKind.String &&
                     typeScopedContext.TryGetTerm(term.GetValue<string>(), out JsonLdTermDefinition termDefinition) &&
-                    termDefinition.LocalContext != null)
+                    termDefinition.HasLocalContext)
                 {
                     activeContext = _contextProcessor.ProcessContext(activeContext, termDefinition.LocalContext,
                         termDefinition.BaseUrl, propagate: false);
@@ -318,15 +320,10 @@ internal class ExpandProcessor : ProcessorBase
         JsonLdTermDefinition activePropertyTermDefinition = null;
         var hasTermDefinition = activeProperty != null && activeContext.TryGetTerm(activeProperty,
             out activePropertyTermDefinition);
-        JsonNode propertyScopedContext = null;
-        if (hasTermDefinition && activePropertyTermDefinition.LocalContext != null)
+        if (hasTermDefinition && activePropertyTermDefinition.HasLocalContext)
         {
-            propertyScopedContext = activePropertyTermDefinition.LocalContext;
-        }
-
-        // 8 - If property-scoped context is defined, set active context to the result of the Context Processing algorithm, passing active context, property-scoped context as local context, base URL from the term definition for active property, in active context and true for override protected.
-        if (propertyScopedContext != null)
-        {
+            JsonNode propertyScopedContext = activePropertyTermDefinition.LocalContext;
+            // 8 - If property-scoped context is defined, set active context to the result of the Context Processing algorithm, passing active context, property-scoped context as local context, base URL from the term definition for active property, in active context and true for override protected.
             activeContext = _contextProcessor.ProcessContext(activeContext, propertyScopedContext, baseUrl, overrideProtected: true);
         }
 
@@ -852,7 +849,7 @@ internal class ExpandProcessor : ProcessorBase
                         if (containerMapping.Contains(JsonLdContainer.Type))
                         {
                             JsonLdTermDefinition indexTermDefinition = mapContext.GetTerm(index);
-                            if (indexTermDefinition?.LocalContext != null)
+                            if (indexTermDefinition?.HasLocalContext == true)
                             {
                                 mapContext = _contextProcessor.ProcessContext(mapContext, indexTermDefinition.LocalContext,
                                     indexTermDefinition.BaseUrl);

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FlattenProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FlattenProcessor.cs
@@ -26,7 +26,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace VDS.RDF.JsonLd.Processors;
 
@@ -53,35 +53,35 @@ internal class FlattenProcessor
     /// <param name="ordered">True to process the properties of the element in lexicographical order.</param>
     /// <returns>A new token representing the flattened element.</returns>
     /// <remarks>This operation does not modify the input element.</remarks>
-    public JToken FlattenElement(JToken element, bool ordered = false)
+    public JsonNode FlattenElement(JsonNode element, bool ordered = false)
     {
         // 1 = Initialize node map to a map consisting of a single member whose key is @default
         // and whose value is an empty map.
         // 2 - Perform the Node Map Generation algorithm, passing element and node map.
-        JObject nodeMap = _nodeMapGenerator.GenerateNodeMap(element);
+        JsonObject nodeMap = _nodeMapGenerator.GenerateNodeMap(element);
 
         // 3 - Initialize default graph to the value of the @default member of node map,
         // which is a map representing the default graph.
-        var defaultGraph = nodeMap["@default"] as JObject;
+        var defaultGraph = nodeMap["@default"] as JsonObject;
 
         // 4 - For each key-value pair graph name-graph in node map where graph name is not @default,
         // ordered lexicographically by graph name if ordered is true, perform the following steps: 
-        IEnumerable<JProperty> properties = nodeMap.Properties().Where(p => !p.Name.Equals("@default"));
-        if (ordered) properties = properties.OrderBy(p => p.Name);
-        foreach (JProperty p in properties)
+        IEnumerable<KeyValuePair<string, JsonNode>> properties = nodeMap.Where(p => !p.Key.Equals("@default"));
+        if (ordered) properties = properties.OrderBy(p => p.Key);
+        foreach (var p in properties)
         {
-            var graphName = p.Name;
-            var graph = p.Value as JObject;
+            var graphName = p.Key;
+            var graph = p.Value as JsonObject;
 
             // 4.1 - If default graph does not have a graph name entry, create one and initialize its
             // value to a map consisting of an @id entry whose value is set to graph name.
             if (!defaultGraph.ContainsKey(graphName))
             {
-                defaultGraph.Add(graphName, new JObject(new JProperty("@id", graphName)));
+                defaultGraph.Add(graphName, new JsonObject{{"@id", graphName}});
             }
 
             // 4.2 - Reference the value associated with the graph name entry in default graph using the variable entry.
-            var entry = defaultGraph[graphName] as JObject;
+            var entry = defaultGraph[graphName] as JsonObject;
 
             // 4.3 - Add an @graph entry to entry and set it to an empty array.
             // 4.4 - For each id-node pair in graph ordered lexicographically by id if ordered is true,
@@ -92,27 +92,27 @@ internal class FlattenProcessor
         // 5 - Initialize an empty array flattened.
         // 6 - For each id-node pair in default graph ordered lexicographically by id if ordered is true,
         // add node to flattened, unless the only entry of node is @id.
-        JArray flattened = FlattenGraph(defaultGraph, ordered);
+        JsonArray flattened = FlattenGraph(defaultGraph, ordered);
 
 
         // 7 - return flattened.
         return flattened;
     }
 
-    private static JArray FlattenGraph(JObject graphObject, bool ordered)
+    private static JsonArray FlattenGraph(JsonObject graphObject, bool ordered)
     {
-        var flattened = new JArray();
-        IEnumerable<JProperty> graphProperties = graphObject.Properties();
-        if (ordered) graphProperties = graphProperties.OrderBy(p => p.Name);
-        foreach (JProperty p in graphProperties)
+        var flattened = new JsonArray();
+        IEnumerable<KeyValuePair<string, JsonNode>> graphProperties = graphObject;
+
+        if (ordered) graphProperties = graphProperties.OrderBy(p => p.Key);
+        foreach (var p in graphProperties)
         {
-            var node = p.Value as JObject;
-            if (node.Count > 1 || node.Properties().Any(x => !x.Name.Equals("@id")))
+            var node = p.Value as JsonObject;
+            if (node.Count > 1 || node.Any(x => !x.Key.Equals("@id")))
             {
                 flattened.Add(node);
             }
         }
-
         return flattened;
     }
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FlattenProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FlattenProcessor.cs
@@ -110,7 +110,7 @@ internal class FlattenProcessor
             var node = p.Value as JsonObject;
             if (node.Count > 1 || node.Any(x => !x.Key.Equals("@id")))
             {
-                flattened.Add(node);
+                flattened.Add(node.DetachedClone());
             }
         }
         return flattened;

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
@@ -328,7 +328,7 @@ internal static class FramingProcessor
 
                 // 4.7.4.4 - Add property to output with a new dictionary having a property @preserve and a value that is a copy of the value of @default in frame if it exists, or the string @null otherwise.
                 JsonArray defaultValue = JsonLdUtils.EnsureArray(propertyFrame["@default"]) ?? new JsonArray("@null");
-                output[property] = new JsonObject{["@preserve"] = defaultValue};
+                output[property] = new JsonObject{["@preserve"] = defaultValue.DetachedClone()};
                 //if (!(defaultValue is JsonArray)) defaultValue = new JsonArray(defaultValue);
                 //FramingAppend(output, new JsonObject(new JProperty("@preserve", defaultValue)), property);
                 // // output[property] = new JsonObject(new JProperty("@preserve", frame["@default"] ?? "@null"));
@@ -381,34 +381,45 @@ internal static class FramingProcessor
     {
         if (frame["@embed"] != null)
         {
-            var embedString = frame["@embed"] is JsonObject
-                ? frame["@embed"]["@value"].GetValue<string>()
-                : frame["@embed"].GetValue<string>();
-            switch (embedString.ToLowerInvariant())
+            JsonNode embedValue = frame["@embed"] is JsonObject ? frame["@embed"]["@value"] : frame["@embed"];
+            switch (embedValue.SafeValueKind())
             {
-                case "@always":
-                    return JsonLdEmbed.Always;
-                case "true":
-                case "@once":
+                case JsonValueKind.True:
                     return JsonLdEmbed.Once;
-                case "@first" when processingMode == JsonLdProcessingMode.JsonLd10:
-                    return JsonLdEmbed.First;
-                case "@last" when processingMode == JsonLdProcessingMode.JsonLd10:
-                    return JsonLdEmbed.Last;
-                case "@link" when processingMode == JsonLdProcessingMode.JsonLd10:
-                    return JsonLdEmbed.Link;
-                case "@first":
-                case "@last":
-                case "@link":
-                    throw new JsonLdProcessorException(JsonLdErrorCode.InvalidEmbedValue,
-                        $"Invalid @embed value {embedString}. This value is only valid if the processing mode is JSON-LD 1.0.");
-                case "false":
-                case "@never":
+                case JsonValueKind.False:
                     return JsonLdEmbed.Never;
+                case JsonValueKind.String:
+                    var embedString = embedValue.GetValue<string>();
+                    switch (embedString.ToLowerInvariant())
+                    {
+                        case "@always":
+                            return JsonLdEmbed.Always;
+                        case "true":
+                        case "@once":
+                            return JsonLdEmbed.Once;
+                        case "@first" when processingMode == JsonLdProcessingMode.JsonLd10:
+                            return JsonLdEmbed.First;
+                        case "@last" when processingMode == JsonLdProcessingMode.JsonLd10:
+                            return JsonLdEmbed.Last;
+                        case "@link" when processingMode == JsonLdProcessingMode.JsonLd10:
+                            return JsonLdEmbed.Link;
+                        case "@first":
+                        case "@last":
+                        case "@link":
+                            throw new JsonLdProcessorException(JsonLdErrorCode.InvalidEmbedValue,
+                                $"Invalid @embed value {embedString}. This value is only valid if the processing mode is JSON-LD 1.0.");
+                        case "false":
+                        case "@never":
+                            return JsonLdEmbed.Never;
+                        default:
+                            throw new JsonLdProcessorException(JsonLdErrorCode.InvalidEmbedValue,
+                                $"Invalid @embed value {embedString}");
+                    }
                 default:
                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidEmbedValue,
-                        $"Invalid @embed value {embedString}");
+                        $"Invalid @embed value {embedValue.ToJsonString()}. Must be a string or boolean value.");
             }
+
         }
         return defaultValue;
     }
@@ -450,14 +461,35 @@ internal static class FramingProcessor
             switch (frame[property])
             {
                 case JsonValue optValue:
-                    return optValue.GetValueKind() == JsonValueKind.Null ? defaultValue :optValue.GetValue<bool>();
+                    return GetBooleanOption(optValue, defaultValue);
                 case JsonObject optObject:
-                    return optObject.ContainsKey("@value") ? optObject["@value"].GetValue<bool>() : defaultValue;
+                    return optObject.ContainsKey("@value") ? GetBooleanOption(optObject["@value"].AsValue(), defaultValue) : defaultValue;
             }
         }
         return defaultValue;
     }
 
+    private static bool GetBooleanOption(JsonValue jsonValue, bool defaultValue)
+    {
+        switch (jsonValue.SafeValueKind())
+        {
+            case JsonValueKind.Null:
+                return defaultValue;
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            case JsonValueKind.String:
+                var str = jsonValue.GetValue<string>().ToLowerInvariant();
+                if (str.Equals("true")) return true;
+                if (str.Equals("false")) return false;
+                throw new JsonLdProcessorException(JsonLdErrorCode.InvalidFrame,
+                    $"Invalid frame option value {jsonValue.ToJsonString()}. Must be a boolean or null.");
+            default:
+                throw new JsonLdProcessorException(JsonLdErrorCode.InvalidFrame,
+                    $"Invalid frame option value {jsonValue.ToJsonString()}. Must be a boolean or null.");
+        }
+    }
 
     private static Dictionary<string, JsonObject> MatchFrame(FramingState state, IEnumerable<string> subjects,
         JsonObject frame, bool requireAll)
@@ -715,7 +747,7 @@ internal static class FramingProcessor
     private static JsonNode Lowercase(JsonNode token)
     {
         if (token == null) return null;
-        if (token.GetValueKind() == JsonValueKind.String){
+        if (token.SafeValueKind() == JsonValueKind.String){
             return JsonValue.Create(token.GetValue<string>().ToLower(CultureInfo.InvariantCulture));
         }
 
@@ -738,7 +770,7 @@ internal static class FramingProcessor
     private static bool IsWildcard(JsonNode token)
     {
         if (token == null) return false;
-        switch (token.GetValueKind())
+        switch (token.SafeValueKind())
         {
             case JsonValueKind.Array:
                 return (token as JsonArray).Any(IsWildcard);
@@ -813,7 +845,7 @@ internal static class FramingProcessor
             {
                 throw new ArgumentException("activeProperty must be null when parent is an array");
             }
-            parentArray.Add(child);
+            parentArray.Add(child.DeepClone());
         }
         else if (parent is JsonObject parentObject)
         {
@@ -828,7 +860,7 @@ internal static class FramingProcessor
             {
                 parent[activeProperty] = array = [];
             }
-            array.Add(child);
+            array.Add(child.DeepClone());
         }
     }
 

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
@@ -194,7 +194,7 @@ internal static class FramingProcessor
                 // 4.7.1 - If property is a keyword, add property and objects to output.
                 if (JsonLdUtils.IsKeyword(property))
                 {
-                    output[property] = p.Value;
+                    output[property] = p.Value.DeepClone();
                     continue;
                 }
 

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingProcessor.cs
@@ -28,7 +28,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd.Processors;
@@ -46,8 +47,8 @@ internal static class FramingProcessor
     /// <param name="ordered"></param>
     /// <param name="idStack"></param>
     /// <param name="processingMode"></param>
-    public static void ProcessFrame(FramingState state, List<string> subjects, JToken frameObjectOrArray,
-        JToken parent,
+    public static void ProcessFrame(FramingState state, List<string> subjects, JsonNode frameObjectOrArray,
+        JsonNode parent,
         string activeProperty, bool ordered = false, Stack<string> idStack = null, 
         JsonLdProcessingMode processingMode = JsonLdProcessingMode.JsonLd11)
     {
@@ -55,13 +56,13 @@ internal static class FramingProcessor
         if (idStack == null) idStack = new Stack<string>();
 
         // 1 - If frame is an array, set frame to the first member of the array, which must be a valid frame.
-        if (frameObjectOrArray is JArray frameArray)
+        if (frameObjectOrArray is JsonArray frameArray)
         {
-            frameObjectOrArray = frameArray.Count == 0 ? new JObject() : frameArray[0];
+            frameObjectOrArray = frameArray.Count == 0 ? new JsonObject() : frameArray[0];
             ValidateFrame(frameObjectOrArray);
         }
 
-        var frame = frameObjectOrArray as JObject;
+        var frame = frameObjectOrArray as JsonObject;
 
         // 2 - Initialize flags embed, explicit, and requireAll from object embed flag, explicit inclusion flag, and require all flag in state overriding from any property values for @embed, @explicit, and @requireAll in frame.
         JsonLdEmbed embed = GetEmbedOption(frame, state.Embed, processingMode);
@@ -69,21 +70,21 @@ internal static class FramingProcessor
         var requireAll = GetBooleanOption(frame, "@requireAll", state.RequireAll);
 
         // 3 - Create a list of matched subjects by filtering subjects against frame using the Frame Matching algorithm with state, subjects, frame, and requireAll.
-        Dictionary<string, JObject> matchedSubjects = MatchFrame(state, subjects, frame, requireAll);
+        Dictionary<string, JsonObject> matchedSubjects = MatchFrame(state, subjects, frame, requireAll);
 
         // 5 - For each id and associated node object node from the set of matched subjects, ordered lexicographically by id if the optional ordered flag is true:
-        var matches = (IEnumerable<KeyValuePair<string, JObject>>) matchedSubjects;
+        var matches = (IEnumerable<KeyValuePair<string, JsonObject>>) matchedSubjects;
         if (ordered) matches = matches.OrderBy(x => x.Key, StringComparer.Ordinal);
-        foreach (KeyValuePair<string, JObject> match in matches)
+        foreach (KeyValuePair<string, JsonObject> match in matches)
         {
             var id = match.Key;
-            JObject node = match.Value;
+            JsonObject node = match.Value;
 
             // Set up tracking for embedded nodes, clearing the value for each top-level property
             state.TrackEmbeddedNodes(activeProperty == null);
 
             // 4.1 - Initialize output to a new dictionary with @id and id.
-            var output = new JObject(new JProperty("@id", id));
+            var output = new JsonObject{["@id"] = id};
 
             // 4.2 - If the embedded flag in state is false and there is an existing embedded node in parent associated with graph name and id in state, do not perform additional processing for this node. 
             if (!state.Embedded && state.HasEmbeddedNode(id))
@@ -120,7 +121,7 @@ internal static class FramingProcessor
             if (state.GraphMap.ContainsKey(id))
             {
                 var recurse = false;
-                JObject subframe = null;
+                JsonObject subframe = null;
                 // 4.5.1 - If frame does not have the key @graph, set recurse to true, unless graph name in state is @merged and set subframe to a new empty dictionary.
                 if (!frame.ContainsKey("@graph"))
                 {
@@ -130,20 +131,20 @@ internal static class FramingProcessor
                 // 4.5.2 - Otherwise, set subframe to the first entry for @graph in frame, or a new empty dictionary, if it does not exist, and set recurse to true, unless id is @merged or @default.
                 else
                 {
-                    //var graphEntry = (frame["@graph"] as JArray);
+                    //var graphEntry = (frame["@graph"] as JsonArray);
                     //if (graphEntry == null)
                     //{
-                    //    graphEntry = new JArray(new JObject());
+                    //    graphEntry = new JsonArray(new JsonObject());
                     //    frameObjectOrArray["@graph"] = graphEntry;
                     //}
                     //else if (graphEntry.Count == 0)
                     //{
-                    //    graphEntry.Add(new JObject());
+                    //    graphEntry.Add(new JsonObject());
                     //}
-                    // subframe = graphEntry[0] as JObject;
+                    // subframe = graphEntry[0] as JsonObject;
                     if (frame.ContainsKey("@graph"))
                     {
-                        subframe = frame["@graph"][0] as JObject;
+                        subframe = frame["@graph"][0] as JsonObject;
                     }
                     else
                     {
@@ -165,7 +166,7 @@ internal static class FramingProcessor
                     // 4.5.3.3 - Invoke the algorithm using a copy of state with the value of graph name set to id and the value of embedded flag set to false,
                     // the keys from the graph map in state associated with id as subjects, subframe as frame, output as parent, and @graph as active property. 
                     ProcessFrame(state,
-                        state.Subjects.Properties().Select(p => p.Name).ToList(),
+                        state.Subjects.Select(p => p.Key).ToList(),
                         subframe, output, "@graph", ordered, idStack);
                     // Pop the value from graph stack in state and set graph name in state back to that value.
                     state.GraphName = state.GraphStack.Pop();
@@ -177,18 +178,18 @@ internal static class FramingProcessor
             {
                 var oldEmbedded = state.Embedded;
                 state.Embedded = false;
-                JToken includeFrame = frame["@included"];
+                JsonNode includeFrame = frame["@included"];
                 ProcessFrame(state, subjects, includeFrame, output, "@included", ordered, idStack);
                 state.Embedded = oldEmbedded;
             }
 
             // 4.7 - For each property and objects in node, ordered by property:
-            IEnumerable<JProperty> nodeProperties = node.Properties();
-            if (ordered) nodeProperties = nodeProperties.OrderBy(p => p.Name, StringComparer.Ordinal);
-            foreach (JProperty p in nodeProperties)
+            IEnumerable<KeyValuePair<string, JsonNode>> nodeProperties = node;
+            if (ordered) nodeProperties = nodeProperties.OrderBy(p => p.Key, StringComparer.Ordinal);
+            foreach (var p in nodeProperties)
             {
-                var property = p.Name;
-                var objects =p.Value as JArray;
+                var property = p.Key;
+                var objects = p.Value as JsonArray;
 
                 // 4.7.1 - If property is a keyword, add property and objects to output.
                 if (JsonLdUtils.IsKeyword(property))
@@ -204,17 +205,17 @@ internal static class FramingProcessor
                 }
 
                 // 4.7.3 - For each item in objects:
-                foreach (JToken item in objects)
+                foreach (JsonNode item in objects)
                 {
                     // 4.7.3.1 - If item is a dictionary with the property @list, 
                     // then each listitem in the list is processed in sequence and 
                     // added to a new list dictionary in output:
                     if (JsonLdUtils.IsListObject(item))
                     {
-                        var list = new JObject();
+                        var list = new JsonObject();
                         output[property] =
-                            new JArray(list); // KA: Not sure what the correct key is for the list object
-                        foreach (JToken listItem in item["@list"] as JArray)
+                            new JsonArray(list); // KA: Not sure what the correct key is for the list object
+                        foreach (JsonNode listItem in item["@list"] as JsonArray)
                         {
                             // 4.7.3.1.1 - If listitem is a node reference, invoke the recursive algorithm using state, 
                             // the value of @id from listitem as the sole member of a new subjects array, 
@@ -224,18 +225,18 @@ internal static class FramingProcessor
                             // with properties for @embed, @explicit and @requireAll taken from embed, explicit and requireAll. 
                             if (JsonLdUtils.IsNodeReference(listItem))
                             {
-                                JToken listFrame = null;
-                                if (frame.ContainsKey(property) && frame[property] is JArray fpArray &&
-                                    fpArray.Count > 0 && fpArray[0] is JObject subframe &&
+                                JsonNode listFrame = null;
+                                if (frame.ContainsKey(property) && frame[property] is JsonArray fpArray &&
+                                    fpArray.Count > 0 && fpArray[0] is JsonObject subframe &&
                                     subframe.ContainsKey("@list"))
                                 {
-                                    listFrame = subframe["@list"] as JArray;
+                                    listFrame = subframe["@list"] as JsonArray;
                                 }
                                 if (listFrame == null) listFrame = MakeFrameObject(embed, explicitFlag, requireAll);
                                 var oldEmbedded = state.Embedded;
                                 state.Embedded = true;
                                 ProcessFrame(state,
-                                    [listItem["@id"].Value<string>()],
+                                    [listItem["@id"].GetValue<string>()],
                                     listFrame,
                                     list,
                                     "@list",
@@ -248,10 +249,10 @@ internal static class FramingProcessor
                             {
                                 if (list["@list"] == null)
                                 {
-                                    list["@list"] = new JArray();
+                                    list["@list"] = new JsonArray();
                                 }
 
-                                (list["@list"] as JArray).Add(listItem.DeepClone());
+                                (list["@list"] as JsonArray).Add(listItem.DeepClone());
                             }
                         }
                     }
@@ -263,12 +264,12 @@ internal static class FramingProcessor
                     // If frame does not exist, create a new frame using a new map with properties for @embed, @explicit and @requireAll taken from embed, explicit and requireAll.
                     else if (JsonLdUtils.IsNodeReference(item))
                     {
-                        JObject newFrame = ((frameObjectOrArray[property] as JArray)?[0]) as JObject ??
+                        JsonObject newFrame = ((frameObjectOrArray[property] as JsonArray)?[0]) as JsonObject ??
                                            MakeFrameObject(embed, explicitFlag, requireAll);
                         var oldEmbedded = state.Embedded;
                         state.Embedded = true;
                         ProcessFrame(state,
-                            [item["@id"].Value<string>()],
+                            [item["@id"].GetValue<string>()],
                             newFrame,
                             output,
                             property,
@@ -292,9 +293,9 @@ internal static class FramingProcessor
             }
 
             // 4.7.4 - For each non-keyword property and objects in frame (other than `@type) that is not in output: 
-            foreach (JProperty frameProperty in frame.Properties())
+            foreach (KeyValuePair<string, JsonNode> frameProperty in frame)
             {
-                var property = frameProperty.Name;
+                var property = frameProperty.Key;
                 if (property.Equals("@type"))
                 {
                     if (!IsDefaultObjectArray(frameProperty.Value)) continue;
@@ -304,20 +305,20 @@ internal static class FramingProcessor
                     if (output.ContainsKey(property) || JsonLdUtils.IsKeyword(property)) continue;
                 }
 
-                var objects = frameProperty.Value as JArray;
+                var objects = frameProperty.Value as JsonArray;
                 if (objects == null || objects.Count == 0)
                 {
                     // KA - Check that this is still needed?
                     // Initialise as an array containing an empty frame
-                    objects = new JArray(new JObject());
+                    objects = new JsonArray(new JsonObject());
                 }
 
                 // 4.7.4.1 - Let item be the first element in objects, which must be a frame object.
-                JToken item = objects[0];
+                JsonNode item = objects[0];
                 ValidateFrame(item);
 
                 // 4.7.4.2 - Set property frame to the first item in objects or a newly created frame object if value is objects. property frame must be a dictionary.
-                JObject propertyFrame = objects[0] as JObject ?? MakeFrameObject(embed, explicitFlag, requireAll); // KA - incomplete as I can't make sense of the spec algorithm here
+                JsonObject propertyFrame = objects[0] as JsonObject ?? MakeFrameObject(embed, explicitFlag, requireAll); // KA - incomplete as I can't make sense of the spec algorithm here
                 // 4.7.4.3 - Skip property and property frame if property frame contains @omitDefault with a value of true, or does not contain @omitDefault and the value of the omit default flag is true.
                 var frameOmitDefault = GetBooleanOption(propertyFrame, "@omitDefault", state.OmitDefault);
                 if (frameOmitDefault)
@@ -326,34 +327,34 @@ internal static class FramingProcessor
                 }
 
                 // 4.7.4.4 - Add property to output with a new dictionary having a property @preserve and a value that is a copy of the value of @default in frame if it exists, or the string @null otherwise.
-                JArray defaultValue = JsonLdUtils.EnsureArray(propertyFrame["@default"]) ?? new JArray("@null");
-                output[property] = new JObject(new JProperty("@preserve", defaultValue));
-                //if (!(defaultValue is JArray)) defaultValue = new JArray(defaultValue);
-                //FramingAppend(output, new JObject(new JProperty("@preserve", defaultValue)), property);
-                // // output[property] = new JObject(new JProperty("@preserve", frame["@default"] ?? "@null"));
+                JsonArray defaultValue = JsonLdUtils.EnsureArray(propertyFrame["@default"]) ?? new JsonArray("@null");
+                output[property] = new JsonObject{["@preserve"] = defaultValue};
+                //if (!(defaultValue is JsonArray)) defaultValue = new JsonArray(defaultValue);
+                //FramingAppend(output, new JsonObject(new JProperty("@preserve", defaultValue)), property);
+                // // output[property] = new JsonObject(new JProperty("@preserve", frame["@default"] ?? "@null"));
             }
 
             // 4.7.5 - If frame has the property @reverse, then for each reverse property and sub frame that are the values of @reverse in frame:
             if (frame.ContainsKey("@reverse"))
             {
-                foreach (JProperty rp in (frame["@reverse"] as JObject).Properties())
+                foreach (KeyValuePair<string, JsonNode> rp in frame["@reverse"] as JsonObject)
                 {
-                    var reverseProperty = rp.Name;
-                    JToken subFrame = rp.Value;
+                    var reverseProperty = rp.Key;
+                    JsonNode subFrame = rp.Value;
                     // 4.7.5.1 - Create a @reverse property in output with a new dictionary reverse dict as its value.
-                    output["@reverse"] ??= new JObject();
-                    JToken reverseDict = output["@reverse"];
+                    output["@reverse"] ??= new JsonObject();
+                    JsonNode reverseDict = output["@reverse"];
 
                     // 4.7.5.2 - For each reverse id and node in the map of flattened subjects that has the property reverse property containing a node reference with an @id of id:
-                    foreach (JProperty p in state.Subjects.Properties())
+                    foreach (KeyValuePair<string, JsonNode> p in state.Subjects)
                     {
-                        var n = p.Value as JObject;
-                        if (n[reverseProperty] is not JArray reversePropertyValues) continue;
-                        if (reversePropertyValues.Any(x => x["@id"]?.Value<string>().Equals(id) == true))
+                        var n = p.Value as JsonObject;
+                        if (n[reverseProperty] is not JsonArray reversePropertyValues) continue;
+                        if (reversePropertyValues.Any(x => x["@id"]?.GetValue<string>().Equals(id) == true))
                         {
                             // 4.7.5.2.1 - Add reverse property to reverse dict with a new empty array as its value.
-                            var reverseId = p.Name;
-                            reverseDict[reverseProperty] ??= new JArray();
+                            var reverseId = p.Key;
+                            reverseDict[reverseProperty] ??= new JsonArray();
                             // 4.7.5.2.2 - Invoke the recursive algorithm using state, the reverse id as the sole member of a new subjects array, sub frame as frame, null as active property, and the array value of reverse property in reverse dict as parent.
                             var oldEmbedded = state.Embedded;
                             state.Embedded = true;
@@ -376,13 +377,13 @@ internal static class FramingProcessor
         }
     }
 
-    private static JsonLdEmbed GetEmbedOption(JObject frame, JsonLdEmbed defaultValue, JsonLdProcessingMode processingMode)
+    private static JsonLdEmbed GetEmbedOption(JsonObject frame, JsonLdEmbed defaultValue, JsonLdProcessingMode processingMode)
     {
         if (frame["@embed"] != null)
         {
-            var embedString = frame["@embed"] is JObject
-                ? frame["@embed"]["@value"].Value<string>()
-                : frame["@embed"].Value<string>();
+            var embedString = frame["@embed"] is JsonObject
+                ? frame["@embed"]["@value"].GetValue<string>()
+                : frame["@embed"].GetValue<string>();
             switch (embedString.ToLowerInvariant())
             {
                 case "@always":
@@ -412,12 +413,14 @@ internal static class FramingProcessor
         return defaultValue;
     }
 
-    private static JObject MakeFrameObject(JsonLdEmbed embed, bool explicitFlag, bool requireAll)
+    private static JsonObject MakeFrameObject(JsonLdEmbed embed, bool explicitFlag, bool requireAll)
     {
-        var ret = new JObject(
-            new JProperty("@embed", JsonLdEmbedAsString(embed)),
-            new JProperty("@explicit", explicitFlag),
-            new JProperty("@requireAll", requireAll));
+        var ret = new JsonObject
+        {
+            ["@embed"] = JsonLdEmbedAsString(embed),
+            ["@explicit"] = explicitFlag,
+            ["@requireAll"] = requireAll,
+        };
         return ret;
     }
 
@@ -440,41 +443,41 @@ internal static class FramingProcessor
         }
     }
 
-    private static bool GetBooleanOption(JObject frame, string property, bool defaultValue)
+    private static bool GetBooleanOption(JsonObject frame, string property, bool defaultValue)
     {
         if (frame[property] != null)
         {
             switch (frame[property])
             {
-                case JValue optValue:
-                    return optValue.Type == JTokenType.Null ? defaultValue :optValue.Value<bool>();
-                case JObject optObject:
-                    return optObject.ContainsKey("@value") ? optObject["@value"].Value<bool>() : defaultValue;
+                case JsonValue optValue:
+                    return optValue.GetValueKind() == JsonValueKind.Null ? defaultValue :optValue.GetValue<bool>();
+                case JsonObject optObject:
+                    return optObject.ContainsKey("@value") ? optObject["@value"].GetValue<bool>() : defaultValue;
             }
         }
         return defaultValue;
     }
 
 
-    private static Dictionary<string, JObject> MatchFrame(FramingState state, IEnumerable<string> subjects,
-        JObject frame, bool requireAll)
+    private static Dictionary<string, JsonObject> MatchFrame(FramingState state, IEnumerable<string> subjects,
+        JsonObject frame, bool requireAll)
     {
-        var matches = new Dictionary<string, JObject>();
-        JArray idMatches = frame.ContainsKey("@id") ? JsonLdUtils.EnsureArray(frame["@id"]) : null;
-        JArray typeMatches = frame.ContainsKey("@type") ? JsonLdUtils.EnsureArray(frame["@type"]) : null;
-        var propertyMatches = new Dictionary<string, JArray>();
-        foreach (KeyValuePair<string, JToken> p in frame)
+        var matches = new Dictionary<string, JsonObject>();
+        JsonArray idMatches = frame.ContainsKey("@id") ? JsonLdUtils.EnsureArray(frame["@id"]) : null;
+        JsonArray typeMatches = frame.ContainsKey("@type") ? JsonLdUtils.EnsureArray(frame["@type"]) : null;
+        var propertyMatches = new Dictionary<string, JsonArray>();
+        foreach (KeyValuePair<string, JsonNode> p in frame)
         {
             if (JsonLdUtils.IsKeyword(p.Key)) continue;
             propertyMatches[p.Key] = JsonLdUtils.EnsureArray(p.Value);
         }
         foreach (var subject in subjects)
         {
-            var node = state.Subjects[subject] as JObject;
+            var node = state.Subjects[subject] as JsonObject;
             // Check @id and @type first
             if (idMatches != null)
             {
-                if (!(IsWildcard(idMatches) || IsMatchNone(idMatches) || idMatches.Any(v=>v.Value<string>().Equals(subject))))
+                if (!(IsWildcard(idMatches) || IsMatchNone(idMatches) || idMatches.Any(v=>v.GetValue<string>().Equals(subject))))
                 {
                     // No match on id. Continue to next subject
                     continue;
@@ -488,12 +491,12 @@ internal static class FramingProcessor
             }
             if (typeMatches != null)
             {
-                JArray nodeTypes = node.ContainsKey("@type") ? JsonLdUtils.EnsureArray(node["@type"]) : null;
+                JsonArray nodeTypes = node.ContainsKey("@type") ? JsonLdUtils.EnsureArray(node["@type"]) : null;
                 var hasTypeMatch =
-                    IsMatchNone(typeMatches) && (nodeTypes == null || nodeTypes.Count == 0) ||
-                    IsWildcard(typeMatches) && nodeTypes != null && nodeTypes.Count > 0 ||
+                    (IsMatchNone(typeMatches) && (nodeTypes == null || nodeTypes.Count == 0)) ||
+                    (IsWildcard(typeMatches) && nodeTypes != null && nodeTypes.Count > 0) ||
                     IsDefaultObjectArray(typeMatches) ||
-                    nodeTypes != null && typeMatches.Any(t => nodeTypes.Any(nt => nt.Value<string>().Equals(t.Value<string>())));
+                    (nodeTypes != null && typeMatches.Any(t => nodeTypes.Any(nt => nt.GetValue<string>().Equals(t.GetValue<string>()))));
                 if (hasTypeMatch)
                 {
                     if (!requireAll)
@@ -530,7 +533,7 @@ internal static class FramingProcessor
             // If !requireAll, assume there is no match and break when disproven
             var match = requireAll;
             var hasNonDefaultMatch = false;
-            foreach (KeyValuePair<string, JArray> pm in propertyMatches)
+            foreach (KeyValuePair<string, JsonArray> pm in propertyMatches)
             {
                 MatchType propertyMatch = MatchProperty(state, node, pm.Key, pm.Value, requireAll);
                 if (propertyMatch == MatchType.Abort)
@@ -566,10 +569,10 @@ internal static class FramingProcessor
         return matches;
     }
 
-    private static MatchType MatchProperty(FramingState state, JObject node, string property, JToken frameValue, bool requireAll)
+    private static MatchType MatchProperty(FramingState state, JsonObject node, string property, JsonNode frameValue, bool requireAll)
     {
-        var nodeValues = node[property] as JArray;
-        var frameArray = frameValue as JArray;
+        var nodeValues = node[property] as JsonArray;
+        var frameArray = frameValue as JsonArray;
         bool isMatchNone = false, isWildcard = false, hasDefault = false;
         if (frameArray.Count == 0)
         {
@@ -604,9 +607,9 @@ internal static class FramingProcessor
         if (JsonLdUtils.IsValueObject(frameArray[0]))
         {
             // frameArray is a value pattern array
-            foreach (JToken valuePattern in frameArray)
+            foreach (JsonNode valuePattern in frameArray)
             {
-                foreach (JToken value in nodeValues)
+                foreach (JsonNode value in nodeValues)
                 {
                     if (ValuePatternMatch(valuePattern, value))
                     {
@@ -619,19 +622,19 @@ internal static class FramingProcessor
 
         if (JsonLdUtils.IsListObject(frameArray[0]))
         {
-            JToken frameListValue = frameArray[0]["@list"][0];
+            JsonNode frameListValue = frameArray[0]["@list"][0];
             if (JsonLdUtils.IsListObject(nodeValues[0]))
             {
-                JToken nodeListValues = nodeValues[0]["@list"];
+                JsonNode nodeListValues = nodeValues[0]["@list"];
                 if (JsonLdUtils.IsValueObject(frameListValue))
                 {
-                    if (nodeListValues.Any(v => ValuePatternMatch(frameListValue, v)))
+                    if (nodeListValues.AsArray().Any(v => ValuePatternMatch(frameListValue, v)))
                     {
                         return MatchType.Match;
                     }
                 } else if (JsonLdUtils.IsSubject(frameListValue) || JsonLdUtils.IsSubjectReference(frameListValue))
                 {
-                    if (nodeListValues.Any(v => NodePatternMatch(state, frameListValue as JObject, v, requireAll)))
+                    if (nodeListValues.AsArray().Any(v => NodePatternMatch(state, frameListValue as JsonObject, v, requireAll)))
                     {
                         return MatchType.Match;
                     }
@@ -640,12 +643,12 @@ internal static class FramingProcessor
         }
 
         // frameArray is a node pattern array
-        var valueSubjects = nodeValues.Where(x => x["@id"] != null).Select(x => x["@id"].Value<string>()).ToList();
+        var valueSubjects = nodeValues.Where(x => x["@id"] != null).Select(x => x["@id"].GetValue<string>()).ToList();
         if (valueSubjects.Any())
         {
-            foreach (JToken subframe in frameArray)
+            foreach (JsonNode subframe in frameArray)
             {
-                Dictionary<string, JObject> matchedSubjects = MatchFrame(state, valueSubjects, subframe as JObject, requireAll);
+                Dictionary<string, JsonObject> matchedSubjects = MatchFrame(state, valueSubjects, subframe as JsonObject, requireAll);
                 if (matchedSubjects.Any()) return MatchType.Match;
             }
         }
@@ -653,35 +656,35 @@ internal static class FramingProcessor
         return hasDefault ? MatchType.Match : MatchType.NoMatch;
     }
 
-    private static bool NodePatternMatch(FramingState state, JObject frame, JToken value, bool requireAll)
+    private static bool NodePatternMatch(FramingState state, JsonObject frame, JsonNode value, bool requireAll)
     {
-        if (value is not JObject valueObject || !valueObject.ContainsKey("@id")) return false;
-        Dictionary<string, JObject> matches = MatchFrame(state, [valueObject["@id"].Value<string>()], frame, requireAll);
+        if (value is not JsonObject valueObject || !valueObject.ContainsKey("@id")) return false;
+        Dictionary<string, JsonObject> matches = MatchFrame(state, [valueObject["@id"].GetValue<string>()], frame, requireAll);
         return matches.Any();
 
     }
 
-    private static bool ValuePatternMatch(JToken valuePattern, JToken value)
+    private static bool ValuePatternMatch(JsonNode valuePattern, JsonNode value)
     {
-        if (valuePattern is JArray array) valuePattern = array[0];
-        var valuePatternObject = valuePattern as JObject;
-        var valueObject = value as JObject;
+        if (valuePattern is JsonArray array) valuePattern = array[0];
+        var valuePatternObject = valuePattern as JsonObject;
+        var valueObject = value as JsonObject;
         if (valuePatternObject == null || valueObject == null) return false;
         if (valuePatternObject.Count == 0)
         {
             // Pattern is wildcard
             return true;
         }
-        JToken v1 = valueObject["@value"];
-        JToken t1 = valueObject["@type"];
-        JToken l1 = valueObject["@language"];
-        JToken v2 = valuePatternObject["@value"];
-        JToken t2 = valuePatternObject["@type"];
-        JToken l2 = valuePatternObject["@language"];
+        JsonNode v1 = valueObject["@value"];
+        JsonNode t1 = valueObject["@type"];
+        JsonNode l1 = valueObject["@language"];
+        JsonNode v2 = valuePatternObject["@value"];
+        JsonNode t2 = valuePatternObject["@type"];
+        JsonNode l2 = valuePatternObject["@language"];
         return ValuePatternTokenMatch(v2, v1) && ValuePatternTokenMatch(t2, t1) && ValuePatternTokenMatch(l2, l1, true);
     }
 
-    private static bool ValuePatternTokenMatch(JToken patternToken, JToken valueToken, bool normalizeCase = false)
+    private static bool ValuePatternTokenMatch(JsonNode patternToken, JsonNode valueToken, bool normalizeCase = false)
     {
         if (patternToken == null && valueToken == null) return true;
         if (IsWildcard(patternToken))
@@ -689,7 +692,7 @@ internal static class FramingProcessor
             // Pattern is a wildcard
             return valueToken != null;
         }
-        var patternTokenArray = patternToken as JArray;
+        var patternTokenArray = patternToken as JsonArray;
         if (patternTokenArray != null)
         {
             if (!patternTokenArray.Any())
@@ -700,20 +703,20 @@ internal static class FramingProcessor
             // Otherwise the value token must be in the pattern token array
             if (normalizeCase) valueToken = Lowercase(valueToken);
             return normalizeCase ? 
-                patternTokenArray.Any(x=>JToken.DeepEquals(Lowercase(x), valueToken)) :
-                patternTokenArray.Any(x => JToken.DeepEquals(x, valueToken));
+                patternTokenArray.Any(x=>JsonNode.DeepEquals(Lowercase(x), valueToken)) :
+                patternTokenArray.Any(x => JsonNode.DeepEquals(x, valueToken));
         }
         // Otherwise the pattern specifies a single value to match - just do a straight value match
         return normalizeCase
-            ? JToken.DeepEquals(Lowercase(patternToken), Lowercase(valueToken))
-            : JToken.DeepEquals(patternToken, valueToken);
+            ? JsonNode.DeepEquals(Lowercase(patternToken), Lowercase(valueToken))
+            : JsonNode.DeepEquals(patternToken, valueToken);
     }
 
-    private static JToken Lowercase(JToken token)
+    private static JsonNode Lowercase(JsonNode token)
     {
         if (token == null) return null;
-        if (token.Type == JTokenType.String){
-            return new JValue(token.Value<string>().ToLower(CultureInfo.InvariantCulture));
+        if (token.GetValueKind() == JsonValueKind.String){
+            return JsonValue.Create(token.GetValue<string>().ToLower(CultureInfo.InvariantCulture));
         }
 
         return token;
@@ -732,29 +735,28 @@ internal static class FramingProcessor
         Abort,
     }
 
-    private static bool IsWildcard(JToken token)
+    private static bool IsWildcard(JsonNode token)
     {
         if (token == null) return false;
-        switch (token.Type)
+        switch (token.GetValueKind())
         {
-            case JTokenType.Array:
-                return (token as JArray).Any(IsWildcard);
-            case JTokenType.Object:
-                return (token as JObject).Properties()
-                    .All(p => JsonLdKeywords.FramingKeywords.Contains(p.Name));
+            case JsonValueKind.Array:
+                return (token as JsonArray).Any(IsWildcard);
+            case JsonValueKind.Object:
+                return (token as JsonObject).All(p => JsonLdKeywords.FramingKeywords.Contains(p.Key));
             default:
                 return false;
         }
     }
 
-    private static bool IsMatchNone(JToken token)
+    private static bool IsMatchNone(JsonNode token)
     {
         return JsonLdUtils.IsEmptyArray(token);
     }
 
-    private static bool IsEmptyMapArray(JToken token)
+    private static bool IsEmptyMapArray(JsonNode token)
     {
-        return (token is JArray array) && array.Count == 1 && JsonLdUtils.IsEmptyMap(array[0]);
+        return (token is JsonArray array) && array.Count == 1 && JsonLdUtils.IsEmptyObject(array[0]);
     }
 
     /// <summary>
@@ -762,10 +764,10 @@ internal static class FramingProcessor
     /// </summary>
     /// <param name="value">The token to validate.</param>
     /// <exception cref="JsonLdProcessorException">Raised if <paramref name="value"/> is not a valid frame object.</exception>
-    private static void ValidateFrame(JToken value)
+    private static void ValidateFrame(JsonNode value)
     {
         // 1.1 - Frame MUST be a map.
-        if (value is not JObject obj)
+        if (value is not JsonObject obj)
         {
             throw new JsonLdProcessorException(JsonLdErrorCode.InvalidFrame,
                 $"Invalid frame. The frame must be a map.");
@@ -776,7 +778,7 @@ internal static class FramingProcessor
         // value, a valid IRI or an array where all values are valid IRIs.
         if (obj.ContainsKey("@id"))
         {
-            JToken idValue = obj["@id"];
+            JsonNode idValue = obj["@id"];
             if (!(IsEmptyMapArray(idValue) || JsonLdUtils.IsIri(idValue) || JsonLdUtils.IsArray(idValue, JsonLdUtils.IsIri)))
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidFrame,
@@ -790,7 +792,7 @@ internal static class FramingProcessor
         // values are valid IRIs.
         if (obj.ContainsKey("@type"))
         {
-            JToken typeValue = obj["@type"];
+            JsonNode typeValue = obj["@type"];
             if (!(IsEmptyMapArray(typeValue) || IsDefaultObjectArray(typeValue) || JsonLdUtils.IsIri(typeValue) ||
                   JsonLdUtils.IsArray(typeValue, JsonLdUtils.IsIri)))
             {
@@ -803,9 +805,9 @@ internal static class FramingProcessor
         }
     }
 
-    private static void FramingAppend(JToken parent, JToken child, string activeProperty)
+    private static void FramingAppend(JsonNode parent, JsonNode child, string activeProperty)
     {
-        if (parent is JArray parentArray)
+        if (parent is JsonArray parentArray)
         {
             if (activeProperty != null)
             {
@@ -813,7 +815,7 @@ internal static class FramingProcessor
             }
             parentArray.Add(child);
         }
-        else if (parent is JObject parentObject)
+        else if (parent is JsonObject parentObject)
         {
             if (string.IsNullOrEmpty(activeProperty))
             {
@@ -821,7 +823,7 @@ internal static class FramingProcessor
                     "Active property must be a non-null value when the parent is a JSON object",
                     nameof(activeProperty));
             }
-            var array = parentObject[activeProperty] as JArray;
+            var array = parentObject[activeProperty] as JsonArray;
             if (array == null)
             {
                 parent[activeProperty] = array = [];
@@ -830,28 +832,28 @@ internal static class FramingProcessor
         }
     }
 
-    private static bool IsDefaultObjectArray(JToken token)
+    private static bool IsDefaultObjectArray(JsonNode token)
     {
-        return token is JArray array &&
+        return token is JsonArray array &&
                array.Count == 1 &&
-               array[0] is JObject o &&
+               array[0] is JsonObject o &&
                o.Count == 1 &&
                o.ContainsKey("@default");
     }
 
     private static void RemoveEmbed(FramingState state, string id)
     {
-        Tuple<JToken, string> embed = state.GetEmbeddedNode(id);
+        Tuple<JsonNode, string> embed = state.GetEmbeddedNode(id);
         if (embed == null) return;
-        JToken parent = embed.Item1;
+        JsonNode parent = embed.Item1;
         var property = embed.Item2;
-        var subject = new JObject(new JProperty("@id", id));
-        if (parent is JArray parentArray)
+        var subject = new JsonObject{["@id"] = id};
+        if (parent is JsonArray parentArray)
         {
             for(var i = 0; i < parentArray.Count; i++)
             {
-                JToken item = parentArray[i];
-                if (item is JObject itemObject && itemObject.ContainsKey("@id") && itemObject["@id"].Value<string>().Equals(id))
+                JsonNode item = parentArray[i];
+                if (item is JsonObject itemObject && itemObject.ContainsKey("@id") && itemObject["@id"].GetValue<string>().Equals(id))
                 {
                     parent[i] = subject;
                     break;
@@ -861,8 +863,8 @@ internal static class FramingProcessor
         else
         {
             var useArray = JsonLdUtils.IsArray(parent[property]);
-            JsonLdUtils.RemoveValue(parent as JObject, property, subject, useArray);
-            JsonLdUtils.AddValue(parent as JObject, property, subject, useArray);
+            JsonLdUtils.RemoveValue(parent as JsonObject, property, subject, useArray);
+            JsonLdUtils.AddValue(parent as JsonObject, property, subject, useArray);
         }
     }
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingState.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/FramingState.cs
@@ -26,7 +26,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd.Processors;
@@ -37,16 +37,16 @@ internal class FramingState
     public bool ExplicitInclusion { get; set; }
     public bool RequireAll { get; set; }
     public bool OmitDefault { get; set; }
-    public JObject GraphMap { get; set; }
+    public JsonObject GraphMap { get; set; }
     public string GraphName { get; set; }
-    public JObject Subjects => GraphMap[GraphName] as JObject;
+    public JsonObject Subjects => GraphMap[GraphName] as JsonObject;
     public Stack<string> GraphStack { get; set; }
-    public JObject Link { get; set; }
+    public JsonObject Link { get; set; }
     public bool Embedded { get; set; }
 
-    private readonly Dictionary<string, Dictionary<string, Tuple<JToken, string>>> _embeds;
+    private readonly Dictionary<string, Dictionary<string, Tuple<JsonNode, string>>> _embeds;
 
-    public FramingState(JsonLdProcessorOptions options, JObject graphMap, string graphName)
+    public FramingState(JsonLdProcessorOptions options, JsonObject graphMap, string graphName)
     {
         Embed = options.Embed;
         Embedded = false;
@@ -73,17 +73,17 @@ internal class FramingState
         return _embeds[GraphName].ContainsKey(id);
     }
 
-    public void AddEmbeddedNode(string id, JToken node, string property)
+    public void AddEmbeddedNode(string id, JsonNode node, string property)
     {
         if (!_embeds.ContainsKey(GraphName))
         {
             _embeds[GraphName] = [];
         }
 
-        _embeds[GraphName][id] = new Tuple<JToken, string>(node, property);
+        _embeds[GraphName][id] = new Tuple<JsonNode, string>(node, property);
     }
 
-    public Tuple<JToken, string> GetEmbeddedNode(string id)
+    public Tuple<JsonNode, string> GetEmbeddedNode(string id)
     {
         if (_embeds.ContainsKey(GraphName) && _embeds[GraphName].ContainsKey(id))
         {

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
@@ -529,6 +529,7 @@ internal class JsonLdUtils
     /// <param name="parent">The subject node to retrieve a property from.</param>
     /// <param name="propertyName">The name of the property whose value is to be retrieved.</param>
     /// <returns>The property value if found, null otherwise.</returns>
+    [Obsolete("This method will incorrectly return null if the property exists but has a null value. Use TryGetPropertyValue instead.", true)]
     public static JsonNode GetPropertyValue(JsonLdContext activeContext, JsonObject parent, string propertyName)
     {
         if (parent.TryGetPropertyValue(propertyName, out JsonNode ret)) return ret;
@@ -537,6 +538,42 @@ internal class JsonLdUtils
             if (parent.TryGetPropertyValue(alias, out ret)) return ret;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Tries to get the value of a property from a subject node, taking into account possible aliases defined in the active context.
+    /// </summary>
+    /// <param name="activeContext">The context to use.</param>
+    /// <param name="parent">The subject node to retrieve a property from.</param>
+    /// <param name="propertyName">The name of the property whose value is to be retrieved.</param>
+    /// <param name="value">The property value if found, null otherwise.</param>
+    /// <returns>True if the property value was found, false otherwise.</returns>
+    public static bool TryGetPropertyValue(JsonLdContext activeContext, JsonObject parent, string propertyName, out JsonNode value)
+    {
+        if (parent.TryGetPropertyValue(propertyName, out value)) return true;
+        foreach (var alias in activeContext.GetAliases(propertyName))
+        {
+            if (parent.TryGetPropertyValue(alias, out value)) return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Determine if a subject node has a property, taking into account possible aliases defined in the active context.
+    /// </summary>
+    /// <param name="activeContext">The context to use.</param>
+    /// <param name="parent">The subject node to check for the property.</param>
+    /// <param name="propertyName">The name of the property to check for.</param>
+    /// <returns>True if the property exists, false otherwise.</returns>
+    public static bool HasProperty(JsonLdContext activeContext, JsonObject parent, string propertyName)
+    {
+        if (parent.ContainsKey(propertyName)) return true;
+        foreach (var alias in activeContext.GetAliases(propertyName))
+        {
+            if (parent.ContainsKey(alias)) return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
@@ -53,7 +53,7 @@ internal class JsonLdUtils
     public static JsonArray EnsureArray(JsonNode token)
     {
         if (token is JsonArray array) return array;
-        return new JsonArray(token.DeepClone());
+        return new JsonArray(token.DetachedClone());
     }
 
     /// <summary>
@@ -230,7 +230,10 @@ internal class JsonLdUtils
     /// <returns>True if <paramref name="node"/> is a string whose value is a valid IRI, false otherwise.</returns>
     public static bool IsIri(JsonNode node)
     {
-        return (node is JsonValue value && value.GetValue<string>() is string s && IsIri(s));
+        return node is JsonValue value &&
+            value.SafeValueKind() == JsonValueKind.String &&
+            value.GetValue<string>() is string s &&
+            IsIri(s);
     }
 
     /// <summary>
@@ -248,6 +251,11 @@ internal class JsonLdUtils
         return !(node == null || node is JsonArray || node is JsonObject);
     }
 
+    public static bool IsScalarOrNull(JsonNode node)
+    {
+        return node == null || IsScalar(node);
+    }
+
     /// <summary>
     /// Determine if a JSON node represents a string value.
     /// </summary>
@@ -255,12 +263,12 @@ internal class JsonLdUtils
     /// <returns>True if <paramref name="node"/> represents a string value, false otherwise.</returns>
     public static bool IsString(JsonNode node)
     {
-        return node.GetValueKind() == JsonValueKind.String;
+        return node.SafeValueKind() == JsonValueKind.String;
     }
 
     public static bool IsValidBaseDirection(JsonNode token)
     {
-        if (token.GetValueKind() != JsonValueKind.String) return false;
+        if (token.SafeValueKind() != JsonValueKind.String) return false;
         var value = token.GetValue<string>();
         return value == "ltr" || value == "rtl";
     }
@@ -273,7 +281,7 @@ internal class JsonLdUtils
     /// <returns>True if the token represents JSON null, false otherwise.</returns>
     public static bool IsNull(JsonNode node)
     {
-        return node.GetValueKind() == JsonValueKind.Null;
+        return node.SafeValueKind() == JsonValueKind.Null;
     }
 
     /// <summary>
@@ -283,7 +291,7 @@ internal class JsonLdUtils
     /// <returns>True if <paramref name="node"/> represents a JSON string and the value of the string can be parsed as an absolute IRI, false otherwise.</returns>
     public static bool IsAbsoluteIri(JsonNode node)
     {
-        if (node.GetValueKind() != JsonValueKind.String) return false;
+        if (node.SafeValueKind() != JsonValueKind.String) return false;
         var value = node.GetValue<string>();
         return IsAbsoluteIri(value);
     }
@@ -311,7 +319,7 @@ internal class JsonLdUtils
     /// <returns>True if <paramref name="node"/> is a string node and the value of the string can be parsed as a relative IRI.</returns>
     public static bool IsRelativeIri(JsonNode node)
     {
-        if (node.GetValueKind() != JsonValueKind.String) return false;
+        if (node.SafeValueKind() != JsonValueKind.String) return false;
         var value = node.GetValue<string>();
         return IsRelativeIri(value);
     }
@@ -368,7 +376,7 @@ internal class JsonLdUtils
     /// or are both subject or subject references with matching @id values.</returns>
     public static bool CompareValues(JsonNode t1, JsonNode t2)
     {
-        if (t1.Equals(t2)) return true;
+        if (JsonNode.DeepEquals(t1, t2)) return true;
         if (t1 is JsonObject o1 && t2 is JsonObject o2)
         {
             if (IsValueObject(o1) && IsValueObject(o2))
@@ -433,27 +441,30 @@ internal class JsonLdUtils
         else
         {
             // Adding a single item
+            value = value.DetachedClone();
 
             // If the property doesn't exist, add value as the single value of the property
             if (!o.ContainsKey(entry))
             {
-                o[entry] = value.DeepClone();
+                o[entry] = value;
             }
             else
             {
                 // If property exists and its value is an array, append value to the array
                 if (o[entry] is JsonArray entryArray)
                 {
-                    entryArray.Add(value.DeepClone());
+                    entryArray.Add(value);
                 }
                 else
                 {
                     // Otherwise convert the target property value to an array and then append value
-                    entryArray = new JsonArray(o[entry])
+                    JsonNode existingValue = o[entry];
+                    o.Remove(entry);
+                    o[entry] = new JsonArray
                     {
-                        value.DeepClone(),
+                        existingValue,
+                        value,
                     };
-                    o[entry] = entryArray;
                 }
             }
         }
@@ -468,6 +479,7 @@ internal class JsonLdUtils
     /// <param name="propertyIsArray">True if the value of the property is always an array.</param>
     public static void RemoveValue(JsonObject subject, string property, JsonNode value, bool propertyIsArray = false)
     {
+        if (!subject.ContainsKey(property)) return;
         var values = EnsureArray(subject[property]).Where(t => !CompareValues(t, value)).ToList();
         switch (values.Count)
         {
@@ -479,9 +491,9 @@ internal class JsonLdUtils
                 break;
             default:
             {
-                var array = new JsonArray();
-                foreach (JsonNode v in values) array.Add(v);
-                subject[property] = array;
+                var newArray = new JsonArray();
+                foreach (JsonNode v in values) newArray.Add(v.DetachedClone());
+                subject[property] = newArray;
                 break;
             }
         }
@@ -499,7 +511,7 @@ internal class JsonLdUtils
         JsonArray result = EnsureArray(node1);
         if (node2 is JsonArray array)
         {
-            foreach (JsonNode c in array) result.Add(c);
+            foreach (JsonNode c in array) result.Add(c.DeepClone());
         }
         else
         {
@@ -538,7 +550,7 @@ internal class JsonLdUtils
     /// or if <paramref name="value"/> is a string but its value is neither 'ltr' nor 'rtl'.</exception>
     public static LanguageDirection ParseLanguageDirection(JsonNode value)
     {
-        switch (value.GetValueKind())
+        switch (value.SafeValueKind())
         {
             case JsonValueKind.Null:
                 return LanguageDirection.Unspecified;
@@ -577,7 +589,7 @@ internal class JsonLdUtils
 
     public static bool IsBooleanNode(JsonNode value)
     {
-        return value.GetValueKind() == JsonValueKind.True || value.GetValueKind() == JsonValueKind.False;
+        return value.SafeValueKind() == JsonValueKind.True || value.SafeValueKind() == JsonValueKind.False;
     }
 
     /// <summary>
@@ -603,7 +615,7 @@ internal class JsonLdUtils
             int index = array.IndexOf(node);
             if (index >= 0)
             {
-                array[index] = newValue;
+                array[index] = newValue.DetachedClone();
             }
         }
         else if (node.Parent is JsonObject obj)
@@ -611,7 +623,7 @@ internal class JsonLdUtils
             var property = obj.FirstOrDefault(p => p.Value == node);
             if (property.Key != null)
             {
-                obj[property.Key] = newValue;
+                obj[property.Key] = newValue.DetachedClone();
             }
         }
     }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
@@ -53,7 +53,7 @@ internal class JsonLdUtils
     public static JsonArray EnsureArray(JsonNode token)
     {
         if (token is JsonArray array) return array;
-        return new JsonArray(token);
+        return new JsonArray(token.DeepClone());
     }
 
     /// <summary>
@@ -437,21 +437,21 @@ internal class JsonLdUtils
             // If the property doesn't exist, add value as the single value of the property
             if (!o.ContainsKey(entry))
             {
-                o[entry] = value;
+                o[entry] = value.DeepClone();
             }
             else
             {
                 // If property exists and its value is an array, append value to the array
                 if (o[entry] is JsonArray entryArray)
                 {
-                    entryArray.Add(value);
+                    entryArray.Add(value.DeepClone());
                 }
                 else
                 {
                     // Otherwise convert the target property value to an array and then append value
                     entryArray = new JsonArray(o[entry])
                     {
-                        value,
+                        value.DeepClone(),
                     };
                     o[entry] = entryArray;
                 }
@@ -594,6 +594,26 @@ internal class JsonLdUtils
             result.TryAdd(kvp.Key, kvp.Value.DeepClone());
         }
         return result;
+    }
+
+    public static void ReplaceInParent(JsonNode node, JsonNode newValue)
+    {
+        if (node.Parent is JsonArray array)
+        {
+            int index = array.IndexOf(node);
+            if (index >= 0)
+            {
+                array[index] = newValue;
+            }
+        }
+        else if (node.Parent is JsonObject obj)
+        {
+            var property = obj.FirstOrDefault(p => p.Value == node);
+            if (property.Key != null)
+            {
+                obj[property.Key] = newValue;
+            }
+        }
     }
 
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
@@ -28,7 +28,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd.Processors;
@@ -49,10 +50,10 @@ internal class JsonLdUtils
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
-    public static JArray EnsureArray(JToken token)
+    public static JsonArray EnsureArray(JsonNode token)
     {
-        if (token is JArray array) return array;
-        return new JArray(token);
+        if (token is JsonArray array) return array;
+        return new JsonArray(token);
     }
 
     /// <summary>
@@ -60,9 +61,10 @@ internal class JsonLdUtils
     /// </summary>
     /// <param name="token">The token to test.</param>
     /// <returns>True if <paramref name="token"/> represents a JSON object and has no child properties, false otherwise.</returns>
-    public static bool IsEmptyMap(JToken token)
+    [Obsolete("Use IsEmptyObject(JsonNode) instead.")]
+    public static bool IsEmptyMap(JsonNode token)
     {
-        return token.Type == JTokenType.Object && !token.Children().Any();
+        return IsEmptyObject(token);
     }
 
     /// <summary>
@@ -80,117 +82,125 @@ internal class JsonLdUtils
     /// </summary>
     /// <param name="token">The token to check.</param>
     /// <returns>True if the token represents a JSON object with no properties, false otherwise.</returns>
-    public static bool IsEmptyObject(JToken token)
+    public static bool IsEmptyObject(JsonNode token)
     {
-        return (token is JObject obj && obj.Count == 0);
+        return token is JsonObject obj && obj.Count == 0;
     }
 
     /// <summary>
     /// Determine if the specified token is a JSON-LD default object.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is JSON object with an @default property, false otherwise.</returns>
-    public static bool IsDefaultObject(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is JSON object with an @default property, false otherwise.</returns>
+    public static bool IsDefaultObject(JsonNode node)
     {
-        return token is JObject o && o.ContainsKey("@default");
+        return node is JsonObject obj && obj.ContainsKey("@default");
+    }
+
+    public static bool HasNonNullProperty(JsonObject obj, string propertyName)
+    {
+        return obj.TryGetPropertyValue(propertyName, out JsonNode value) && value != null;
     }
 
     /// <summary>
     /// Determine if a JSON token is a JSON-LD value object.
     /// </summary>
-    /// <param name="token"></param>
-    /// <returns>True of <paramref name="token"/> is a <see cref="JObject"/> with a. <code>@value</code> property, false otherwise.</returns>
-    public static bool IsValueObject(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True of <paramref name="node"/> is a <see cref="JsonObject"/> with a non-null @value property, false otherwise.</returns>
+    public static bool IsValueObject(JsonNode node)
     {
-        return ((token as JObject)?.Property("@value")) != null;
+        return node is JsonObject obj && HasNonNullProperty(obj, "@value");
+    }
+
+
+    /// <summary>
+    /// Determine if a JSON node is a JSON-LD list object.
+    /// </summary>
+    /// <param name="node"></param>
+    /// <returns>True of <paramref name="node"/> is a <see cref="JsonObject"/> with a non-null @list property, false otherwise.</returns>
+    public static bool IsListObject(JsonNode node)
+    {
+        return node is JsonObject obj && HasNonNullProperty(obj, "@list");
     }
 
     /// <summary>
-    /// Determine if a JSON token is a JSON-LD list object.
+    /// Determine if a JSON node represents a JSON-LD node reference object.
     /// </summary>
-    /// <param name="token"></param>
-    /// <returns>True of <paramref name="token"/> is a <see cref="JObject"/> with a. <code>@list</code> property, false otherwise.</returns>
-    public static bool IsListObject(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is an object with a non-null @id property, false otherwise.</returns>
+    public static bool IsNodeReference(JsonNode node)
     {
-        return ((token as JObject)?.Property("@list")) != null;
+        return node is JsonObject obj && HasNonNullProperty(obj, "@id");
     }
 
     /// <summary>
-    /// Determine if a JSON token represents a JSON-LD node reference object.
+    /// Checks if a JSON node represents a subject.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is an object wth an @id property, false otherwise.</returns>
-    public static bool IsNodeReference(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is an object, is not an @value, @set or @list, and either has more than one key or does not have an @id key.</returns>
+    public static bool IsSubject(JsonNode node)
     {
-        return (token as JObject)?.Property("@id") != null;
+        return node is JsonObject obj &&
+               !(HasNonNullProperty(obj, "@value") || HasNonNullProperty(obj, "@set") || HasNonNullProperty(obj, "@list")) &&
+               (obj.Count > 1 || !HasNonNullProperty(obj, "@id"));
     }
 
     /// <summary>
-    /// Checks if a JSON token represents a subject.
+    /// Checks if a JSON node represents a subject reference.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is an object, is not an @vale, @set or @list, and either has more than one key or does not have an @id key.</returns>
-    public static bool IsSubject(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is an object with a single @id property.</returns>
+    public static bool IsSubjectReference(JsonNode node)
     {
-        return token is JObject t &&
-               !(t.ContainsKey("@value") || t.ContainsKey("@set") || t.ContainsKey("@list")) &&
-               (t.Count > 1 || !t.ContainsKey("@id"));
+        return node is JsonObject obj && obj.Count == 1 && HasNonNullProperty(obj, "@id");
     }
 
     /// <summary>
-    /// Checks if a JSON token represents a subject reference.
+    /// Determine if a JSON node is a JSON-LD graph object.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is an object with a single @id property.</returns>
-    public static bool IsSubjectReference(JToken token)
+    /// <param name="node"></param>
+    /// <returns>True if <paramref name="node"/> is a JsonObject with an @graph property and optionally @id and @index properties and no other properties; false otherwise.</returns>
+    public static bool IsGraphObject(JsonNode node)
     {
-        return token is JObject t && t.Count == 1 && t.ContainsKey("@id");
-    }
-
-    /// <summary>
-    /// Determine if a JSON token is a JSON-LD graph object.
-    /// </summary>
-    /// <param name="token"></param>
-    /// <returns>True if <paramref name="token"/> is a JObject with an @graph property and optionally @id and @index properties and no other properties; false otherwise.</returns>
-    public static bool IsGraphObject(JToken token)
-    {
-        if (token is not JObject o) return false;
+        if (node is not JsonObject o) return false;
+        if (o.Count > 3) return false;
         if (!o.ContainsKey("@graph")) return false;
-        return o.Properties().All(p => JsonLdKeywords.GraphObjectKeys.Contains(p.Name));
+        return o.All(p => JsonLdKeywords.GraphObjectKeys.Contains(p.Key));
     }
 
     /// <summary>
-    /// Determines if a JSON token is a JSON-LD simple graph object.
+    /// Determines if a JSON node is a JSON-LD simple graph object.
     /// </summary>
-    /// <param name="token">The token to test.</param>
-    /// <returns>True if <paramref name="token"/> is a JObject with an @graph property and optionally an @index property and no other properties; false otherwise.</returns>
-    public static bool IsSimpleGraphObject(JToken token)
+    /// <param name="node">The node to test.</param>
+    /// <returns>True if <paramref name="node"/> is a JsonObject with an @graph property and optionally an @index property and no other properties; false otherwise.</returns>
+    public static bool IsSimpleGraphObject(JsonNode node)
     {
-        if (token is not JObject o) return false;
+        if (node is not JsonObject o) return false;
+        if (o.Count > 2) return false;
         if (!o.ContainsKey("@graph")) return false;
-        return (o.Properties().All(p => p.Name == "@graph" || p.Name == "@index"));
+        return o.All(p => p.Key == "@graph" || p.Key == "@index");
     }
 
     /// <summary>
-    /// Determine if a JSON token is an array, optionally testing each item in the array.
+    /// Determine if a JSON node is an array, optionally testing each item in the array.
     /// </summary>
-    /// <param name="token">The token to test.</param>
-    /// <param name="itemTest">The test to be applied to each child item of <paramref name="token"/>.</param>
-    /// <returns>True if <paramref name="token"/> is a array and either <paramref name="itemTest"/> is null or returns true for all items in the array, false otherwise.</returns>
-    public static bool IsArray(JToken token, Func<JToken, bool> itemTest = null)
+    /// <param name="node">The node to test.</param>
+    /// <param name="itemTest">The test to be applied to each child item of <paramref name="node"/>.</param>
+    /// <returns>True if <paramref name="node"/> is a array and either <paramref name="node"/> is null or returns true for all items in the array, false otherwise.</returns>
+    public static bool IsArray(JsonNode node, Func<JsonNode, bool> itemTest = null)
     {
-        if (token.Type != JTokenType.Array) return false;
-        return itemTest == null || token.Children().All(itemTest);
+        if (node is not JsonArray array) return false;
+        return itemTest == null || array.All(itemTest);
     }
 
     /// <summary>
-    /// Determine if the specified token is an empty array token.
+    /// Determine if the specified node is an empty array node.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is an array with no items, false otherwise.</returns>
-    public static bool IsEmptyArray(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is an array with no items, false otherwise.</returns>
+    public static bool IsEmptyArray(JsonNode node)
     {
-        return token is JArray array && array.Count == 0;
+        return node is JsonArray array && array.Count == 0;
     }
 
     private static readonly Regex FragmentRegex = new Regex("^([a-zA-Z0-9-._~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*$");
@@ -214,13 +224,13 @@ internal class JsonLdUtils
     }
 
     /// <summary>
-    /// Determine if the specified token is an IRI string.
+    /// Determine if the specified node is an IRI string.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is a string whose value is a valid IRI, false otherwise.</returns>
-    public static bool IsIri(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is a string whose value is a valid IRI, false otherwise.</returns>
+    public static bool IsIri(JsonNode node)
     {
-        return (token.Type == JTokenType.String && IsIri(token.Value<string>()));
+        return (node is JsonValue value && value.GetValue<string>() is string s && IsIri(s));
     }
 
     /// <summary>
@@ -233,42 +243,49 @@ internal class JsonLdUtils
         return value != null && value.StartsWith("_:");
     }
 
-    public static bool IsScalar(JToken token)
+    public static bool IsScalar(JsonNode node)
     {
-        return !(token == null || token.Type == JTokenType.Array || token.Type == JTokenType.Object);
+        return !(node == null || node is JsonArray || node is JsonObject);
     }
 
     /// <summary>
-    /// Determine if a JSON token represents a string value.
+    /// Determine if a JSON node represents a string value.
     /// </summary>
-    /// <param name="token">The token to test.</param>
-    /// <returns>True if <paramref name="token"/> represents a string value, false otherwise.</returns>
-    public static bool IsString(JToken token)
+    /// <param name="node">The node to test.</param>
+    /// <returns>True if <paramref name="node"/> represents a string value, false otherwise.</returns>
+    public static bool IsString(JsonNode node)
     {
-        return token.Type == JTokenType.String;
+        return node.GetValueKind() == JsonValueKind.String;
     }
 
-    public static bool IsValidBaseDirection(JToken token)
+    public static bool IsValidBaseDirection(JsonNode token)
     {
-        if (token.Type != JTokenType.String) return false;
-        return token.Value<string>() == "ltr" || token.Value<string>() == "rtl";
+        if (token.GetValueKind() != JsonValueKind.String) return false;
+        var value = token.GetValue<string>();
+        return value == "ltr" || value == "rtl";
     }
 
 
     /// <summary>
-    /// Determine if a JSON token represents the null value.
+    /// Determine if a JSON node represents the null value.
     /// </summary>
-    /// <param name="token">The token to test.</param>
+    /// <param name="node">The node to test.</param>
     /// <returns>True if the token represents JSON null, false otherwise.</returns>
-    public static bool IsNull(JToken token)
+    public static bool IsNull(JsonNode node)
     {
-        return token.Type == JTokenType.Null;
+        return node.GetValueKind() == JsonValueKind.Null;
     }
 
-    public static bool IsAbsoluteIri(JToken token)
+    /// <summary>
+    /// Determine if a JSON node is a string whose value can be parsed as an absolute IRI.
+    /// </summary>
+    /// <param name="node">The node to tests.</param>
+    /// <returns>True if <paramref name="node"/> represents a JSON string and the value of the string can be parsed as an absolute IRI, false otherwise.</returns>
+    public static bool IsAbsoluteIri(JsonNode node)
     {
-        if (token is not JValue value) return false;
-        return value.Type == JTokenType.String && IsAbsoluteIri(value.Value<string>());
+        if (node.GetValueKind() != JsonValueKind.String) return false;
+        var value = node.GetValue<string>();
+        return IsAbsoluteIri(value);
     }
 
     /// <summary>
@@ -290,12 +307,13 @@ internal class JsonLdUtils
     /// <summary>
     /// Determine if a JSON token is a string whose value can be parsed as a relative IRI.
     /// </summary>
-    /// <param name="token">The token to check.</param>
-    /// <returns>True if <paramref name="token"/> is a string token and the value of the string can be parsed as a relative IRI.</returns>
-    public static bool IsRelativeIri(JToken token)
+    /// <param name="node">The node to check.</param>
+    /// <returns>True if <paramref name="node"/> is a string node and the value of the string can be parsed as a relative IRI.</returns>
+    public static bool IsRelativeIri(JsonNode node)
     {
-        if (token is not JValue value) return false;
-        return value.Type == JTokenType.String && IsRelativeIri(value.Value<string>());
+        if (node.GetValueKind() != JsonValueKind.String) return false;
+        var value = node.GetValue<string>();
+        return IsRelativeIri(value);
     }
 
     /// <summary>
@@ -321,15 +339,15 @@ internal class JsonLdUtils
     /// <summary>
     /// Determines if a token represents a JSON-LD node object.
     /// </summary>
-    /// <param name="token"></param>
+    /// <param name="node"></param>
     /// <param name="isTopmostMap"></param>
     /// <returns></returns>
-    public static bool IsNodeObject(JToken token, bool isTopmostMap = false)
+    public static bool IsNodeObject(JsonNode node, bool isTopmostMap = false)
     {
         // A map is a node object if it exists outside of the JSON-LD context and:
         //   - it does not contain the @value, @list, or @set keywords, or
         //   - it is not the top - most map in the JSON-LD document consisting of no other entries than @graph and @context.
-        if (token is not JObject o) return false;
+        if (node is not JsonObject o) return false;
         if (!(o.ContainsKey("@value") || o.ContainsKey("@list") || o.ContainsKey("@set"))) return true;
         if (!isTopmostMap)
         {
@@ -348,10 +366,10 @@ internal class JsonLdUtils
     /// <returns>True if <paramref name="t1"/> and <paramref name="t2"/> are equal primitives;
     /// or are both value objects with matching @value, @type, @language and @index values;
     /// or are both subject or subject references with matching @id values.</returns>
-    public static bool CompareValues(JToken t1, JToken t2)
+    public static bool CompareValues(JsonNode t1, JsonNode t2)
     {
         if (t1.Equals(t2)) return true;
-        if (t1 is JObject o1 && t2 is JObject o2)
+        if (t1 is JsonObject o1 && t2 is JsonObject o2)
         {
             if (IsValueObject(o1) && IsValueObject(o2))
             {
@@ -376,7 +394,7 @@ internal class JsonLdUtils
     /// <param name="v1"></param>
     /// <param name="v2"></param>
     /// <returns></returns>
-    public static bool SafeEquals(JToken v1, JToken v2)
+    public static bool SafeEquals(JsonNode v1, JsonNode v2)
     {
         if (v1 == null) return v2 == null;
         return CompareValues(v1, v2);
@@ -389,14 +407,14 @@ internal class JsonLdUtils
     /// <param name="entry">The name of the property to receive the value.</param>
     /// <param name="value">The value to be added.</param>
     /// <param name="asArray">If true, the property created on the subject is always an array. If false the property created on the subject will be an array only if required to hold mutiple values.</param>
-    public static void AddValue(JObject o, string entry, JToken value, bool asArray = false)
+    public static void AddValue(JsonObject o, string entry, JsonNode value, bool asArray = false)
     {
         if (asArray)
         {
             // Ensure target property is an array
             if (!o.ContainsKey(entry))
             {
-                o[entry] = new JArray();
+                o[entry] = new JsonArray();
             }
             else
             {
@@ -404,10 +422,10 @@ internal class JsonLdUtils
             }
         }
 
-        if (value is JArray valueArray)
+        if (value is JsonArray valueArray)
         {
             // Call this method to add each individual item
-            foreach (JToken item in valueArray)
+            foreach (JsonNode item in valueArray)
             {
                 AddValue(o, entry, item, asArray);
             }
@@ -424,14 +442,14 @@ internal class JsonLdUtils
             else
             {
                 // If property exists and its value is an array, append value to the array
-                if (o[entry] is JArray entryArray)
+                if (o[entry] is JsonArray entryArray)
                 {
                     entryArray.Add(value);
                 }
                 else
                 {
                     // Otherwise convert the target property value to an array and then append value
-                    entryArray = new JArray(o[entry])
+                    entryArray = new JsonArray(o[entry])
                     {
                         value,
                     };
@@ -448,7 +466,7 @@ internal class JsonLdUtils
     /// <param name="property">The property that relates the value to the subject.</param>
     /// <param name="value">The value to remove.</param>
     /// <param name="propertyIsArray">True if the value of the property is always an array.</param>
-    public static void RemoveValue(JObject subject, string property, JToken value, bool propertyIsArray = false)
+    public static void RemoveValue(JsonObject subject, string property, JsonNode value, bool propertyIsArray = false)
     {
         var values = EnsureArray(subject[property]).Where(t => !CompareValues(t, value)).ToList();
         switch (values.Count)
@@ -461,8 +479,8 @@ internal class JsonLdUtils
                 break;
             default:
             {
-                var array = new JArray();
-                foreach (JToken v in values) array.Add(v);
+                var array = new JsonArray();
+                foreach (JsonNode v in values) array.Add(v);
                 subject[property] = array;
                 break;
             }
@@ -470,22 +488,22 @@ internal class JsonLdUtils
     }
 
     /// <summary>
-    /// Creates a new array which is a concatenation of the values of token1 and token2.
+    /// Creates a new array which is a concatenation of the provided inputs.
     /// </summary>
-    /// <param name="token1"></param>
-    /// <param name="token2"></param>
+    /// <param name="node1">The first input.</param>
+    /// <param name="node2">The second input.</param>
     /// <remarks>This method flattens any input arrays.</remarks>
-    /// <returns></returns>
-    public static JArray ConcatenateValues(JToken token1, JToken token2)
+    /// <returns>An array consisting of the (flattened) concatenation of <paramref name="node1"/> and <paramref name="node2"/>.</returns>
+    public static JsonArray ConcatenateValues(JsonNode node1, JsonNode node2)
     {
-        JArray result = EnsureArray(token1);
-        if (token2 is JArray)
+        JsonArray result = EnsureArray(node1);
+        if (node2 is JsonArray array)
         {
-            foreach (JToken c in token2.Children()) result.Add(c);
+            foreach (JsonNode c in array) result.Add(c);
         }
         else
         {
-            result.Add(token2);
+            result.Add(node2);
         }
 
         return result;
@@ -499,12 +517,12 @@ internal class JsonLdUtils
     /// <param name="parent">The subject node to retrieve a property from.</param>
     /// <param name="propertyName">The name of the property whose value is to be retrieved.</param>
     /// <returns>The property value if found, null otherwise.</returns>
-    public static JToken GetPropertyValue(JsonLdContext activeContext, JObject parent, string propertyName)
+    public static JsonNode GetPropertyValue(JsonLdContext activeContext, JsonObject parent, string propertyName)
     {
-        if (parent.TryGetValue(propertyName, out JToken ret)) return ret;
+        if (parent.TryGetPropertyValue(propertyName, out JsonNode ret)) return ret;
         foreach (var alias in activeContext.GetAliases(propertyName))
         {
-            if (parent.TryGetValue(alias, out ret)) return ret;
+            if (parent.TryGetPropertyValue(alias, out ret)) return ret;
         }
         return null;
     }
@@ -518,14 +536,14 @@ internal class JsonLdUtils
     /// <paramref name="value"/> is a string token with the value 'ltr' or 'rtl' respectively.</returns>
     /// <exception cref="JsonLdProcessorException"> raised if <paramref name="value"/> is not a JSON string or null token,
     /// or if <paramref name="value"/> is a string but its value is neither 'ltr' nor 'rtl'.</exception>
-    public static LanguageDirection ParseLanguageDirection(JToken value)
+    public static LanguageDirection ParseLanguageDirection(JsonNode value)
     {
-        switch (value.Type)
+        switch (value.GetValueKind())
         {
-            case JTokenType.Null:
+            case JsonValueKind.Null:
                 return LanguageDirection.Unspecified;
-            case JTokenType.String:
-                var directionStr = value.Value<string>();
+            case JsonValueKind.String:
+                var directionStr = value.GetValue<string>();
                 switch (directionStr)
                 {
                     case "ltr":
@@ -555,6 +573,27 @@ internal class JsonLdUtils
             default:
                 return null;
         }
+    }
+
+    public static bool IsBooleanNode(JsonNode value)
+    {
+        return value.GetValueKind() == JsonValueKind.True || value.GetValueKind() == JsonValueKind.False;
+    }
+
+    /// <summary>
+    /// Merges two JSON objects into a new object, using properties from <paramref name="obj1"/> as the base.
+    /// </summary>
+    /// <param name="obj1">The first JSON object.</param>
+    /// <param name="obj2">The second JSON object.</param>
+    /// <returns>A new JSON object containing merged properties from both input objects. Properties from <paramref name="obj2"/> will not overwrite those from <paramref name="obj1"/>.</returns>
+    public static JsonObject MergeObjects(JsonObject obj1, JsonObject obj2)
+    {
+        var result = obj1.DeepClone() as JsonObject;
+        foreach (KeyValuePair<string, JsonNode> kvp in obj2)
+        {
+            result.TryAdd(kvp.Key, kvp.Value.DeepClone());
+        }
+        return result;
     }
 
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/JsonLdUtils.cs
@@ -109,7 +109,10 @@ internal class JsonLdUtils
     /// <returns>True of <paramref name="node"/> is a <see cref="JsonObject"/> with a non-null @value property, false otherwise.</returns>
     public static bool IsValueObject(JsonNode node)
     {
-        return node is JsonObject obj && HasNonNullProperty(obj, "@value");
+        if (node is not JsonObject obj) return false;
+        return obj.ContainsKey("@value");
+        
+//        return node is JsonObject obj && HasNonNullProperty(obj, "@value");
     }
 
 

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
@@ -357,12 +357,12 @@ public class NodeMapGenerator : INodeMapGenerator
         {
             foreach (JsonNode item in array)
             {
-                target.Add(item);
+                target.Add(item.DeepClone());
             }
         }
         else
         {
-            target.Add(values);
+            target.Add(values.DeepClone());
         }
     }
 

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
@@ -73,7 +73,7 @@ public class NodeMapGenerator : INodeMapGenerator
         var elementObject = element as JsonObject;
         var graph = nodeMap[activeGraph] as JsonObject;
         JsonObject node = null, subjectNode = null;
-        if (activeSubject != null && activeSubject.GetValueKind() == JsonValueKind.String)
+        if (activeSubject != null && activeSubject.SafeValueKind() == JsonValueKind.String)
         {
             subjectNode = node = graph[activeSubject.GetValue<string>()] as JsonObject;
         }
@@ -93,7 +93,7 @@ public class NodeMapGenerator : INodeMapGenerator
                     }
                 }
             }
-            else if (elementObject["@type"].GetValueKind() == JsonValueKind.String)
+            else if (elementObject["@type"].SafeValueKind() == JsonValueKind.String)
             {
                 var typeId = elementObject["@type"].GetValue<string>();
                 if (JsonLdUtils.IsBlankNodeIdentifier(typeId))
@@ -113,20 +113,20 @@ public class NodeMapGenerator : INodeMapGenerator
                 // create one and initialize its value to an array containing element.
                 if (!subjectNode.ContainsKey(activeProperty))
                 {
-                    subjectNode[activeProperty] = new JsonArray(element);
+                    subjectNode[activeProperty] = new JsonArray(element.DeepClone());
                 }
                 // 4.1.2 - Otherwise, compare element against every item in the array associated with the active property member of node. If there is no item equivalent to element, append element to the array. Two dictionaries are considered equal if they have equivalent key-value pairs.
                 var existingItems = node[activeProperty] as JsonArray;
                 if (!existingItems.Any(x => JsonNode.DeepEquals(x, element)))
                 {
-                    existingItems.Add(element);
+                    existingItems.Add(element.DeepClone());
                 }
             }
             else
             {
                 // 4.2 - Otherwise, append element to the @list member of list.
                 var listArray = list["@list"] as JsonArray;
-                listArray.Add(element);
+                listArray.Add(element.DeepClone());
             }
         }
         // 5 - Otherwise, if element has an @list member, perform the following steps:
@@ -186,7 +186,7 @@ public class NodeMapGenerator : INodeMapGenerator
                 // 6.5.1 - If node does not have an active property member, create one and initialize its value to an array containing active subject.
                 if (!node.ContainsKey(activeProperty))
                 {
-                    node[activeProperty] = new JsonArray(activeSubject);
+                    node[activeProperty] = new JsonArray(activeSubject.DeepClone());
                 }
                 // 6.5.2 - Otherwise, compare active subject against every item in the array associated with the active property member of node.
                 // If there is no item equivalent to active subject, append active subject to the array.
@@ -244,7 +244,7 @@ public class NodeMapGenerator : INodeMapGenerator
                     throw new JsonLdProcessorException(JsonLdErrorCode.ConflictingIndexes,
                         $"Conflicting indexes for node with id {id}.");
                 }
-                node["@index"] = elementObject["@index"];
+                node["@index"] = elementObject["@index"].DeepClone();
                 elementObject.Remove("@index");
             }
 
@@ -370,7 +370,7 @@ public class NodeMapGenerator : INodeMapGenerator
     {
         if (!toArray.Any(x => JsonNode.DeepEquals(x, element)))
         {
-            toArray.Add(element);
+            toArray.Add(element.DetachedClone());
         }
     }
 }

--- a/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/Processors/NodeMapGenerator.cs
@@ -24,8 +24,10 @@
 // </copyright>
 */
 
+using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace VDS.RDF.JsonLd.Processors;
 
@@ -41,23 +43,23 @@ public class NodeMapGenerator : INodeMapGenerator
     /// </summary>
     /// <param name="element">The element to be processed.</param>
     /// <param name="identifierGenerator">The identifier generator instance to use when creating new blank node identifiers. Defaults to a new instance of <see cref="BlankNodeGenerator"/>.</param>
-    /// <returns>The generated node map dictionary as a JObject instance.</returns>
-    public JObject GenerateNodeMap(JToken element, IBlankNodeGenerator identifierGenerator = null)
+    /// <returns>The generated node map dictionary as a JsonObject instance.</returns>
+    public JsonObject GenerateNodeMap(JsonNode element, IBlankNodeGenerator identifierGenerator = null)
     {
         _blankNodeGenerator = identifierGenerator ?? new BlankNodeGenerator();
-        var nodeMap = new JObject(new JProperty("@default", new JObject()));
+        var nodeMap = new JsonObject([new KeyValuePair<string, JsonNode>("@default", new JsonObject())]);
         GenerateNodeMapAlgorithm(element, nodeMap);
         return nodeMap;
     }
 
-    private void GenerateNodeMapAlgorithm(JToken element, JObject nodeMap,
-        string activeGraph = "@default", JToken activeSubject = null,
-        string activeProperty = null, JObject list = null)
+    private void GenerateNodeMapAlgorithm(JsonNode element, JsonObject nodeMap,
+        string activeGraph = "@default", JsonNode activeSubject = null,
+        string activeProperty = null, JsonObject list = null)
     {
         // 1 - If element is an array, process each item in element as follows and then return:
-        if (element is JArray elementArray)
+        if (element is JsonArray elementArray)
         {
-            foreach (JToken item in elementArray)
+            foreach (JsonNode item in elementArray)
             {
                 // 1.1 - Run this algorithm recursively by passing item for element, node map, active graph, active subject, active property, and list.
                 GenerateNodeMapAlgorithm(item, nodeMap, activeGraph, activeSubject, activeProperty, list);
@@ -68,32 +70,32 @@ public class NodeMapGenerator : INodeMapGenerator
         // Reference the map which is the value of the active graph entry of node map using the variable graph.
         // If the active subject is null, set node to null otherwise reference the active subject entry of graph
         // using the variable subject node.
-        var elementObject = element as JObject;
-        var graph = nodeMap[activeGraph] as JObject;
-        JObject node = null, subjectNode = null;
-        if (activeSubject != null && activeSubject is JValue)
+        var elementObject = element as JsonObject;
+        var graph = nodeMap[activeGraph] as JsonObject;
+        JsonObject node = null, subjectNode = null;
+        if (activeSubject != null && activeSubject.GetValueKind() == JsonValueKind.String)
         {
-            subjectNode = node = graph[activeSubject.Value<string>()] as JObject;
+            subjectNode = node = graph[activeSubject.GetValue<string>()] as JsonObject;
         }
 
         // 3 - For each item in the @type entry of element, if any, or for the value of @type, if the value of @type exists and is not an array: 
         if (elementObject.ContainsKey("@type"))
         {
             // 3.1 - If item is a blank node identifier, replace it with a newly generated blank node identifier passing item for identifier.
-            if (elementObject["@type"] is JArray typeArray)
+            if (elementObject["@type"] is JsonArray typeArray)
             {
                 for (var ix = 0; ix < typeArray.Count; ix++)
                 {
-                    var typeId = typeArray[ix].Value<string>();
+                    var typeId = typeArray[ix].GetValue<string>();
                     if (JsonLdUtils.IsBlankNodeIdentifier(typeId))
                     {
                         typeArray[ix] = _blankNodeGenerator.GenerateBlankNodeIdentifier(typeId);
                     }
                 }
             }
-            else if (elementObject["@type"] is JValue)
+            else if (elementObject["@type"].GetValueKind() == JsonValueKind.String)
             {
-                var typeId = elementObject["@type"].Value<string>();
+                var typeId = elementObject["@type"].GetValue<string>();
                 if (JsonLdUtils.IsBlankNodeIdentifier(typeId))
                 {
                     elementObject["@type"] = _blankNodeGenerator.GenerateBlankNodeIdentifier(typeId);
@@ -111,11 +113,11 @@ public class NodeMapGenerator : INodeMapGenerator
                 // create one and initialize its value to an array containing element.
                 if (!subjectNode.ContainsKey(activeProperty))
                 {
-                    subjectNode[activeProperty] = new JArray(element);
+                    subjectNode[activeProperty] = new JsonArray(element);
                 }
                 // 4.1.2 - Otherwise, compare element against every item in the array associated with the active property member of node. If there is no item equivalent to element, append element to the array. Two dictionaries are considered equal if they have equivalent key-value pairs.
-                var existingItems = node[activeProperty] as JArray;
-                if (!existingItems.Any(x => JToken.DeepEquals(x, element)))
+                var existingItems = node[activeProperty] as JsonArray;
+                if (!existingItems.Any(x => JsonNode.DeepEquals(x, element)))
                 {
                     existingItems.Add(element);
                 }
@@ -123,7 +125,7 @@ public class NodeMapGenerator : INodeMapGenerator
             else
             {
                 // 4.2 - Otherwise, append element to the @list member of list.
-                var listArray = list["@list"] as JArray;
+                var listArray = list["@list"] as JsonArray;
                 listArray.Add(element);
             }
         }
@@ -131,7 +133,10 @@ public class NodeMapGenerator : INodeMapGenerator
         else if (elementObject.ContainsKey("@list"))
         {
             // 5.1 - Initialize a new map result consisting of a single entry @list whose value is initialized to an empty array.
-            var result = new JObject(new JProperty("@list", new JArray()));
+            var result = new JsonObject
+            {
+                ["@list"] = new JsonArray(),
+            };
 
             // 5.2 - Recursively call this algorithm passing the value of element's @list entry for element,
             // node map, active graph, active subject, active property, and result for list.
@@ -140,12 +145,12 @@ public class NodeMapGenerator : INodeMapGenerator
             // 5.3 - If list is null, append result to the value of the active property entry of subject node.
             if (list == null)
             {
-                (subjectNode[activeProperty] as JArray).Add(result);
+                (subjectNode[activeProperty] as JsonArray).Add(result);
             }
             else
             {
                 // 5.4 - Otherwise, append result to the @list entry of list.
-                (list["@list"] as JArray).Add(result);
+                (list["@list"] as JsonArray).Add(result);
             }
         }
         // 6 - Otherwise element is a node object, perform the following steps:
@@ -155,7 +160,7 @@ public class NodeMapGenerator : INodeMapGenerator
             // 6.1 - If element has an @id member, set id to its value and remove the member from element. If id is a blank node identifier, replace it with a newly generated blank node identifier passing id for identifier.
             if (elementObject.ContainsKey("@id"))
             {
-                id = elementObject["@id"]?.Value<string>();
+                id = elementObject["@id"]?.GetValue<string>();
                 elementObject.Remove("@id");
                 if (id == null) return; // Required to pass W3C test e122
                 if (JsonLdUtils.IsBlankNodeIdentifier(id))
@@ -171,46 +176,46 @@ public class NodeMapGenerator : INodeMapGenerator
             // 6.3 - If graph does not contain a member id, create one and initialize its value to a dictionary consisting of a single member @id whose value is id.
             if (!graph.ContainsKey(id))
             {
-                graph[id] = new JObject(new JProperty("@id", id));
+                graph[id] = new JsonObject{["@id"] = id};
             }
             // 6.4 - Reference the value of the id member of graph using the variable node.
-            node = graph[id] as JObject;
+            node = graph[id] as JsonObject;
             // 6.5 - If active subject is a dictionary, a reverse property relationship is being processed. Perform the following steps:
-            if (activeSubject is JObject)
+            if (activeSubject is JsonObject)
             {
                 // 6.5.1 - If node does not have an active property member, create one and initialize its value to an array containing active subject.
                 if (!node.ContainsKey(activeProperty))
                 {
-                    node[activeProperty] = new JArray(activeSubject);
+                    node[activeProperty] = new JsonArray(activeSubject);
                 }
                 // 6.5.2 - Otherwise, compare active subject against every item in the array associated with the active property member of node.
                 // If there is no item equivalent to active subject, append active subject to the array.
                 // Two dictionaries are considered equal if they have equivalent key-value pairs.
                 else
                 {
-                    AppendUniqueElement(activeSubject, node[activeProperty] as JArray);
+                    AppendUniqueElement(activeSubject, node[activeProperty] as JsonArray);
                 }
             }
             // 6.6 - Otherwise, if active property is not null, perform the following steps:
             else if (activeProperty != null)
             {
                 // 6.6.1 - Create a new dictionary reference consisting of a single member @id whose value is id.
-                var reference = new JObject(new JProperty("@id", id));
+                var reference = new JsonObject{["@id"] = id};
                 // 6.6.2 - If list is null:
                 if (list == null)
                 {
                     // 6.6.2.1 - If subject node does not have an active property member, create one and initialize its value to an array containing reference.
                     if (!subjectNode.ContainsKey(activeProperty))
                     {
-                        subjectNode[activeProperty] = new JArray(reference);
+                        subjectNode[activeProperty] = new JsonArray(reference);
                     }
                     // 6.6.2.2 - Otherwise, compare reference against every item in the array associated with the active property member of node. If there is no item equivalent to reference, append reference to the array. Two dictionaries are considered equal if they have equivalent key-value pairs.
-                    AppendUniqueElement(reference, subjectNode[activeProperty] as JArray);
+                    AppendUniqueElement(reference, subjectNode[activeProperty] as JsonArray);
                 }
                 else
                 {
                     // 6.6.3 - Otherwise, append reference to the @list member of list.
-                    var listArray = list["@list"] as JArray;
+                    var listArray = list["@list"] as JsonArray;
                     listArray.Add(reference);
                 }
             }
@@ -218,13 +223,13 @@ public class NodeMapGenerator : INodeMapGenerator
             // Finally remove the @type entry from element.
             if (elementObject.ContainsKey("@type"))
             {
-                if (node.Property("@type") == null)
+                if (!node.ContainsKey("@type"))
                 {
-                    node["@type"] = new JArray();
+                    node["@type"] = new JsonArray();
                 }
-                foreach (JToken item in JsonLdUtils.EnsureArray(elementObject["@type"]))
+                foreach (JsonNode item in JsonLdUtils.EnsureArray(elementObject["@type"]))
                 {
-                    AppendUniqueElement(item, node["@type"] as JArray);
+                    AppendUniqueElement(item, node["@type"] as JsonArray);
                 }
                 elementObject.Remove("@type");
             }
@@ -234,7 +239,7 @@ public class NodeMapGenerator : INodeMapGenerator
             // Otherwise, continue by removing the @index entry from element.
             if (elementObject.ContainsKey("@index"))
             {
-                if (node.ContainsKey("@index") && !JToken.DeepEquals(elementObject["@index"], node["@index"]))
+                if (node.ContainsKey("@index") && !JsonNode.DeepEquals(elementObject["@index"], node["@index"]))
                 {
                     throw new JsonLdProcessorException(JsonLdErrorCode.ConflictingIndexes,
                         $"Conflicting indexes for node with id {id}.");
@@ -247,16 +252,16 @@ public class NodeMapGenerator : INodeMapGenerator
             if (elementObject.ContainsKey("@reverse"))
             {
                 // 6.9.1 - Create a map referenced node with a single entry @id whose value is id.
-                var referencedNode = new JObject(new JProperty("@id", id));
+                var referencedNode = new JsonObject{["@id"] = id};
                 // 6.9.2 - Initialize reverse map to the value of the @reverse entry of element.
-                var reverseMap = elementObject["@reverse"] as JObject;
+                var reverseMap = elementObject["@reverse"] as JsonObject;
                 // 6.9.3 - For each key-value pair property-values in reverse map:
-                foreach (JProperty p in reverseMap.Properties())
+                foreach (var p in reverseMap)
                 {
-                    var property = p.Name;
-                    var values = p.Value as JArray;
+                    var property = p.Key;
+                    var values = p.Value as JsonArray;
                     // 6.9.3.1 - For each value of values:
-                    foreach (JToken value in values)
+                    foreach (JsonNode value in values)
                     {
                         // 6.9.3.1.1 - Recursively invoke this algorithm passing value for element, node map,
                         // active graph, referenced node for active subject, and property for active property.
@@ -275,7 +280,7 @@ public class NodeMapGenerator : INodeMapGenerator
                 // KA: Ensure nodeMap contains a dictionary for the graph
                 if (!nodeMap.ContainsKey(id))
                 {
-                    nodeMap.Add(id, new JObject());
+                    nodeMap.Add(id, new JsonObject());
                 }
                 GenerateNodeMapAlgorithm(elementObject["@graph"], nodeMap, id);
                 elementObject.Remove("@graph");
@@ -288,10 +293,10 @@ public class NodeMapGenerator : INodeMapGenerator
                 elementObject.Remove("@included");
             }
             // 6.12 - Finally, for each key-value pair property-value in element ordered by property perform the following steps:
-            foreach (JProperty p in elementObject.Properties().OrderBy(p => p.Name).ToList())
+            foreach (var p in elementObject.OrderBy(p => p.Key).ToList())
             {
-                var property = p.Name;
-                JToken value = p.Value;
+                var property = p.Key;
+                JsonNode value = p.Value;
                 // 6.12.1 - If property is a blank node identifier, replace it with a newly generated blank node identifier passing property for identifier.
                 if (JsonLdUtils.IsBlankNodeIdentifier(property))
                 {
@@ -300,7 +305,7 @@ public class NodeMapGenerator : INodeMapGenerator
                 // 6.12.2 - If node does not have a property entry, create one and initialize its value to an empty array.
                 if (!node.ContainsKey(property))
                 {
-                    node[property] = new JArray();
+                    node[property] = new JsonArray();
                 }
                 // 6.12.3 - Recursively invoke this algorithm passing value for element, node map, active graph, id for active subject, and property for active property.
                 GenerateNodeMapAlgorithm(value, nodeMap, activeGraph, id, property);
@@ -309,30 +314,30 @@ public class NodeMapGenerator : INodeMapGenerator
     }
 
     /// <inheritdoc />
-    public JObject GenerateMergedNodeMap(JObject graphMap)
+    public JsonObject GenerateMergedNodeMap(JsonObject graphMap)
     {
-        var result = new JObject();
-        foreach (JProperty p in graphMap.Properties())
+        var result = new JsonObject();
+        foreach (var p in graphMap)
         {
-            var graphName = p.Name;
-            var nodeMap = p.Value as JObject;
-            foreach (JProperty np in nodeMap.Properties())
+            var graphName = p.Key;
+            var nodeMap = p.Value as JsonObject;
+            foreach (var np in nodeMap)
             {
-                var id = np.Name;
-                var node = np.Value as JObject;
-                if (result[id] is not JObject mergedNode)
+                var id = np.Key;
+                var node = np.Value as JsonObject;
+                if (result[id] is not JsonObject mergedNode)
                 {
-                    result[id] = mergedNode = new JObject(new JProperty("@id", id));
+                    result[id] = mergedNode = new JsonObject { ["@id"] = id };
                 }
-                foreach (JProperty nodeProperty in node.Properties())
+                foreach (var nodeProperty in node)
                 {
-                    if (!JsonLdUtils.IsKeyword(nodeProperty.Name) || nodeProperty.Name.Equals("@type"))
+                    if (!JsonLdUtils.IsKeyword(nodeProperty.Key) || nodeProperty.Key.Equals("@type"))
                     {
-                        MergeValues(mergedNode, nodeProperty.Name, nodeProperty.Value);
+                        MergeValues(mergedNode, nodeProperty.Key, nodeProperty.Value);
                     }
                     else
                     {
-                        mergedNode[nodeProperty.Name] = nodeProperty.Value.DeepClone();
+                        mergedNode[nodeProperty.Key] = nodeProperty.Value.DeepClone();
                     }
                 }
             }
@@ -341,16 +346,16 @@ public class NodeMapGenerator : INodeMapGenerator
         return result;
     }
 
-    private static void MergeValues(JObject parent, string property, JToken values)
+    private static void MergeValues(JsonObject parent, string property, JsonNode values)
     {
         if (parent[property] == null)
         {
-            parent[property] = new JArray();
+            parent[property] = new JsonArray();
         }
-        var target = parent[property] as JArray;
-        if (values is JArray array)
+        var target = parent[property] as JsonArray;
+        if (values is JsonArray array)
         {
-            foreach (JToken item in array)
+            foreach (JsonNode item in array)
             {
                 target.Add(item);
             }
@@ -361,9 +366,9 @@ public class NodeMapGenerator : INodeMapGenerator
         }
     }
 
-    private static void AppendUniqueElement(JToken element, JArray toArray)
+    private static void AppendUniqueElement(JsonNode element, JsonArray toArray)
     {
-        if (!toArray.Any(x => JToken.DeepEquals(x, element)))
+        if (!toArray.Any(x => JsonNode.DeepEquals(x, element)))
         {
             toArray.Add(element);
         }

--- a/Libraries/dotNetRdf.Core/JsonLd/RemoteContextProvider.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/RemoteContextProvider.cs
@@ -26,6 +26,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 

--- a/Libraries/dotNetRdf.Core/JsonLd/RemoteContextProvider.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/RemoteContextProvider.cs
@@ -26,7 +26,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 
 namespace VDS.RDF.JsonLd;
@@ -58,8 +58,8 @@ public class RemoteContextProvider: IRemoteContextProvider
             RemoteDocument remoteDoc = LoadJson(reference,
                 new JsonLdLoaderOptions
                     { Profile = JsonLdVocabulary.Context, RequestProfile = JsonLdVocabulary.Context }, _options);
-            JToken jsonRepresentation = GetJsonRepresentation(remoteDoc);
-            if (jsonRepresentation is not JObject remoteJsonObject)
+            JsonNode jsonRepresentation = GetJsonRepresentation(remoteDoc);
+            if (jsonRepresentation is not JsonObject remoteJsonObject)
             {
                 throw new JsonLdProcessorException(JsonLdErrorCode.InvalidRemoteContext,
                     $"Remote document at {reference} could not be parsed as a JSON object.");
@@ -95,18 +95,18 @@ public class RemoteContextProvider: IRemoteContextProvider
             : DefaultDocumentLoader.LoadJson(remoteRef, loaderOptions);
     }
 
-    private static JToken GetJsonRepresentation(RemoteDocument remoteDoc)
+    private static JsonNode GetJsonRepresentation(RemoteDocument remoteDoc)
     {
         switch (remoteDoc.Document)
         {
-            case JToken representation:
+            case JsonNode representation:
                 return representation;
             case string docStr:
             {
                 try
                 {
 
-                    return JToken.Parse(docStr);
+                    return JsonNode.Parse(docStr);
                 }
                 catch (Exception ex)
                 {

--- a/Libraries/dotNetRdf.Core/JsonLd/RemoteDocument.cs
+++ b/Libraries/dotNetRdf.Core/JsonLd/RemoteDocument.cs
@@ -49,6 +49,6 @@ public class RemoteDocument
     /// <summary>
     /// The retrieved document. This can either be the raw payload or the already parsed document.
     /// </summary>
-    /// <remarks>This property may be a JToken or a string. If it is a string, the string is parsed to a JToken.</remarks>
+    /// <remarks>This property may be a JsonNode or a string. If it is a string, the string is parsed to a JsonNode.</remarks>
     public object Document { get; set; }
 }

--- a/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
@@ -26,9 +26,9 @@
 
 using System;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.Parsing.Handlers;
-using Newtonsoft.Json.Linq;
 using VDS.RDF.JsonLd;
 using System.Globalization;
 using System.Linq;
@@ -87,7 +87,7 @@ public class JsonLdParser : IStoreReader
     /// </summary>
     /// <param name="store">The store to add the parsed RDF quads to.</param>
     /// <param name="input">The expanded JSON-LD document.</param>
-    internal void Load(ITripleStore store, JArray input)
+    internal void Load(ITripleStore store, JsonArray input)
     {
         if (store == null) throw new ArgumentNullException(nameof(store));
         if (input == null) throw new ArgumentNullException(nameof(input));
@@ -127,16 +127,14 @@ public class JsonLdParser : IStoreReader
 
     /// <inheritdoc />
     public void Load(IRdfHandler handler, TextReader input, IUriFactory uriFactory) {
-        JToken element;
-        using (var reader = new JsonTextReader(input) { DateParseHandling = DateParseHandling.None })
-        {
-            element = JToken.ReadFrom(reader);
-        }
+        JsonNode element;
+        var jsonString = input.ReadToEnd();
+        element = JsonNode.Parse(jsonString);
         var warnings = new List<JsonLdProcessorWarning>();
-        JArray expandedElement = JsonLdProcessor.Expand(element, ParserOptions, warnings);
+        JsonArray expandedElement = JsonLdProcessor.Expand(element, ParserOptions, warnings);
         if (warnings.Any())
         {
-            foreach (var warning in warnings)
+            foreach (JsonLdProcessorWarning warning in warnings)
             {
                 RaiseWarning(warning.Message);
             }
@@ -144,7 +142,7 @@ public class JsonLdParser : IStoreReader
         Load(handler, expandedElement, uriFactory);
     }
     
-    private void Load(IRdfHandler handler, JArray input, IUriFactory uriFactory) {
+    private void Load(IRdfHandler handler, JsonArray input, IUriFactory uriFactory) {
         if (handler == null) throw new ArgumentNullException(nameof(handler));
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (uriFactory == null) throw new ArgumentNullException(nameof(uriFactory));
@@ -154,11 +152,11 @@ public class JsonLdParser : IStoreReader
         try
         {
             var nodeMapGenerator = new NodeMapGenerator();
-            JObject nodeMap = nodeMapGenerator.GenerateNodeMap(input);
-            foreach (JProperty p in nodeMap.Properties())
+            JsonObject nodeMap = nodeMapGenerator.GenerateNodeMap(input);
+            foreach (KeyValuePair<string, JsonNode> p in nodeMap)
             {
-                var graphName = p.Name;
-                var graph = p.Value as JObject;
+                var graphName = p.Key;
+                var graph = p.Value as JsonObject;
                 if (graph == null) continue;
                 IRefNode graphNode;
                 if (graphName == "@default")
@@ -180,10 +178,10 @@ public class JsonLdParser : IStoreReader
                         continue;
                     }
                 }
-                foreach (JProperty gp in graph.Properties())
+                foreach (KeyValuePair<string, JsonNode> gp in graph)
                 {
-                    var subject = gp.Name;
-                    var node = gp.Value as JObject;
+                    var subject = gp.Key;
+                    var node = gp.Value as JsonObject;
                     IRefNode subjectNode;
                     if (IsBlankNodeIdentifier(subject))
                     {
@@ -200,13 +198,13 @@ public class JsonLdParser : IStoreReader
                         }
                         subjectNode = handler.CreateUriNode(subjectIri);
                     }
-                    foreach (JProperty np in node.Properties())
+                    foreach (KeyValuePair<string, JsonNode> np in node)
                     {
-                        var property = np.Name;
-                        var values = np.Value as JArray;
+                        var property = np.Key;
+                        var values = np.Value as JsonArray;
                         if (property.Equals("@type"))
                         {
-                            foreach (JToken type in values)
+                            foreach (JsonNode type in values)
                             {
                                 INode typeNode = MakeNode(handler, type, graphNode);
                                 if (typeNode is null)
@@ -224,7 +222,7 @@ public class JsonLdParser : IStoreReader
                         else if ((JsonLdUtils.IsBlankNodeIdentifier(property) && ParserOptions.ProduceGeneralizedRdf) ||
                                  Uri.IsWellFormedUriString(property, UriKind.Absolute))
                         {
-                            foreach (JToken item in values)
+                            foreach (JsonNode item in values)
                             {
                                 var predicateNode = MakeNode(handler, property, graphNode) as IRefNode;
                                 if (ParserOptions.SafeMode && predicateNode is null)
@@ -263,11 +261,11 @@ public class JsonLdParser : IStoreReader
     private const string RdfValue = RdfNs + "value";
     private static readonly Regex ExponentialFormatMatcher = new Regex(@"(\d)0*E\+?0*");
 
-    private INode MakeNode(IRdfHandler handler, JToken token, IRefNode graphName, bool allowRelativeIri = false)
+    private INode MakeNode(IRdfHandler handler, JsonNode token, IRefNode graphName, bool allowRelativeIri = false)
     {
-        if (token is JValue)
+        if (token is JsonValue)
         {
-            var stringValue = token.Value<string>();
+            var stringValue = token.GetValue<string>();
             if (JsonLdUtils.IsBlankNodeIdentifier(stringValue))
             {
                 return handler.CreateBlankNode(stringValue.Substring(2));
@@ -280,27 +278,27 @@ public class JsonLdParser : IStoreReader
             return null;
         }
 
-        if (JsonLdUtils.IsValueObject(token) && token is JObject valueObject)
+        if (JsonLdUtils.IsValueObject(token) && token is JsonObject valueObject)
         {
             string literalValue;
-            JToken value = valueObject["@value"];
-            var datatype = valueObject.Property("@type")?.Value.Value<string>();
-            var language = valueObject.Property("@language")?.Value.Value<string>();
+            JsonNode value = valueObject["@value"];
+            var datatype = valueObject.ContainsKey("@type") ? valueObject["@type"].GetValue<string>() : null;
+            var language = valueObject.ContainsKey("@language") ? valueObject["@language"].GetValue<string>() : null;
             if (datatype == "@json")
             {
                 datatype = RdfNs + "JSON";
                 var serializer = new JsonLiteralSerializer();
                 literalValue = serializer.Serialize(value);
             }
-            else if (value.Type == JTokenType.Boolean)
+            else if (value.GetValueKind() == JsonValueKind.True || value.GetValueKind() == JsonValueKind.False)
             {
-                literalValue = value.Value<bool>() ? "true" : "false";
+                literalValue = value.GetValue<bool>() ? "true" : "false";
                 datatype ??= XsdNs + "boolean";
             }
-            else if (value.Type == JTokenType.Float ||
-                     value.Type == JTokenType.Integer && datatype != null && datatype.Equals(XsdNs + "double"))
+            else if (value.GetValueKind() == JsonValueKind.Number ||
+                     value.GetValueKind() == JsonValueKind.Number && datatype != null && datatype.Equals(XsdNs + "double"))
             {
-                var doubleValue = value.Value<double>();
+                var doubleValue = value.GetValue<double>();
                 var roundedValue = Math.Round(doubleValue);
                 if (doubleValue.Equals(roundedValue) && doubleValue < 1e21 && datatype == null)
                 {
@@ -312,24 +310,24 @@ public class JsonLdParser : IStoreReader
                 }
                 else
                 {
-                    literalValue = value.Value<double>().ToString("E15", CultureInfo.InvariantCulture);
+                    literalValue = value.GetValue<double>().ToString("E15", CultureInfo.InvariantCulture);
                     literalValue = ExponentialFormatMatcher.Replace(literalValue, "$1E");
                     if (literalValue.EndsWith("E")) literalValue = literalValue + "0";
                     datatype ??= XsdNs + "double";
                 }
             }
-            else if (value.Type == JTokenType.Integer ||
-                     value.Type == JTokenType.Float && datatype != null && datatype.Equals(XsdNs + "integer"))
+            else if (value.GetValueKind() == JsonValueKind.Number ||
+                     value.GetValueKind() == JsonValueKind.Number && datatype != null && datatype.Equals(XsdNs + "integer"))
             {
-                literalValue = value.Value<long>().ToString("D", CultureInfo.InvariantCulture);
+                literalValue = value.GetValue<long>().ToString("D", CultureInfo.InvariantCulture);
                 datatype ??= XsdNs + "integer";
             }
             else if (valueObject.ContainsKey("@direction") && ParserOptions.RdfDirection.HasValue)
             {
-                literalValue = value.Value<string>();
-                var direction = valueObject["@direction"].Value<string>();
+                literalValue = value.GetValue<string>();
+                var direction = valueObject["@direction"].GetValue<string>();
                 language = valueObject.ContainsKey("@language")
-                    ? valueObject["@language"].Value<string>().ToLowerInvariant()
+                    ? valueObject["@language"].GetValue<string>().ToLowerInvariant()
                     : string.Empty;
                 if (ParserOptions.RdfDirection == JsonLdRdfDirectionMode.I18NDatatype)
                 {
@@ -364,7 +362,7 @@ public class JsonLdParser : IStoreReader
             }
             else
             {
-                literalValue = value.Value<string>();
+                literalValue = value.GetValue<string>();
                 if (datatype == null && language == null)
                 {
                     datatype = XsdNs + "string";
@@ -379,21 +377,19 @@ public class JsonLdParser : IStoreReader
         }
         if (JsonLdUtils.IsListObject(token))
         {
-            var listArray = token["@list"] as JArray;
+            var listArray = token["@list"] as JsonArray;
             return MakeRdfList(handler, listArray, graphName);
         }
 
-        if((token as JObject)?.Property("@id")!=null)
+        if((token as JsonObject)?.TryGetPropertyValue("@id", out var idProperty) == true)
         {
-            // Must be a node object
-            var nodeObject = (JObject) token;
-            return MakeNode(handler, nodeObject["@id"], graphName);
+            return MakeNode(handler, idProperty, graphName);
         }
 
         return null;
     }
 
-    private INode MakeRdfList(IRdfHandler handler, JArray list, IRefNode graphName)
+    private INode MakeRdfList(IRdfHandler handler, JsonArray list, IRefNode graphName)
     {
         IUriNode rdfFirst = handler.CreateUriNode(new Uri(RdfNs + "first"));
         IUriNode rdfRest = handler.CreateUriNode(new Uri(RdfNs + "rest"));

--- a/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
@@ -127,8 +127,12 @@ public class JsonLdParser : IStoreReader
 
     /// <inheritdoc />
     public void Load(IRdfHandler handler, TextReader input, IUriFactory uriFactory) {
+        // System.Text.Json does not support parsing from a TextReader and in any case the whole DOM is needed for JSON-LD processing
+        // so we read the whole input into a string and parse that into a JsonNode.
         JsonNode element;
         var jsonString = input.ReadToEnd();
+        input.Close();
+
         element = JsonNode.Parse(jsonString);
         var warnings = new List<JsonLdProcessorWarning>();
         JsonArray expandedElement = JsonLdProcessor.Expand(element, ParserOptions, warnings);

--- a/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
@@ -261,6 +261,16 @@ public class JsonLdParser : IStoreReader
     private const string RdfValue = RdfNs + "value";
     private static readonly Regex ExponentialFormatMatcher = new Regex(@"(\d)0*E\+?0*");
 
+    private static bool IsInteger(JsonNode node)
+    {
+        if (node is JsonValue valueNode && valueNode.GetValueKind() == JsonValueKind.Number)
+        {
+            var doubleValue = valueNode.GetValue<double>();
+            var roundedValue = Math.Round(doubleValue);
+            return doubleValue.Equals(roundedValue) && doubleValue < 1e21;
+        }
+        return false;
+    }
     private INode MakeNode(IRdfHandler handler, JsonNode token, IRefNode graphName, bool allowRelativeIri = false)
     {
         if (token is JsonValue)
@@ -295,8 +305,10 @@ public class JsonLdParser : IStoreReader
                 literalValue = value.GetValue<bool>() ? "true" : "false";
                 datatype ??= XsdNs + "boolean";
             }
-            else if (value.GetValueKind() == JsonValueKind.Number ||
-                     value.GetValueKind() == JsonValueKind.Number && datatype != null && datatype.Equals(XsdNs + "double"))
+            else if (
+                value.GetValueKind() == JsonValueKind.Number &&
+                (!IsInteger(value) ||
+                     (IsInteger(value) && datatype != null && datatype.Equals(XsdNs + "double"))))
             {
                 var doubleValue = value.GetValue<double>();
                 var roundedValue = Math.Round(doubleValue);
@@ -316,8 +328,9 @@ public class JsonLdParser : IStoreReader
                     datatype ??= XsdNs + "double";
                 }
             }
-            else if (value.GetValueKind() == JsonValueKind.Number ||
-                     value.GetValueKind() == JsonValueKind.Number && datatype != null && datatype.Equals(XsdNs + "integer"))
+            else if (value.GetValueKind() == JsonValueKind.Number &&
+                (IsInteger(value) ||
+                     (!IsInteger(value) && datatype != null && datatype.Equals(XsdNs + "integer"))))
             {
                 literalValue = value.GetValue<long>().ToString("D", CultureInfo.InvariantCulture);
                 datatype ??= XsdNs + "integer";

--- a/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
@@ -129,11 +129,14 @@ public class JsonLdParser : IStoreReader
     public void Load(IRdfHandler handler, TextReader input, IUriFactory uriFactory) {
         // System.Text.Json does not support parsing from a TextReader and in any case the whole DOM is needed for JSON-LD processing
         // so we read the whole input into a string and parse that into a JsonNode.
-        JsonNode element;
-        var jsonString = input.ReadToEnd();
-        input.Close();
-
-        element = JsonNode.Parse(jsonString);
+        string jsonString;
+        try {
+            jsonString = input.ReadToEnd();
+        } finally {
+            input.Close();
+        }
+        
+        var element = JsonNode.Parse(jsonString);
         var warnings = new List<JsonLdProcessorWarning>();
         JsonArray expandedElement = JsonLdProcessor.Expand(element, ParserOptions, warnings);
         if (warnings.Any())

--- a/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/JsonLdParser.cs
@@ -298,7 +298,12 @@ public class JsonLdParser : IStoreReader
             {
                 datatype = RdfNs + "JSON";
                 var serializer = new JsonLiteralSerializer();
-                literalValue = serializer.Serialize(value);
+                // The "unsafe" JSON Encoder escapes more characters than necessary for JSON-LD, so we need to unescape some of them to conform to the JSON-LD 1.1 specification.
+                literalValue = Regex.Replace(serializer.Serialize(value), @"\\u([0-9a-fA-F]{4})", match =>
+                {
+                    var unicodeChar = (char)Convert.ToInt32(match.Groups[1].Value, 16);
+                    return 0x00 <= unicodeChar && unicodeChar <= 0x1F ? match.Value : unicodeChar.ToString();
+                });
             }
             else if (value.GetValueKind() == JsonValueKind.True || value.GetValueKind() == JsonValueKind.False)
             {
@@ -332,7 +337,8 @@ public class JsonLdParser : IStoreReader
                 (IsInteger(value) ||
                      (!IsInteger(value) && datatype != null && datatype.Equals(XsdNs + "integer"))))
             {
-                literalValue = value.GetValue<long>().ToString("D", CultureInfo.InvariantCulture);
+                var decimalValue = value.GetValue<decimal>();
+                literalValue = decimalValue.ToString("F0", CultureInfo.InvariantCulture);
                 datatype ??= XsdNs + "integer";
             }
             else if (valueObject.ContainsKey("@direction") && ParserOptions.RdfDirection.HasValue)

--- a/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
@@ -101,7 +101,7 @@ public class JsonLdWriter : BaseStoreWriter
         var referencedOnce =new Dictionary<string, Usage>();
         // 4 - Initialize compound literal subjects to an empty map.
         var compoundLiteralSubjects = new Dictionary<string, JsonNode>();
-        var usages = new List<Usage>();
+        var usages = new Dictionary<JsonNode, List<Usage>>();
         // 5 - For each graph in RDF dataset:
         foreach (IGraph graph in store.Graphs)
         {
@@ -206,7 +206,11 @@ public class JsonLdWriter : BaseStoreWriter
                     // 5.7.9.1 - Reference the usages entry of the object entry of node map using the variable usages.
                     // 5.7.9.2 - Append a new map consisting of three entries, node, property, and value to the usages array. The node entry is set to a reference to node, property to predicate, and value to a reference to value.
                     var objectMap = nodeMap[@object] as JsonObject;
-                    usages.Add(new Usage(node, predicate, value));
+                    if (!usages.ContainsKey(objectMap))
+                    {
+                        usages[objectMap] = new List<Usage>();
+                    }
+                    usages[objectMap].Add(new Usage(node, predicate, value));
                 }
                 else if (@object != null && referencedOnce.ContainsKey(@object))
                 {
@@ -300,53 +304,61 @@ public class JsonLdWriter : BaseStoreWriter
             var nil = graphObject[RdfSpecsHelper.RdfListNil] as JsonObject;
 
             // 6.4 - For each item usage in the usages member of nil, perform the following steps:
-
-            foreach (Usage usage in usages.Where(u => u.Node == nil))
+            if (usages.ContainsKey(nil))
             {
-                // 6.4.1 - Initialize node to the value of the value of the node entry of usage,
-                // property to the value of the property entry of usage,
-                // and head to the value of the value entry of usage.
-                JsonObject node = usage.Node;
-                var property = usage.Property;
-                var head = usage.Value as JsonObject;
-                // 6.4.2 - Initialize two empty arrays list and list nodes.
-                var list = new JsonArray();
-                var listNodes = new JsonArray();
-                // 6.4.3 - While property equals rdf:rest, the value of the @id entry of node is a blank node identifier,
-                // the value of the entry of referenced once associated with the @id entry of node is a map,
-                // node has rdf:first and rdf:rest entries, both of which have as value an array consisting of a single element,
-                // and node has no other entries apart from an optional @type entry whose value is an array with a single item equal to rdf:List,
-                // node represents a well-formed list node.
-                // Perform the following steps to traverse the list backwards towards its head:
-                while (IsWellFormedListNode(node, property, referencedOnce))
+                foreach (Usage usage in usages[nil])
                 {
-                    // 6.4.3.1 - Append the only item of rdf:first member of node to the list array.
-                    list.Add((node[RdfSpecsHelper.RdfListFirst] as JsonArray)[0]);
-                    // 6.4.3.2 - Append the value of the @id member of node to the list nodes array.
-                    listNodes.Add(node["@id"]);
-                    // 6.4.3.3 - Initialize node usage to the value of the entry of referenced once associated with the @id entry of node.
-                    Usage nodeUsage = referencedOnce[node["@id"].GetValue<string>()];
+                    // 6.4.1 - Initialize node to the value of the value of the node entry of usage,
+                    // property to the value of the property entry of usage,
+                    // and head to the value of the value entry of usage.
+                    JsonObject node = usage.Node;
+                    var property = usage.Property;
+                    var head = usage.Value as JsonObject;
+                    // 6.4.2 - Initialize two empty arrays list and list nodes.
+                    var list = new List<JsonNode>();
+                    var listNodes = new List<string>();
+                    // 6.4.3 - While property equals rdf:rest, the value of the @id entry of node is a blank node identifier,
+                    // the value of the entry of referenced once associated with the @id entry of node is a map,
+                    // node has rdf:first and rdf:rest entries, both of which have as value an array consisting of a single element,
+                    // and node has no other entries apart from an optional @type entry whose value is an array with a single item equal to rdf:List,
+                    // node represents a well-formed list node.
+                    // Perform the following steps to traverse the list backwards towards its head:
+                    while (IsWellFormedListNode(node, property, referencedOnce))
+                    {
+                        // 6.4.3.1 - Append the only item of rdf:first member of node to the list array.
+                        JsonArray listArray = node[RdfSpecsHelper.RdfListFirst] as JsonArray;
+                        JsonNode firstItem = listArray[0];
+                        listArray.RemoveAt(0);
+                        list.Add(firstItem);
 
-                    // 6.4.3.4 - Set node to the value of the node entry of node usage,
-                    // property to the value of the property entry of node usage,
-                    // and head to the value of the value entry of node usage.
-                    node = nodeUsage.Node;
-                    property = nodeUsage.Property;
-                    head = nodeUsage.Value as JsonObject;
-                    // 6.4.3.5 - If the @id entry of node is an IRI instead of a blank node identifier, exit the while loop.
-                    if (!JsonLdUtils.IsBlankNodeIdentifier(node["@id"].GetValue<string>())) break;
-                }
+                        // 6.4.3.2 - Append the value of the @id member of node to the list nodes array.
+                        listNodes.Add(node["@id"].GetValue<string>());
 
-                // 6.4.4 - Remove the @id entry from head.
-                head.Remove("@id");
-                // 6.4.5 - Reverse the order of the list array.
-                list = [.. listNodes.Reverse()];
-                // 6.4.6 - Add an @list entry to head and initialize its value to the list array.
-                head["@list"] = list;
-                // 6.5.7 - For each item node id in list nodes, remove the node id entry from graph object.
-                foreach (var nodeId in listNodes.Select(item => item.GetValue<string>()))
-                {
-                    graphObject.Remove(nodeId);
+                        // 6.4.3.3 - Initialize node usage to the value of the entry of referenced once associated with the @id entry of node.
+                        Usage nodeUsage = referencedOnce[node["@id"].GetValue<string>()];
+
+                        // 6.4.3.4 - Set node to the value of the node entry of node usage,
+                        // property to the value of the property entry of node usage,
+                        // and head to the value of the value entry of node usage.
+                        node = nodeUsage.Node;
+                        property = nodeUsage.Property;
+                        head = nodeUsage.Value as JsonObject;
+                        // 6.4.3.5 - If the @id entry of node is an IRI instead of a blank node identifier, exit the while loop.
+                        if (!JsonLdUtils.IsBlankNodeIdentifier(node["@id"].GetValue<string>())) break;
+                    }
+
+                    // 6.4.4 - Remove the @id entry from head.
+                    head.Remove("@id");
+                    // 6.4.5 - Reverse the order of the list array.
+                    list.Reverse();
+                    // list = [.. listNodes.Reverse()];
+                    // 6.4.6 - Add an @list entry to head and initialize its value to the list array.
+                    head["@list"] = new JsonArray(list.ToArray());
+                    // 6.5.7 - For each item node id in list nodes, remove the node id entry from graph object.
+                    foreach (var nodeId in listNodes)
+                    {
+                        graphObject.Remove(nodeId);
+                    }
                 }
             }
 
@@ -374,13 +386,14 @@ public class JsonLdWriter : BaseStoreWriter
                 {
                     subjectMapProperties = subjectMapProperties.OrderBy(x => x.Key, StringComparer.Ordinal);
                 }
-                foreach (KeyValuePair<string, JsonNode> subjectMapProperty in subjectMapProperties)
+                foreach (KeyValuePair<string, JsonNode> subjectMapProperty in subjectMapProperties.ToList())
                 {
                     var s = subjectMapProperty.Key;
                     var n = subjectMapProperty.Value as JsonObject;
                     n.Remove("usages");
                     if (n.Any(np => !np.Key.Equals("@id")))
                     {
+                        graphMap[subject].AsObject().Remove(s);
                         graphArray.Add(n);
                     }
                 }

--- a/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
@@ -76,7 +76,7 @@ public class JsonLdWriter : BaseStoreWriter
             jsonArray.WriteTo(jsonWriter);
             jsonWriter.Flush();
             ms.Position = 0;
-            var jsonString = Encoding.UTF8.GetString(ms.GetBuffer());
+            var jsonString = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
             output.Write(jsonString);
         }
         output.Flush();
@@ -389,7 +389,7 @@ public class JsonLdWriter : BaseStoreWriter
             node.Remove("usages");
             if (node.Any(p => !p.Key.Equals("@id")))
             {
-                result.Add(node);
+                result.Add(node.DeepClone());
             }
         }
         // 9 - Return result.

--- a/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
+++ b/Libraries/dotNetRdf.Core/Writing/JsonLdWriter.cs
@@ -28,8 +28,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
 using VDS.RDF.JsonLd;
 using VDS.RDF.JsonLd.Processors;
 using VDS.RDF.JsonLd.Syntax;
@@ -67,8 +69,16 @@ public class JsonLdWriter : BaseStoreWriter
     {
         if (store == null) throw new ArgumentNullException(nameof(store), "Cannot write a null store");
         if(output == null) throw new ArgumentNullException(nameof(output), "Cannot write to a null writer");
-        JArray jsonArray = SerializeStore(store);
-        output.Write(jsonArray.ToString(_options.JsonFormatting));
+        JsonArray jsonArray = SerializeStore(store);
+        using (MemoryStream ms = new MemoryStream())
+        {
+            var jsonWriter = new Utf8JsonWriter(ms, new JsonWriterOptions());
+            jsonArray.WriteTo(jsonWriter);
+            jsonWriter.Flush();
+            ms.Position = 0;
+            var jsonString = Encoding.UTF8.GetString(ms.GetBuffer());
+            output.Write(jsonString);
+        }
         output.Flush();
         if (!leaveOpen)
         {
@@ -81,16 +91,17 @@ public class JsonLdWriter : BaseStoreWriter
     /// </summary>
     /// <param name="store"></param>
     /// <returns></returns>
-    public JArray SerializeStore(ITripleStore store)
+    public JsonArray SerializeStore(ITripleStore store)
     {
         // 1 - Initialize default graph to an empty dictionary.
-        var defaultGraph = new JObject();
+        var defaultGraph = new JsonObject();
         // 2 - Initialize graph map to a dictionary consisting of a single member @default whose value references default graph.
-        var graphMap = new JObject(new JProperty("@default", defaultGraph));
+        var graphMap = new Dictionary<string, JsonNode>{ ["@default"] = defaultGraph };
         // 3 - Initialize referenced once to an empty map.
         var referencedOnce =new Dictionary<string, Usage>();
         // 4 - Initialize compound literal subjects to an empty map.
-        var compoundLiteralSubjects = new JObject();
+        var compoundLiteralSubjects = new Dictionary<string, JsonNode>();
+        var usages = new List<Usage>();
         // 5 - For each graph in RDF dataset:
         foreach (IGraph graph in store.Graphs)
         {
@@ -100,13 +111,13 @@ public class JsonLdWriter : BaseStoreWriter
             // 5.2 - If graph map has no name entry, create one and set its value to an empty map.
             if (!graphMap.ContainsKey(name))
             {
-                graphMap.Add(name, new JObject());
+                graphMap.Add(name, new JsonObject());
             }
 
             // 5.3 - If compound literal subjects has no name entry, create one and set its value to an empty map.
             if (!compoundLiteralSubjects.ContainsKey(name))
             {
-                compoundLiteralSubjects[name] = new JObject();
+                compoundLiteralSubjects[name] = new JsonObject();
             }
 
             // 5.4 - If graph is not the default graph and default graph does not have a name entry,
@@ -115,15 +126,15 @@ public class JsonLdWriter : BaseStoreWriter
             {
                 if (!defaultGraph.ContainsKey(name))
                 {
-                    defaultGraph.Add(name, new JObjectWithUsages(new JProperty("@id", name)));
+                    defaultGraph.Add(name, new JsonObject { ["@id"] = name });
                 }
             }
 
             // 5.5 - Reference the value of the name entry in graph map using the variable node map.
-            var nodeMap = graphMap[name] as JObject;
+            var nodeMap = graphMap[name] as JsonObject;
 
             // 5.6 - Reference the value of the name entry in compound literal subjects using the variable compound map.
-            JToken compoundMap = compoundLiteralSubjects[name];
+            JsonNode compoundMap = compoundLiteralSubjects[name];
 
             // 5.7 - For each triple in graph consisting of subject, predicate, and object:
             foreach (Triple triple in graph.Triples)
@@ -135,11 +146,11 @@ public class JsonLdWriter : BaseStoreWriter
                 // 5.7.1 - If node map does not have a subject entry, create one and initialize its value to a new map consisting of a single entry @id whose value is set to subject.
                 if (!nodeMap.ContainsKey(subject))
                 {
-                    nodeMap.Add(subject, new JObjectWithUsages(new JProperty("@id", subject)));
+                    nodeMap.Add(subject, new JsonObject { ["@id"] = subject });
                 }
 
                 // 5.7.2 - Reference the value of the subject entry in node map using the variable node.
-                var node = nodeMap[subject] as JObjectWithUsages;
+                var node = nodeMap[subject] as JsonObject;
 
                 // 5.7.3 - If the rdfDirection option is compound-literal and predicate is rdf:direction, add an entry in compound map for subject with the value true.
                 if (_options.RdfDirection.HasValue && _options.RdfDirection == JsonLdRdfDirectionMode.CompoundLiteral && RdfSpecsHelper.RdfDirection.Equals(predicate))
@@ -154,7 +165,7 @@ public class JsonLdWriter : BaseStoreWriter
                 {
                     if (!nodeMap.ContainsKey(@object))
                     {
-                        nodeMap.Add(@object, new JObjectWithUsages(new JProperty("@id", @object)));
+                        nodeMap.Add(@object, new JsonObject { ["@id"] = @object });
                     }
                 }
 
@@ -165,12 +176,12 @@ public class JsonLdWriter : BaseStoreWriter
                     // Append object to the value of the @type entry of node; unless such an item already exists. 
                     if (node.ContainsKey("@type"))
                     {
-                        AppendUniqueElement(@object, node["@type"] as JArray);
+                        AppendUniqueElement(@object, node["@type"] as JsonArray);
                     }
                     else
                     {
                         // If no such entry exists, create one and initialize it to an array whose only item is object.
-                        node.Add("@type", new JArray(@object));
+                        node.Add("@type", new JsonArray(@object));
                     }
 
                     // Finally, continue to the next triple.
@@ -178,24 +189,24 @@ public class JsonLdWriter : BaseStoreWriter
                 }
 
                 // 5.7.6 - Initialize value to the result of using the RDF to Object Conversion algorithm, passing object, rdfDirection, and useNativeTypes.
-                JToken value = RdfToObject(triple.Object);
+                JsonNode value = RdfToObject(triple.Object);
 
                 // 5.7.7 -If node does not have a predicate entry, create one and initialize its value to an empty array.
                 if (!node.ContainsKey(predicate))
                 {
-                    node[predicate] = new JArray();
+                    node[predicate] = new JsonArray();
                 }
 
                 // 5.7.8 - If there is no item equivalent to value in the array associated with the predicate entry of node, append a reference to value to the array. Two maps are considered equal if they have equivalent map entries.
-                AppendUniqueElement(value, node[predicate] as JArray);
+                AppendUniqueElement(value, node[predicate] as JsonArray);
 
                 // 5.7.9 - If object is rdf:nil, it represents the termination of an RDF collection:
                 if (triple.Object is IUriNode u && u.Uri.ToString().Equals(RdfSpecsHelper.RdfListNil))
                 {
                     // 5.7.9.1 - Reference the usages entry of the object entry of node map using the variable usages.
                     // 5.7.9.2 - Append a new map consisting of three entries, node, property, and value to the usages array. The node entry is set to a reference to node, property to predicate, and value to a reference to value.
-                    var objectMap = nodeMap[@object] as JObjectWithUsages;
-                    objectMap.Usages.Add(new Usage(node, predicate, value));
+                    var objectMap = nodeMap[@object] as JsonObject;
+                    usages.Add(new Usage(node, predicate, value));
                 }
                 else if (@object != null && referencedOnce.ContainsKey(@object))
                 {
@@ -213,45 +224,45 @@ public class JsonLdWriter : BaseStoreWriter
         }
 
         // 6 - For each name and graph object in graph map:
-        foreach (KeyValuePair<string, JToken> gp in graphMap)
+        foreach (KeyValuePair<string, JsonNode> gp in graphMap)
         {
             var name = gp.Key;
-            var graphObject = gp.Value as JObject;
+            var graphObject = gp.Value as JsonObject;
 
             // 6.1 - If compound literal subjects has an entry for name, then for each cl which is a key in that entry:
             if (compoundLiteralSubjects.ContainsKey(name))
             {
-                if (compoundLiteralSubjects[name] is JObject compoundMap)
+                if (compoundLiteralSubjects[name] is JsonObject compoundMap)
                 {
-                    foreach (JProperty clProp in compoundMap.Properties())
+                    foreach (KeyValuePair<string, JsonNode> clProp in compoundMap)
                     {
-                        var cl = clProp.Name;
+                        var cl = clProp.Key;
                         // 6.1.1 - Initialize cl entry to the value of cl in referenced once, continuing to the next cl if cl entry is not a map.
                         Usage clEntry = referencedOnce[cl];
                         if (clEntry == null) continue;
                         // 6.1.2 - Initialize node to the value of node in cl entry.
                         // 6.1.3 - Initialize property to value of property in cl entry.
                         // 6.1.4 - Initialize value to value of value in cl entry.
-                        JObjectWithUsages node = clEntry.Node;
+                        JsonObject node = clEntry.Node;
                         var property = clEntry.Property;
-                        JToken value = clEntry.Value;
+                        JsonNode value = clEntry.Value;
                         // 6.1.5 - Initialize cl node to the value of cl in graph object, and remove that entry from graph object, continuing to the next cl if cl node is not a map.
-                        var clNode = graphObject[cl] as JObject;
+                        var clNode = graphObject[cl] as JsonObject;
                         graphObject.Remove(cl);
                         if (clNode == null) continue;
                         // 6.1.6 - For each cl reference in the value of property in node where the value of @id in cl reference is cl:
-                        foreach (JObject clReference in node[property].OfType<JObject>()
-                            .Where(n => cl.Equals(n["@id"].Value<string>())))
+                        foreach (JsonObject clReference in node[property].AsArray().OfType<JsonObject>()
+                            .Where(n => cl.Equals(n["@id"].GetValue<string>())))
                         {
                             // 6.1.6.1 - Delete the @id entry in cl reference.
                             clReference.Remove("@id");
                             // 6.1.6.2 - Add an entry to cl reference for @value with the value taken from the rdf:value entry in cl node.
-                            clReference["@value"] = clNode[RdfSpecsHelper.RdfValue][0]["@value"];
+                            clReference["@value"] = clNode[RdfSpecsHelper.RdfValue][0]["@value"].GetValue<string>();
                             // 6.1.6.3 - Add an entry to cl reference for @language with the value taken from the rdf:language entry in cl node, if any.
                             // If that value is not well-formed according to section 2.2.9 of [BCP47], an invalid language-tagged string error has been detected and processing is aborted.
                             if (clNode.ContainsKey(RdfSpecsHelper.RdfLanguage))
                             {
-                                var language = clNode[RdfSpecsHelper.RdfLanguage][0]["@value"].Value<string>();
+                                var language = clNode[RdfSpecsHelper.RdfLanguage][0]["@value"].GetValue<string>();
                                 if (!LanguageTag.IsWellFormed(language))
                                 {
                                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidLanguageTaggedString,
@@ -265,7 +276,7 @@ public class JsonLdWriter : BaseStoreWriter
                             // If that value is not "ltr" or "rtl", an invalid base direction error has been detected and processing is aborted.
                             if (clNode.ContainsKey(RdfSpecsHelper.RdfDirection))
                             {
-                                var direction = clNode[RdfSpecsHelper.RdfDirection][0]["@value"].Value<string>();
+                                var direction = clNode[RdfSpecsHelper.RdfDirection][0]["@value"].GetValue<string>();
                                 if (!("ltr".Equals(direction) || "rtl".Equals(direction)))
                                 {
                                     throw new JsonLdProcessorException(JsonLdErrorCode.InvalidBaseDirection,
@@ -286,21 +297,21 @@ public class JsonLdWriter : BaseStoreWriter
             }
 
             // 6.3 - Initialize nil to the value of the rdf:nil member of graph object.
-            var nil = graphObject[RdfSpecsHelper.RdfListNil] as JObjectWithUsages;
+            var nil = graphObject[RdfSpecsHelper.RdfListNil] as JsonObject;
 
             // 6.4 - For each item usage in the usages member of nil, perform the following steps:
 
-            foreach (Usage usage in nil.Usages)
+            foreach (Usage usage in usages.Where(u => u.Node == nil))
             {
                 // 6.4.1 - Initialize node to the value of the value of the node entry of usage,
                 // property to the value of the property entry of usage,
                 // and head to the value of the value entry of usage.
-                JObjectWithUsages node = usage.Node;
+                JsonObject node = usage.Node;
                 var property = usage.Property;
-                var head = usage.Value as JObject;
+                var head = usage.Value as JsonObject;
                 // 6.4.2 - Initialize two empty arrays list and list nodes.
-                var list = new JArray();
-                var listNodes = new JArray();
+                var list = new JsonArray();
+                var listNodes = new JsonArray();
                 // 6.4.3 - While property equals rdf:rest, the value of the @id entry of node is a blank node identifier,
                 // the value of the entry of referenced once associated with the @id entry of node is a map,
                 // node has rdf:first and rdf:rest entries, both of which have as value an array consisting of a single element,
@@ -310,30 +321,30 @@ public class JsonLdWriter : BaseStoreWriter
                 while (IsWellFormedListNode(node, property, referencedOnce))
                 {
                     // 6.4.3.1 - Append the only item of rdf:first member of node to the list array.
-                    list.Add((node[RdfSpecsHelper.RdfListFirst] as JArray)[0]);
+                    list.Add((node[RdfSpecsHelper.RdfListFirst] as JsonArray)[0]);
                     // 6.4.3.2 - Append the value of the @id member of node to the list nodes array.
                     listNodes.Add(node["@id"]);
                     // 6.4.3.3 - Initialize node usage to the value of the entry of referenced once associated with the @id entry of node.
-                    Usage nodeUsage = referencedOnce[node["@id"].Value<string>()];
+                    Usage nodeUsage = referencedOnce[node["@id"].GetValue<string>()];
 
                     // 6.4.3.4 - Set node to the value of the node entry of node usage,
                     // property to the value of the property entry of node usage,
                     // and head to the value of the value entry of node usage.
                     node = nodeUsage.Node;
                     property = nodeUsage.Property;
-                    head = nodeUsage.Value as JObject;
+                    head = nodeUsage.Value as JsonObject;
                     // 6.4.3.5 - If the @id entry of node is an IRI instead of a blank node identifier, exit the while loop.
-                    if (!JsonLdUtils.IsBlankNodeIdentifier(node["@id"].Value<string>())) break;
+                    if (!JsonLdUtils.IsBlankNodeIdentifier(node["@id"].GetValue<string>())) break;
                 }
 
                 // 6.4.4 - Remove the @id entry from head.
                 head.Remove("@id");
                 // 6.4.5 - Reverse the order of the list array.
-                list = new JArray(list.Reverse());
+                list = [.. listNodes.Reverse()];
                 // 6.4.6 - Add an @list entry to head and initialize its value to the list array.
                 head["@list"] = list;
                 // 6.5.7 - For each item node id in list nodes, remove the node id entry from graph object.
-                foreach (var nodeId in listNodes.Select(item => item.Value<string>()))
+                foreach (var nodeId in listNodes.Select(item => item.GetValue<string>()))
                 {
                     graphObject.Remove(nodeId);
                 }
@@ -342,33 +353,33 @@ public class JsonLdWriter : BaseStoreWriter
         }
 
         // 7 - Initialize an empty array result.
-        var result = new JArray();
+        var result = new JsonArray();
         // 8 - For each subject and node in default graph ordered lexicographically by subject if ordered is true:
-        IEnumerable<JProperty> defaultGraphProperties = defaultGraph.Properties();
-        if (_options.Ordered) defaultGraphProperties = defaultGraphProperties.OrderBy(x => x.Name, StringComparer.Ordinal);
-        foreach (JProperty defaultGraphProperty in defaultGraphProperties)
+        IEnumerable<KeyValuePair<string, JsonNode>> defaultGraphProperties = defaultGraph;
+        if (_options.Ordered) defaultGraphProperties = defaultGraphProperties.OrderBy(x => x.Key, StringComparer.Ordinal);
+        foreach (KeyValuePair<string, JsonNode> defaultGraphProperty in defaultGraphProperties)
         {
-            var subject = defaultGraphProperty.Name;
-            var node = defaultGraphProperty.Value as JObject;
+            var subject = defaultGraphProperty.Key;
+            var node = defaultGraphProperty.Value as JsonObject;
             // 8.1 - If graph map has a subject member:
             if (graphMap.ContainsKey(subject))
             {
                 // 8.1.1 - Add an @graph member to node and initialize its value to an empty array.
-                var graphArray = new JArray();
+                var graphArray = new JsonArray();
                 node["@graph"] = graphArray;
                 // 8.1.2 - For each key-value pair s-n in the subject entry of graph map ordered lexicographically by s if ordered is true,
                 // append n to the @graph entry of node after removing its usages entry, unless the only remaining entry of n is @id.
-                IEnumerable<JProperty> subjectMapProperties = (graphMap[subject] as JObject).Properties();
+                IEnumerable<KeyValuePair<string, JsonNode>> subjectMapProperties = (graphMap[subject] as JsonObject);
                 if (_options.Ordered)
                 {
-                    subjectMapProperties = subjectMapProperties.OrderBy(x => x.Name, StringComparer.Ordinal);
+                    subjectMapProperties = subjectMapProperties.OrderBy(x => x.Key, StringComparer.Ordinal);
                 }
-                foreach (JProperty subjectMapProperty in subjectMapProperties)
+                foreach (KeyValuePair<string, JsonNode> subjectMapProperty in subjectMapProperties)
                 {
-                    var s = subjectMapProperty.Name;
-                    var n = subjectMapProperty.Value as JObject;
+                    var s = subjectMapProperty.Key;
+                    var n = subjectMapProperty.Value as JsonObject;
                     n.Remove("usages");
-                    if (n.Properties().Any(np => !np.Name.Equals("@id")))
+                    if (n.Any(np => !np.Key.Equals("@id")))
                     {
                         graphArray.Add(n);
                     }
@@ -376,7 +387,7 @@ public class JsonLdWriter : BaseStoreWriter
             }
             // 8.2 - Append node to result after removing its usages member, unless the only remaining member of node is @id.
             node.Remove("usages");
-            if (node.Properties().Any(p => !p.Name.Equals("@id")))
+            if (node.Any(p => !p.Key.Equals("@id")))
             {
                 result.Add(node);
             }
@@ -385,7 +396,7 @@ public class JsonLdWriter : BaseStoreWriter
         return result;
     }
 
-    private static bool IsWellFormedListNode(JObject node, string property, Dictionary<string, Usage> nodeUsagesMap)
+    private static bool IsWellFormedListNode(JsonObject node, string property, Dictionary<string, Usage> nodeUsagesMap)
     {
         // If property equals rdf:rest, the value of the @id entry of node is a blank node identifier,
         // the value of the entry of referenced once associated with the @id entry of node is a map,
@@ -393,40 +404,40 @@ public class JsonLdWriter : BaseStoreWriter
         // and node has no other entries apart from an optional @type entry whose value is an array with a single item equal to rdf: List,
         // node represents a well-formed list node. 
         if (!RdfSpecsHelper.RdfListRest.Equals(property)) return false;
-        var nodeId = node["@id"].Value<string>();
+        var nodeId = node["@id"].GetValue<string>();
         if (nodeId == null || !JsonLdUtils.IsBlankNodeIdentifier(nodeId)) return false;
         if (!nodeUsagesMap.TryGetValue(nodeId, out Usage usage)) return false;
         if (usage == null) return false;
 
-        var first = node[RdfSpecsHelper.RdfListFirst] as JArray;
-        var rest = node[RdfSpecsHelper.RdfListRest] as JArray;
+        var first = node[RdfSpecsHelper.RdfListFirst] as JsonArray;
+        var rest = node[RdfSpecsHelper.RdfListRest] as JsonArray;
         if (first == null || rest == null) return false;
         if (first.Count != 1 || rest.Count != 1) return false;
 
-        var type = node["@type"] as JArray;
+        var type = node["@type"] as JsonArray;
         if (type != null && (type.Count != 1 ||
-                             type.Count == 1 && !type[0].Value<string>().Equals(RdfSpecsHelper.RdfList)))
+                             type.Count == 1 && !type[0].GetValue<string>().Equals(RdfSpecsHelper.RdfList)))
             return false;
-        var propCount = node.Properties().Count();
-        if (type == null && propCount != 3 || type != null && propCount != 4) return false;
+        var propCount = node.Count();
+        if ((type == null && propCount != 3) || (type != null && propCount != 4)) return false;
         return true;
     }
 
-    private JToken RdfToObject(INode value)
+    private JsonNode RdfToObject(INode value)
     {
         switch (value)
         {
             // 1 - If value is an IRI or a blank node identifier, return a new dictionary consisting of a single member @id whose value is set to value.
             case IUriNode uriNode:
-                return new JObject(new JProperty("@id", uriNode.Uri.OriginalString));
+                return new JsonObject{["@id"] = uriNode.Uri.OriginalString};
             case IBlankNode bNode:
-                return new JObject(new JProperty("@id", "_:" + bNode.InternalID));
+                return new JsonObject{["@id"] = "_:" + bNode.InternalID};
             case ILiteralNode literal:
                 // 2 - Otherwise value is an RDF literal:
                 // 2.1 - Initialize a new empty dictionary result.
-                var result = new JObject();
+                var result = new JsonObject();
                 // 2.2 - Initialize converted value to value.
-                JToken convertedValue = new JValue(literal.Value);
+                JsonNode convertedValue = JsonValue.Create(literal.Value);
                 // 2.3 - Initialize type to null
                 string type = null;
                 // 2.4 - If use native types is true
@@ -435,7 +446,7 @@ public class JsonLdWriter : BaseStoreWriter
                     // 2.4.1 - If the datatype IRI of value equals xsd:string, set converted value to the lexical form of value.
                     if (literal.DataType.ToString().Equals(XmlSpecsHelper.XmlSchemaDataTypeString))
                     {
-                        convertedValue = new JValue(literal.Value);
+                        convertedValue = JsonValue.Create(literal.Value);
                     }
                     // 2.4.2 - Otherwise, if the datatype IRI of value equals xsd:boolean, set converted value to true if the lexical form of value matches true, or false if it matches false. If it matches neither, set type to xsd:boolean.
                     else if (literal.DataType.ToString()
@@ -443,11 +454,11 @@ public class JsonLdWriter : BaseStoreWriter
                     {
                         if (literal.Value.Equals("true"))
                         {
-                            convertedValue = new JValue(true);
+                            convertedValue = JsonValue.Create(true);
                         }
                         else if (literal.Value.Equals("false"))
                         {
-                            convertedValue = new JValue(false);
+                            convertedValue = JsonValue.Create(false);
                         }
                         else
                         {
@@ -459,14 +470,14 @@ public class JsonLdWriter : BaseStoreWriter
                     {
                         if (IsWellFormedInteger(literal.Value))
                         {
-                            convertedValue = new JValue(long.Parse(literal.Value));
+                            convertedValue = JsonValue.Create(long.Parse(literal.Value));
                         }
                     }
                     else if (literal.DataType.ToString().Equals(XmlSpecsHelper.XmlSchemaDataTypeDouble))
                     {
                         if (IsWellFormedDouble(literal.Value))
                         {
-                            convertedValue = new JValue(double.Parse(literal.Value));
+                            convertedValue = JsonValue.Create(double.Parse(literal.Value));
                         }
                     }
                     // KA: Step missing from spec - otherwise set type to the datatype IRI
@@ -481,7 +492,7 @@ public class JsonLdWriter : BaseStoreWriter
                 {
                     try
                     {
-                        convertedValue = JToken.Parse(literal.Value);
+                        convertedValue = JsonNode.Parse(literal.Value);
                     }
                     catch (Exception ex)
                     {
@@ -545,9 +556,9 @@ public class JsonLdWriter : BaseStoreWriter
         return DoubleLexicalRepresentation.IsMatch(literal);
     }
 
-    private static void AppendUniqueElement(JToken element, JArray toArray)
+    private static void AppendUniqueElement(JsonNode element, JsonArray toArray)
     {
-        if (!toArray.Any(x => JToken.DeepEquals(x, element)))
+        if (!toArray.Any(x => JsonNode.DeepEquals(x, element)))
         {
             toArray.Add(element);
         }
@@ -569,22 +580,16 @@ public class JsonLdWriter : BaseStoreWriter
     public override event StoreWriterWarning Warning;
 #pragma warning restore CS0067
 
-    private class JObjectWithUsages : JObject
-    {
-        public readonly List<Usage> Usages = [];
-        public JObjectWithUsages(params object[] content) : base(content) { }
-    }
-
     private class Usage
     {
-        public Usage(JObjectWithUsages node, string property, JToken value)
+        public Usage(JsonObject node, string property, JsonNode value)
         {
             Node = node;
             Property = property;
             Value = value;
         }
-        public JObjectWithUsages Node { get; }
+        public JsonObject Node { get; }
         public string Property { get; }
-        public JToken Value { get; }
+        public JsonNode Value { get; }
     }
 }

--- a/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
+++ b/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="System.Globalization.Extensions" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Thread" />
     <PackageReference Include="System.Collections.Specialized" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/Testing/dotNetRdf.Tests/JsonLd/JsonLdParserTests.cs
+++ b/Testing/dotNetRdf.Tests/JsonLd/JsonLdParserTests.cs
@@ -43,15 +43,15 @@ public class JsonLdParserTests : IDisposable
                 .WithHeader("Content-Type", "application/ld+json")
                 .WithBody($$"""
                     {
-                      '@context': { 
-                        'name': 'http://xmlns.com/foaf/0.1/name',
-                        'born': { 
-                          '@id': 'http://schema.org/birthDate',
-                          '@type': 'http://www.w3.org/2001/XMLSchema#date'
+                      "@context": {
+                        "name": "http://xmlns.com/foaf/0.1/name",
+                        "born": { 
+                          "@id": "http://schema.org/birthDate",
+                          "@type": "http://www.w3.org/2001/XMLSchema#date"
                         },
-                        'spouse': {
-                          '@id': 'http://schema.org/spouse',
-                          '@type': '@id'
+                        "spouse": {
+                          "@id": "http://schema.org/spouse",
+                          "@type": "@id"
                         }
                       }
                     }
@@ -140,7 +140,8 @@ public class JsonLdParserTests : IDisposable
         original.LoadFromString($@"<http://example.com/1> <http://example.com/1> ""{dateTimeValue}""^^<{datatype}>.");
 
         using var target = new TripleStore();
-        target.LoadFromString(StringWriter.Write(original, new JsonLdWriter()), new JsonLdParser());
+        var originalJsonLd = StringWriter.Write(original, new JsonLdWriter());
+        target.LoadFromString(originalJsonLd, new JsonLdParser());
 
         Assert.True(original.Graphs.Single().Difference(target.Graphs.Single()).AreEqual);
     }
@@ -199,16 +200,16 @@ public class JsonLdParserTests : IDisposable
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/ld+json")
-                .WithBody("{'@context': { 'foo': 'http://example.org/foo'} }"));
+                .WithBody("{\"@context\": { \"foo\": \"http://example.org/foo\"} }"));
         var contextPath = _server.Urls[0] + "/context.jsonld";
         var jsonLd = @"
 {
-  '@context': [
-    { '@base': 'http://example.com/' },
-    '" + contextPath + @"'
+  ""@context"": [
+    { ""@base"": ""http://example.com/"" },
+    """ + contextPath + @"""
   ],
-  '@id': 'foo',
-  'rdf:type': 'foo:Item'
+  ""@id"": ""foo"",
+  ""rdf:type"": ""foo:Item""
 }";
         var jsonLdParser = new JsonLdParser();
         ITripleStore tStore = new TripleStore();
@@ -229,10 +230,10 @@ public class JsonLdParserTests : IDisposable
     {
         var jsonLd = @"
 {
-    '@id': 'urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6',
-    'http://example.org/p': {
-        '@value': 'o',
-        '@type': 'urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'
+    ""@id"": ""urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"",
+    ""http://example.org/p"": {
+        ""@value"": ""o"",
+        ""@type"": ""urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6""
     }
 }";
         var jsonLdParser = new JsonLdParser();
@@ -254,18 +255,18 @@ public class JsonLdParserTests : IDisposable
     public void ItShouldRaiseAWarningIfAnIdCannotBeResolveToAnIri()
     {
         var jsonLd = @"{
-              '@graph': [
+              ""@graph"": [
             {
-                '@id': 'Row1',
-                '@type': 'MelRow',
-                'rdfs:label': 'An empty MEL Row'
+                ""@id"": ""Row1"",
+                ""@type"": ""MelRow"",
+                ""rdfs:label"": ""An empty MEL Row""
             }
             ],
-            '@context': {
-                'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
-                '@vocab': 'http://example.com/ontology/mel#',
-                'sor': 'http://example.com/ontology/sor#',
-                '@version': '1.1'
+            ""@context"": {
+                ""rdfs"": ""http://www.w3.org/2000/01/rdf-schema#"",
+                ""@vocab"": ""http://example.com/ontology/mel#"",
+                ""sor"": ""http://example.com/ontology/sor#"",
+                ""@version"": ""1.1""
             }
         }";
         var warnings = new List<string>();

--- a/Testing/dotNetRdf.Tests/JsonLd/JsonLdParserTests.cs
+++ b/Testing/dotNetRdf.Tests/JsonLd/JsonLdParserTests.cs
@@ -1,10 +1,10 @@
 ﻿using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using VDS.RDF.Nodes;
 using VDS.RDF.Parsing;
 using VDS.RDF.Writing;
@@ -305,12 +305,12 @@ public class JsonLdParserTests : IDisposable
   ""@id"": ""http://localhost:8080/outline/http%3A%2F%2Flocalhost%3A8080%2Fknowledge-graph%2Fengine_01""
 }";
 
-        var input = JToken.Parse(inputJson);
-        var frame = JToken.Parse(frameJson);
-        JObject frameResult = JsonLdProcessor.Frame(input, frame, new JsonLdProcessorOptions());
+        var input = JsonNode.Parse(inputJson);
+        var frame = JsonNode.Parse(frameJson);
+        JsonObject frameResult = JsonLdProcessor.Frame(input, frame, new JsonLdProcessorOptions());
         frameResult["@id"]?.ToString().Should()
             .Be("http://localhost:8080/outline/http%3A%2F%2Flocalhost%3A8080%2Fknowledge-graph%2Fengine_01");
-        frameResult["@type"]?.Children().Count().Should().Be(2);
+        frameResult["@type"]?.AsArray().Count.Should().Be(2);
         frameResult["ex:id"]?.ToString().Should().Be("engine_01");
         _output.WriteLine(frameResult.ToString());
     }

--- a/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
+++ b/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
@@ -252,8 +252,14 @@ public class JsonLdTestSuiteBase
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
                 var expectedOutputElement = JsonNode.Parse(expectedOutputJson);
                 JsonObject actualOutput = JsonLdProcessor.Frame(inputElement, frameElement, options);
-                Assert.True(DeepEquals(expectedOutputElement, actualOutput),
-                    $"Test failed for input {Path.GetFileName(inputPath)}\nExpected:\n{expectedOutputElement}\nActual:\n{actualOutput}");
+                try
+                {
+                    DeepEquals(expectedOutputElement, actualOutput, true, true);
+                }
+                catch (DeepEqualityFailure ex)
+                {
+                    Assert.Fail($"Test failed for input {Path.GetFileName(inputPath)}\nExpected:\n{expectedOutputElement}\nActual:\n{actualOutput}\nMatch Failure: {ex}");
+                }
                 break;
             case JsonLdTestType.NegativeEvaluationTest:
                 JsonLdProcessorException exception = Assert.ThrowsAny<JsonLdProcessorException>(() =>
@@ -288,7 +294,7 @@ public class JsonLdTestSuiteBase
             case JsonValueKind.Object:
                 return DeepEquals(t1.AsObject(), t2.AsObject(), arraysAreOrdered);
             default:
-                return t1.Equals(t2);
+                return JsonNode.DeepEquals(t1, t2);
         }
     }
 
@@ -324,63 +330,76 @@ public class JsonLdTestSuiteBase
                o1.All(p => DeepEquals(p.Value, o2[p.Key], arraysAreOrdered));
     }
 
-    private static bool DeepEquals(JsonNode token1, JsonNode token2, bool ignoreArrayOrder, bool throwOnMismatch)
+    private static bool DeepEquals(JsonNode expected, JsonNode actual, bool ignoreArrayOrder, bool throwOnMismatch)
     {
-        if (token1.GetValueKind() != token2.GetValueKind())
+        if (expected.SafeValueKind() != actual.SafeValueKind())
         {
-            if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+            if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual);
             return false;
         }
-        switch (token1.GetValueKind())
+        switch (expected.SafeValueKind())
         {
             case JsonValueKind.Object:
-                if (!(token1 is JsonObject o1 && token2 is JsonObject o2)) return false;
+                if (!(expected is JsonObject o1 && actual is JsonObject o2)) return false;
                 foreach (var p in o1)
                 {
-                    if (o2[p.Key] == null)
+                    if (!o2.ContainsKey(p.Key))
                     {
-                        if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                        if (throwOnMismatch) 
+                        {
+                            throw new DeepEqualityFailure(expected, actual, $"Property {p.Key} in expected object not found in actual object.");
+                        }
                         return false;
                     }
                     if (!DeepEquals(p.Value, o2[p.Key], ignoreArrayOrder, throwOnMismatch))
                     {
-                        if (throwOnMismatch) throw new DeepEqualityFailure(p.Value, o2[p.Key]);
+                        if (throwOnMismatch) 
+                        {
+                            throw new DeepEqualityFailure(p.Value, o2[p.Key], $"Property {p.Key} values do not match.");
+                        }
                         return false;
                     }
                 }
-                if (o2.Any(p2 => o1[p2.Key] == null))
+                if (o2.Any(p2 => !o1.ContainsKey(p2.Key)))
                 {
-                    if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                    if (throwOnMismatch) {
+                        throw new DeepEqualityFailure(expected, actual, "Actual object has properties not found in expected object.");
+                    }
                     return false;
                 }
                 return true;
             case JsonValueKind.Array:
-                if (!(token1 is JsonArray a1 && token2 is JsonArray a2)) return false;
-                if (a1.Count != a2.Count)
+                if (!(expected is JsonArray expectedArray && actual is JsonArray actualArray))
                 {
-                    if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                    if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual, "One of the tokens is not a JsonArray.");
+                    return false;
+                }
+
+                if (expectedArray.Count != actualArray.Count)
+                {
+                    if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual, "Array lengths do not match - expected: " + expectedArray.Count + ", actual: " + actualArray.Count);
                     return false;
                 }
 
                 if (!ignoreArrayOrder)
                 {
-                    for (var i = 0; i < a1.Count; i++)
+                    for (var i = 0; i < expectedArray.Count; i++)
                     {
-                        if (!DeepEquals(a1[i], a2[i], ignoreArrayOrder, throwOnMismatch))
+                        if (!DeepEquals(expectedArray[i], actualArray[i], ignoreArrayOrder, throwOnMismatch))
                         {
-                            if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                            if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual, $"Array items at index {i} do not match.");
                             return false;
                         }
 
                     }
                     return true;
                 }
-                var unmatchedItems = token2.DeepClone().AsArray().ToList();
-                foreach (JsonNode item1 in a1)
+                var unmatchedItems = actualArray.DeepClone().AsArray().ToList();
+                foreach (JsonNode item1 in expectedArray)
                 {
                     if (unmatchedItems.Count == 0)
                     {
-                        if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                        if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual, "No unmatched items left for array comparison.");
                         return false;
                     }
                     var match = unmatchedItems.FindIndex(x => DeepEquals(item1, x, ignoreArrayOrder, false));
@@ -390,22 +409,23 @@ public class JsonLdTestSuiteBase
                     }
                     else
                     {
-                        if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
+                        if (throwOnMismatch) throw new DeepEqualityFailure(expected, actual, "No matching item found in array.");
                         return false;
                     }
                 }
                 return unmatchedItems.Count == 0;
+            case JsonValueKind.Null:
+                return actual.SafeValueKind() == JsonValueKind.Null;
             default:
-                return JsonNode.DeepEquals(token1, token2);
+                return JsonNode.DeepEquals(expected, actual);
         }
     }
 
     private class DeepEqualityFailure : Exception
     {
-        public DeepEqualityFailure(JsonNode expected, JsonNode actual) : base(
-            $"DeepEquality failed at {expected.GetPath()}.\nExpected: {expected}\nActual: {actual}")
+        public DeepEqualityFailure(JsonNode expected, JsonNode actual, string detail = null) : base(
+            $"DeepEquality failed at {expected?.GetPath() ?? actual?.GetPath() ?? "unknown path"}. {detail ?? ""}\nExpected: {expected.ToJsonString()}\nActual: {actual.ToJsonString()}")
         {
-            
         }
     }
 

--- a/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
+++ b/Testing/dotNetRdf.Tests/JsonLd/JsonLdTestSuiteBase.cs
@@ -2,7 +2,8 @@
 using System.IO;
 using System.Linq;
 using System.Net;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using VDS.RDF.JsonLd.Syntax;
 using VDS.RDF.Parsing;
 using VDS.RDF.Writing;
@@ -29,7 +30,7 @@ public class JsonLdTestSuiteBase
         JsonLdProcessorOptions processorOptions = MakeProcessorOptions(inputPath, baseIri, processorMode, expandContextPath,
             compactArrays, rdfDirection);
         var inputJson = File.ReadAllText(inputPath);
-        var inputElement = JToken.Parse(inputJson);
+        var inputElement = JsonNode.Parse(inputJson);
 
         // Expand tests should not have a context parameter
         Assert.Null(contextPath);
@@ -37,9 +38,9 @@ public class JsonLdTestSuiteBase
         switch (testType)
         {
             case JsonLdTestType.PositiveEvaluationTest:
-                JArray actualOutputElement = JsonLdProcessor.Expand(inputElement, processorOptions);
+                JsonArray actualOutputElement = JsonLdProcessor.Expand(inputElement, processorOptions);
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
-                var expectedOutputElement = JToken.Parse(expectedOutputJson);
+                var expectedOutputElement = JsonNode.Parse(expectedOutputJson);
                 Assert.True(DeepEquals(actualOutputElement, expectedOutputElement),
                     $"Error processing expand test {Path.GetFileName(inputPath)}.\nActual output does not match expected output.\nExpected:\n{expectedOutputElement}\n\nActual:\n{actualOutputElement}");
                 break;
@@ -51,7 +52,7 @@ public class JsonLdTestSuiteBase
                 break;
             case JsonLdTestType.PositiveSyntaxTest:
                 // Expect test to run without throwing processing errors
-                JArray _ = JsonLdProcessor.Expand(inputElement, processorOptions);
+                JsonArray _ = JsonLdProcessor.Expand(inputElement, processorOptions);
                 break;
             case JsonLdTestType.NegativeSyntaxTest:
                 Assert.ThrowsAny<JsonLdProcessorException>(() => JsonLdProcessor.Expand(inputElement, processorOptions));
@@ -68,14 +69,14 @@ public class JsonLdTestSuiteBase
             compactArrays, rdfDirection);
         var inputJson = File.ReadAllText(inputPath);
         var contextJson = contextPath == null ? null : File.ReadAllText(contextPath);
-        var inputElement = JToken.Parse(inputJson);
-        JToken contextElement = contextJson == null ? new JObject() : JToken.Parse(contextJson);
+        var inputElement = JsonNode.Parse(inputJson);
+        JsonNode contextElement = contextJson == null ? JsonNode.Parse("{}") : JsonNode.Parse(contextJson);
         switch (testType)
         {
             case JsonLdTestType.PositiveEvaluationTest:
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
-                var expectedOutputElement = JToken.Parse(expectedOutputJson);
-                JObject actualOutputElement = JsonLdProcessor.Compact(inputElement, contextElement, processorOptions);
+                var expectedOutputElement = JsonNode.Parse(expectedOutputJson);
+                JsonNode actualOutputElement = JsonLdProcessor.Compact(inputElement, contextElement, processorOptions);
                 Assert.True(DeepEquals(actualOutputElement, expectedOutputElement),
                     $"Error processing compact test {Path.GetFileName(inputPath)}.\nActual output does not match expected output.\nExpected:\n{expectedOutputElement}\n\nActual:\n{actualOutputElement}");
                 break;
@@ -98,16 +99,16 @@ public class JsonLdTestSuiteBase
             compactArrays, rdfDirection);
         var inputJson = File.ReadAllText(inputPath);
         var contextJson = contextPath == null ? null : File.ReadAllText(contextPath);
-        var inputElement = JToken.Parse(inputJson);
-        JToken contextElement = contextJson == null ? null : JToken.Parse(contextJson);
+        var inputElement = JsonNode.Parse(inputJson);
+        JsonNode contextElement = contextJson == null ? JsonValue.Create<string>(null) : JsonNode.Parse(contextJson);
 
         switch (testType)
         {
             case JsonLdTestType.PositiveEvaluationTest:
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
-                var expectedOutputElement = JToken.Parse(expectedOutputJson);
+                var expectedOutputElement = JsonNode.Parse(expectedOutputJson);
 
-                JToken actualOutputElement = JsonLdProcessor.Flatten(inputElement, contextElement, processorOptions);
+                JsonNode actualOutputElement = JsonLdProcessor.Flatten(inputElement, contextElement, processorOptions);
                 Assert.True(DeepEquals(actualOutputElement, expectedOutputElement),
                     $"Error processing flatten test {Path.GetFileName(inputPath)}.\nActual output does not match expected output.\nExpected:\n{expectedOutputElement}\n\nActual:\n{actualOutputElement}");
                 break;
@@ -195,9 +196,9 @@ public class JsonLdTestSuiteBase
         {
             case JsonLdTestType.PositiveEvaluationTest:
             {
-                JArray actualOutput = jsonLdWriter.SerializeStore(input);
+                JsonArray actualOutput = jsonLdWriter.SerializeStore(input);
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
-                var expectedOutput = JToken.Parse(expectedOutputJson);
+                var expectedOutput = JsonNode.Parse(expectedOutputJson);
 
                 try
                 {
@@ -218,7 +219,7 @@ public class JsonLdTestSuiteBase
                 break;
             }
             case JsonLdTestType.PositiveSyntaxTest:
-                JArray _ = jsonLdWriter.SerializeStore(input);
+                JsonArray _ = jsonLdWriter.SerializeStore(input);
                 break;
             case JsonLdTestType.NegativeSyntaxTest:
                 Assert.ThrowsAny<JsonLdProcessorException>(() => jsonLdWriter.SerializeStore(input));
@@ -242,15 +243,15 @@ public class JsonLdTestSuiteBase
             Ordered = ordered,
         };
         if (omitGraph.HasValue) options.OmitGraph = omitGraph.Value;
-        var inputElement = JToken.Parse(inputJson);
-        var frameElement = JToken.Parse(frameJson);
+        var inputElement = JsonNode.Parse(inputJson);
+        var frameElement = JsonNode.Parse(frameJson);
         
         switch (testType)
         {
             case JsonLdTestType.PositiveEvaluationTest:
                 var expectedOutputJson = File.ReadAllText(expectedOutputPath);
-                var expectedOutputElement = JToken.Parse(expectedOutputJson);
-                JObject actualOutput = JsonLdProcessor.Frame(inputElement, frameElement, options);
+                var expectedOutputElement = JsonNode.Parse(expectedOutputJson);
+                JsonObject actualOutput = JsonLdProcessor.Frame(inputElement, frameElement, options);
                 Assert.True(DeepEquals(expectedOutputElement, actualOutput),
                     $"Test failed for input {Path.GetFileName(inputPath)}\nExpected:\n{expectedOutputElement}\nActual:\n{actualOutput}");
                 break;
@@ -270,34 +271,36 @@ public class JsonLdTestSuiteBase
         
     }
 
-    private static bool DeepEquals(JToken t1, JToken t2, bool arraysAreOrdered = false)
+    private static bool DeepEquals(JsonNode t1, JsonNode t2, bool arraysAreOrdered = false)
     {
         if (t1 == null) return t2 == null;
         if (t2 == null) return false;
-        if (t1.Type == JTokenType.Null && t2.Type == JTokenType.Null) return true;
-        if (t1.Type == JTokenType.Null && t2.Type == JTokenType.String) return t2.Value<string>() == null;
-        if (t2.Type == JTokenType.Null && t1.Type == JTokenType.String) return t1.Value<string>() == null;
-        if (t1.Type != t2.Type) return false;
-        switch (t1.Type)
+        var t1Kind = t1.GetValueKind();
+        var t2Kind = t2.GetValueKind();
+        if (t1Kind == JsonValueKind.Null && t2Kind == JsonValueKind.Null) return true;
+        if (t1Kind == JsonValueKind.Null && t2Kind == JsonValueKind.String) return t2.GetValue<string>() == null;
+        if (t2Kind == JsonValueKind.Null && t1Kind == JsonValueKind.String) return t1.GetValue<string>() == null;
+        if (t1Kind != t2Kind) return false;
+        switch (t1Kind)
         {
-            case JTokenType.Array:
-                return DeepEquals(t1 as JArray, t2 as JArray, arraysAreOrdered);
-            case JTokenType.Object:
-                return DeepEquals(t1 as JObject, t2 as JObject, arraysAreOrdered);
+            case JsonValueKind.Array:
+                return DeepEquals(t1.AsArray(), t2.AsArray(), arraysAreOrdered);
+            case JsonValueKind.Object:
+                return DeepEquals(t1.AsObject(), t2.AsObject(), arraysAreOrdered);
             default:
                 return t1.Equals(t2);
         }
     }
 
-    private static bool DeepEquals(JArray a1, JArray a2, bool arraysAreOrdered = false)
+    private static bool DeepEquals(JsonArray a1, JsonArray a2, bool arraysAreOrdered = false)
     {
         if (a1.Count != a2.Count) return false;
         if (arraysAreOrdered)
         {
             return !a1.Where((t, i) => !DeepEquals(t, a2[i], true)).Any();
         }
-        var a2Clone = new JArray(a2);
-        foreach (JToken item in a1)
+        JsonArray a2Clone = a2.DeepClone().AsArray();
+        foreach (JsonNode item in a1)
         {
             var matched = false;
             for (var j = 0; j < a2Clone.Count; j++)
@@ -314,45 +317,45 @@ public class JsonLdTestSuiteBase
         return true;
     }
 
-    private static bool DeepEquals(JObject o1, JObject o2, bool arraysAreOrdered = false)
+    private static bool DeepEquals(JsonObject o1, JsonObject o2, bool arraysAreOrdered = false)
     {
         if (o1.Count != o2.Count) return false;
-        return o1.Properties().All(p => o2.ContainsKey(p.Name)) &&
-               o1.Properties().All(p => DeepEquals(p.Value, o2[p.Name], arraysAreOrdered));
+        return o1.All(p => o2.ContainsKey(p.Key)) &&
+               o1.All(p => DeepEquals(p.Value, o2[p.Key], arraysAreOrdered));
     }
 
-    private static bool DeepEquals(JToken token1, JToken token2, bool ignoreArrayOrder, bool throwOnMismatch)
+    private static bool DeepEquals(JsonNode token1, JsonNode token2, bool ignoreArrayOrder, bool throwOnMismatch)
     {
-        if (token1.Type != token2.Type)
+        if (token1.GetValueKind() != token2.GetValueKind())
         {
             if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
             return false;
         }
-        switch (token1.Type)
+        switch (token1.GetValueKind())
         {
-            case JTokenType.Object:
-                if (!(token1 is JObject o1 && token2 is JObject o2)) return false;
-                foreach (JProperty p in o1.Properties())
+            case JsonValueKind.Object:
+                if (!(token1 is JsonObject o1 && token2 is JsonObject o2)) return false;
+                foreach (var p in o1)
                 {
-                    if (o2[p.Name] == null)
+                    if (o2[p.Key] == null)
                     {
                         if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
                         return false;
                     }
-                    if (!DeepEquals(o1[p.Name], o2[p.Name], ignoreArrayOrder, throwOnMismatch))
+                    if (!DeepEquals(p.Value, o2[p.Key], ignoreArrayOrder, throwOnMismatch))
                     {
-                        if (throwOnMismatch) throw new DeepEqualityFailure(o1[p.Name], o2[p.Name]);
+                        if (throwOnMismatch) throw new DeepEqualityFailure(p.Value, o2[p.Key]);
                         return false;
                     }
                 }
-                if (o2.Properties().Any(p2 => o1.Property(p2.Name) == null))
+                if (o2.Any(p2 => o1[p2.Key] == null))
                 {
                     if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
                     return false;
                 }
                 return true;
-            case JTokenType.Array:
-                if (!(token1 is JArray a1 && token2 is JArray a2)) return false;
+            case JsonValueKind.Array:
+                if (!(token1 is JsonArray a1 && token2 is JsonArray a2)) return false;
                 if (a1.Count != a2.Count)
                 {
                     if (throwOnMismatch) throw new DeepEqualityFailure(token1, token2);
@@ -372,8 +375,8 @@ public class JsonLdTestSuiteBase
                     }
                     return true;
                 }
-                var unmatchedItems = (token2 as JArray).ToList();
-                foreach (JToken item1 in a1)
+                var unmatchedItems = token2.DeepClone().AsArray().ToList();
+                foreach (JsonNode item1 in a1)
                 {
                     if (unmatchedItems.Count == 0)
                     {
@@ -393,14 +396,14 @@ public class JsonLdTestSuiteBase
                 }
                 return unmatchedItems.Count == 0;
             default:
-                return JToken.DeepEquals(token1, token2);
+                return JsonNode.DeepEquals(token1, token2);
         }
     }
 
     private class DeepEqualityFailure : Exception
     {
-        public DeepEqualityFailure(JToken expected, JToken actual) : base(
-            $"DeepEquality failed at {expected.Path}.\nExpected: {expected}\nActual: {actual}")
+        public DeepEqualityFailure(JsonNode expected, JsonNode actual) : base(
+            $"DeepEquality failed at {expected.GetPath()}.\nExpected: {expected}\nActual: {actual}")
         {
             
         }
@@ -445,7 +448,7 @@ public class JsonLdTestSuiteBase
         if (expandContextPath != null)
         {
             var expandContextJson = File.ReadAllText(expandContextPath);
-            processorOptions.ExpandContext = JObject.Parse(expandContextJson);
+            processorOptions.ExpandContext = JsonNode.Parse(expandContextJson);
         }
         processorOptions.CompactArrays = compactArrays;
         if (!string.IsNullOrEmpty(rdfDirection))


### PR DESCRIPTION
Updates the entire JSON-LD stack to use System.Text.Json in place of Newtonsoft.Json.

Merging this PR will result in a breaking API change as there are parts of the API where the underlying Newtonsoft.Json types leak into the API.

Due to the differences between the DOM implementations of System.Text.Json and Newtonsoft.Json, there is a lot more explicit cloning of nodes because System.Text.Json does not allow a node to have multiple parents. There might be some unecessary cloning in cases where a node could safely be moved from one parent to another - addressing this is a future optimization task.

Addresses #538