### PR TITLE
Replace char.IsDigit with more accurate validation

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -7,6 +7,7 @@ This is a major version update to the dotNetRDF library.
 
 BREAKING: In line with our deprecation policy, all APIS previously flagged as Obsolete with an error have been removed, an APIS flagged as Obsolete with a warning in 3.x will now result in a compile-time error. All of the obsolete APIs suggest their replacement.
 NEW: Introduced `VDS.RDF.Utils.RdfGraphContent` - an `HttpContent` implementation for writing the content of a `Graph` to the body of an HTTP request.
+ENHANCEMENT: Removed dependency on AngleSharp that was left in one small corner of the codebase. Thanks to @langsamu for the report and fix.
 
 3.5.2
 -----

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
 		<PackageVersion Include="System.Interactive.Async" Version="7.0.1" />
 		<PackageVersion Include="System.Linq.Async" Version="7.0.1" />
 		<PackageVersion Include="System.Threading.Channels" Version="10.0.7" />
-		<PackageVersion Include="AngleSharp" Version="1.4.0" />
 		<PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
 		<PackageVersion Include="System.Globalization.Extensions" Version="4.3.0" />

--- a/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
@@ -24,7 +24,6 @@
 // </copyright>
 */
 
-using AngleSharp.Text;
 using System;
 using System.Text.RegularExpressions;
 using VDS.RDF.Parsing.Tokens;
@@ -855,7 +854,7 @@ public class TurtleSpecsHelper
         {
             return true;
         }
-        else if (c.IsDigit())
+        else if (char.IsDigit(c))
         {
             return true;
         }

--- a/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
+++ b/Libraries/dotNetRdf.Core/Parsing/TurtleSpecsHelper.cs
@@ -377,7 +377,7 @@ public class TurtleSpecsHelper
                     if (portions[p].Length == 0) continue;
 
                     // If we see any of the escape sequence starters or a leading digit then this must be the start of the local name
-                    if (portions[p].Contains("%") || portions[p].Contains("\\") || char.IsDigit(portions[p][0])) break;
+                    if (portions[p].Contains("%") || portions[p].Contains("\\") || IsAsciiDigit(portions[p][0])) break;
 
                     // Otherwise must be a valid prefix
                     if (!IsPNPrefix(portions[p], syntax)) return false;
@@ -449,7 +449,7 @@ public class TurtleSpecsHelper
         int start = 1, temp = 0;
 
         // Validate first character
-        if (cs[0] != ':' && !char.IsDigit(cs[0]) && !IsPLX(cs, 0, out temp) && !IsPNCharsU(cs[0]))
+        if (cs[0] != ':' && !IsAsciiDigit(cs[0]) && !IsPLX(cs, 0, out temp) && !IsPNCharsU(cs[0]))
         {
             // Handle surrogate pairs for UTF-32 characters
             if (UnicodeSpecsHelper.IsHighSurrogate(cs[0]) && cs.Length > 1)
@@ -583,6 +583,11 @@ public class TurtleSpecsHelper
         }
     }
 
+    private static bool IsAsciiDigit(char c)
+    {
+        return c >= 0x30 && c <= 0x39;
+    }
+    
     /// <summary>
     /// Gets whether a character is a Hex character.
     /// </summary>
@@ -590,7 +595,7 @@ public class TurtleSpecsHelper
     /// <returns></returns>
     public static bool IsHex(char c)
     {
-        if (char.IsDigit(c))
+        if (IsAsciiDigit(c))
         {
             return true;
         }
@@ -755,7 +760,7 @@ public class TurtleSpecsHelper
         {
             return true;
         }
-        else if (char.IsDigit(c))
+        else if (IsAsciiDigit(c))
         {
             return true;
         }
@@ -854,7 +859,7 @@ public class TurtleSpecsHelper
         {
             return true;
         }
-        else if (char.IsDigit(c))
+        else if (IsAsciiDigit(c))
         {
             return true;
         }
@@ -895,7 +900,7 @@ public class TurtleSpecsHelper
         {
             return true;
         }
-        else if (char.IsDigit(c))
+        else if (IsAsciiDigit(c))
         {
             return true;
         }

--- a/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
+++ b/Libraries/dotNetRdf.Core/dotNetRdf.Core.csproj
@@ -45,7 +45,6 @@
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="AngleSharp" />
     <PackageReference Include="System.ComponentModel.TypeConverter" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Globalization.Extensions" />


### PR DESCRIPTION
Replace char.IsDigit(c) with a new private static IsAsciiDigit(c) which will return true only for characters between `0` and `9` inclusive.

Replaces #890 